### PR TITLE
Fix Valid Values property list population and add Connected state guard

### DIFF
--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/README.md
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/README.md
@@ -350,7 +350,7 @@ Browse pyegeria's client-side report format specifications. These are not stored
 
 Look up the registered valid values for a specific Egeria property name. Uses Egeria's controlled vocabulary registry (`get_valid_metadata_values`), which is separate from the Reference Data sets.
 
-- Left panel: a text input for any property name, plus quick-access buttons for standard Egeria property names (`contentStatus`, `activityStatus`, `governanceStatus`, etc.).
+- Left panel: on tab open, a sidebar is pre-populated with all property names that have registered valid values (via `GET /api/valid-values/properties`). Click a name to look it up, or type any property name directly.
 - Right panel: the ordered list of allowed values for the selected property, with display names, preferred values, and descriptions.
 
 #### REST APIs
@@ -476,6 +476,10 @@ Response: `{ guid, mermaidGraph }`. `mermaidGraph` is an empty string if no diag
 
 #### Valid Values
 
+**`GET /api/valid-values/properties`** — List all property names that have at least one registered valid value.
+
+Response: `{ properties: [string, ...], total: N }`. Used by the Valid Values tab to pre-populate the sidebar. Queries `ValidMetadataValue` entries where `preferredValue IS_NULL` (these are the header registrations). Property names are extracted from `elementProperties.propertiesAsStrings.identifier` in the raw OpenMetadata response.
+
 **`GET /api/valid-values/lookup`** — Valid values for a property name.
 
 Query params: `property_name` (required), `type_name` (optional).
@@ -513,7 +517,7 @@ For the extension history and remaining open work, see [Extending the TypeExplor
 | `glossary_handler.py` | `/api/glossary*`; uses `graph_query_depth=1` for terms; GUID-deduplicates before returning |
 | `digital_products_handler.py` | `/api/digital-products`; recursive tree via `get_collection_members` with `graph_query_depth=0` |
 | `mermaid_handler.py` | `/api/mermaid/{guid}`; uses `MetadataExpert.get_anchored_element_graph` |
-| `valid_values_handler.py` | `/api/valid-values/lookup`; uses `ReferenceDataManager.get_valid_metadata_values` |
+| `valid_values_handler.py` | `/api/valid-values/properties` (pre-populates sidebar via `MetadataExpert.find_metadata_elements`); `/api/valid-values/lookup` (values for a name via `ReferenceDataManager.get_valid_metadata_values`) |
 | `report_specs_handler.py` | `/api/report-specs`; reads local pyegeria report spec objects; no Egeria connection |
 | `rest_api_handler.py` | `/api/request-bodies`, `/api/rest-apis`; catalog + live OpenAPI endpoint discovery |
 | `pyegeria_handler.py` | FastAPI app entry point; mounts all routers |

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/digital_products_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/digital_products_handler.py
@@ -14,6 +14,7 @@ Endpoints:
 """
 
 import os
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -29,13 +30,13 @@ _CONTAINER_TYPES = {
 }
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import CollectionManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -156,10 +157,14 @@ def _build_tree(mgr, collection_guid: str, visited: set, depth: int = 0) -> list
 def get_catalogs(
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(100, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return all DigitalProductCatalog collections (paginated through all available collections)."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -177,14 +182,20 @@ def get_catalogs(
 
 @router.get("/api/digital-products/catalogs/{catalog_guid}/tree",
             summary="Full hierarchy tree for a catalog")
-def get_catalog_tree(catalog_guid: str):
+def get_catalog_tree(
+    catalog_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return the full recursive hierarchy tree for a DigitalProductCatalog.
 
     Tree nodes: {guid, typeName, displayName, ..., isContainer: bool, children: [node...]}
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -204,10 +215,16 @@ def get_catalog_tree(catalog_guid: str):
 
 
 @router.get("/api/digital-products/{node_guid}", summary="Get detail for any product/collection node")
-def get_node(node_guid: str):
+def get_node(
+    node_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return detail for a single digital product or family node."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/glossary_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/glossary_handler.py
@@ -22,13 +22,13 @@ from loguru import logger
 router = APIRouter(tags=["glossary"])
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import GlossaryManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = GlossaryManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = GlossaryManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -156,10 +156,14 @@ def _serialize_term(term: dict) -> dict:
 def get_glossaries(
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(100, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return all Egeria glossaries with summary information."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -191,10 +195,14 @@ def get_glossary_folders(
     collection_guid: str,
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(200, ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return the CollectionFolder children of a glossary (organisational hierarchy)."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -223,6 +231,10 @@ def get_terms_in_collection(
     collection_guid: str,
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(500, ge=1, le=2000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return GlossaryTerms that are members of the given collection (glossary or folder).
@@ -231,7 +243,7 @@ def get_terms_in_collection(
     then filters for GlossaryTerm type elements. Much faster than a full-table scan.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -259,13 +271,17 @@ def search_all_terms(
     q:          str = Query("*",   description="Search string; use * to return all"),
     start_from: int = Query(0,     ge=0),
     page_size:  int = Query(200,   ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Search for GlossaryTerms across all glossaries using a text search string.
     Terms can belong to multiple glossaries; this view is independent of glossary membership.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -302,10 +318,16 @@ def search_all_terms(
 
 
 @router.get("/api/glossary/term/{term_guid}", summary="Get a single term by GUID")
-def get_term(term_guid: str):
+def get_term(
+    term_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return full detail for a single glossary term."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/mermaid_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/mermaid_handler.py
@@ -10,37 +10,38 @@ Endpoints:
 """
 
 import os
-from fastapi import APIRouter, HTTPException
+from typing import Optional
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 from loguru import logger
 
 router = APIRouter(tags=["mermaid"])
 
 
-def _get_classifier():
+def _get_classifier(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ClassificationExplorer
     import pyegeria
     pyegeria.enable_ssl_check = False
     pyegeria.disable_ssl_warnings = True
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ClassificationExplorer(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ClassificationExplorer(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
 
-def _get_expert():
+def _get_expert(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import MetadataExpert
     import pyegeria
     pyegeria.enable_ssl_check = False
     pyegeria.disable_ssl_warnings = True
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -52,14 +53,20 @@ def _normalise(graph) -> str:
 
 
 @router.get("/api/mermaid/{guid}/anchored", summary="Get full anchored element graph")
-def get_anchored_graph(guid: str):
+def get_anchored_graph(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return a Mermaid diagram showing the element and all its anchored elements.
     Uses MetadataExpert.get_anchored_element_graph — a broader, more expensive traversal.
     Returns {guid, mermaidGraph}.
     """
     try:
-        mgr = _get_expert()
+        mgr = _get_expert(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create MetadataExpert")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -74,14 +81,20 @@ def get_anchored_graph(guid: str):
 
 
 @router.get("/api/mermaid/{guid}", summary="Get context diagram for an element (graph_query_depth=5)")
-def get_mermaid_graph(guid: str):
+def get_mermaid_graph(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return a Mermaid context diagram using ClassificationExplorer.get_element_by_guid.
     Extracts the top-level mermaidGraph field from the response.
     Returns {guid, mermaidGraph}.
     """
     try:
-        mgr = _get_classifier()
+        mgr = _get_classifier(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ClassificationManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/reference_data_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/reference_data_handler.py
@@ -20,13 +20,13 @@ from loguru import logger
 router = APIRouter(tags=["reference-data"])
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ReferenceDataManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -88,6 +88,10 @@ def get_valid_value_definitions(
     q:          Optional[str] = Query(None, description="Search string (substring match, case-insensitive). Defaults to all."),
     start_from: int           = Query(0,   ge=0),
     page_size:  int           = Query(200, ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return valid value definitions from Egeria.
@@ -96,7 +100,7 @@ def get_valid_value_definitions(
     Returns a flat list suitable for client-side grouping by typeName (ValidValueSet vs ValidValueDefinition).
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -139,6 +143,10 @@ def get_valid_value_definitions(
 def get_metadata_values(
     property_name: str           = Query(..., description="Property name to look up valid values for"),
     type_name:     Optional[str] = Query(None, description="Optional: restrict to a specific open metadata type"),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return the valid metadata values registered for a given property name.
@@ -146,7 +154,7 @@ def get_metadata_values(
     Does not require Egeria connection (uses local ValidMetadataManager registry).
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -169,10 +177,16 @@ def get_metadata_values(
 
 
 @router.get("/api/reference-data/{vv_guid}", summary="Get a valid value definition by GUID")
-def get_valid_value_definition(vv_guid: str):
+def get_valid_value_definition(
+    vv_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return full detail for a single valid value definition."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer-architecture.md
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer-architecture.md
@@ -24,6 +24,7 @@ Browser
   │  GET /api/digital-products/{guid}            (node detail)
   │  GET /api/mermaid/{guid}           (context diagram — graph_query_depth=5)
   │  GET /api/mermaid/{guid}/anchored  (full anchored element graph)
+  │  GET /api/valid-values/properties  (property names that have registered valid values)
   │  GET /api/valid-values/lookup      (valid values for a property name)
   │  GET /api/request-bodies           (Layer 1 request body catalog — no Egeria needed)
   │  GET /api/rest-apis                (OpenAPI endpoint catalog)
@@ -75,7 +76,8 @@ Apache and the FastAPI server run in separate containers on the same Docker netw
 | Digital Products tree | `GET /api/digital-products/catalogs/{guid}/tree` | Catalog selected |
 | Context diagram | `GET /api/mermaid/{guid}` — `get_metadata_element_by_guid` at depth=5 | User clicks "▦ Load Context Diagram" |
 | Full anchored graph | `GET /api/mermaid/{guid}/anchored` — `get_anchored_element_graph` | User clicks "▦ Load Full Graph" |
-| Valid Values | `GET /api/valid-values/lookup?property_name=…` | User selects or enters a property name |
+| Valid Values — property list | `GET /api/valid-values/properties` | First time tab is opened (pre-populates sidebar) |
+| Valid Values — lookup | `GET /api/valid-values/lookup?property_name=…` | User selects or enters a property name |
 | REST APIs — body catalog | `GET /api/request-bodies` | REST APIs tab is opened (no Egeria needed) |
 | REST APIs — endpoints | `GET /api/rest-apis` | User clicks "Load API Endpoints" in the toolbar |
 
@@ -201,6 +203,7 @@ The Reference Data view displays a hierarchy: root-level ValidValueSets as tree 
 |---------|---------|-------------|
 | `ValidMetadataManager` | `type_system_handler.py` | `get_all_entity_defs`, `get_all_relationship_defs`, `get_all_classification_defs` |
 | `ReferenceDataManager` | `reference_data_handler.py`, `valid_values_handler.py` | `find_valid_value_definitions`, `get_valid_metadata_values` |
+| `MetadataExpert` | `valid_values_handler.py` | `find_metadata_elements` (properties list — raw OpenMetadata format) |
 | `GlossaryManager` | `glossary_handler.py` | `find_glossaries`, `find_glossary_terms`, `get_term_by_guid`, `get_collection_members` |
 | `CollectionManager` | `digital_products_handler.py` | `find_collections`, `get_collection_members`, `get_collection_by_guid` |
 | `MetadataExpert` | `mermaid_handler.py` | `get_metadata_element_by_guid` (depth=5), `get_anchored_element_graph` |
@@ -274,6 +277,20 @@ This table answers the question "where does the data actually come from?" for ea
 Fixed upstream in pyegeria (the method now uses `_extract_typedef_list()` and accepts `get_inherited_attributes` / `get_relationship_attributes` parameters). The monkey-patch that previously existed in `type_system_handler.py` has been removed.
 
 This incident is a worked example of the pyegeria upgrade process — see [Upgrading pyegeria](#upgrading-pyegeria) below.
+
+### find_metadata_elements returns raw OpenMetadata format
+
+`MetadataExpert.find_metadata_elements(body)` returns elements in raw OpenMetadata format — **not** the processed pyegeria format returned by manager methods like `find_valid_value_definitions`. There is no `elementHeader` / `properties` split; instead each element has:
+
+```
+el["elementGUID"]                                                      # top-level GUID
+el["elementProperties"]["propertiesAsStrings"]["identifier"]          # fastest path — string value
+el["elementProperties"]["propertyValueMap"]["identifier"]["primitiveValue"]  # full structure
+```
+
+The property name field is `"identifier"`, not `"propertyName"`. Code that looks for `"propertyName"` in `propertyValueMap` will silently find nothing.
+
+The `propertiesAsStrings` shortcut is preferred for extraction — it contains the same string values without the type wrapper objects.
 
 ### MetadataExpert vs MetadataExplorer
 

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer.html
@@ -154,6 +154,7 @@
                 padding: 4px 12px; cursor: pointer; font-size: 13px; color: var(--muted);
                 font-family: inherit; line-height: 1.5; }
     .view-tab.on { color: var(--accent); font-weight: 600; border-bottom-color: var(--accent); }
+    .view-tab:disabled { opacity: 0.35; cursor: not-allowed; }
     .theme-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted);
                  border-radius: 20px; padding: 3px 12px; cursor: pointer; font-size: 12px;
                  font-family: inherit; }
@@ -536,6 +537,26 @@ const {
   useRef
 } = React;
 
+// ── Credential context ────────────────────────────────────────────────────────
+// Provides Egeria connection params to all child components without prop-drilling.
+const CredContext = React.createContext({ url: '', server: '', userId: '', password: '' });
+
+function credQS(creds) {
+  var p = new URLSearchParams();
+  if (creds && creds.url)      p.set('url',      creds.url);
+  if (creds && creds.server)   p.set('server',   creds.server);
+  if (creds && creds.userId)   p.set('user_id',  creds.userId);
+  if (creds && creds.password) p.set('user_pwd', creds.password);
+  var s = p.toString();
+  return s ? '?' + s : '';
+}
+
+function credAppend(base, creds) {
+  var qs = credQS(creds);
+  if (!qs) return base;
+  return base + (base.includes('?') ? '&' + qs.slice(1) : qs);
+}
+
 // ── Markdown renderer ─────────────────────────────────────────────────────────
 function MermaidDiagram({ code }) {
   const ref = React.useRef(null);
@@ -588,11 +609,12 @@ function DiagramPanel({ fetchUrl, label, buttonLabel }) {
   const [code, setCode] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [visible, setVisible] = React.useState(true);
+  const creds = React.useContext(CredContext);
 
   React.useEffect(function() {
     if (!open) return;
     setCode(null);
-    fetch(fetchUrl)
+    fetch(credAppend(fetchUrl, creds))
       .then(function(r) { return r.ok ? r.json() : null; })
       .then(function(data) { setCode(data && data.mermaidGraph ? data.mermaidGraph : ''); })
       .catch(function() { setCode(''); });
@@ -2061,6 +2083,7 @@ function GlossaryTermDetail({ term, onNavigateToTerm }) {
 }
 
 function GlossaryView({ navGuid }) {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [glossaryState, setGlossaryState] = useState('loading');
   const [glossaryAttempt, setGlossaryAttempt] = useState(0);
@@ -2095,7 +2118,7 @@ function GlossaryView({ navGuid }) {
   // Fetch term when cross-navigated from Digital Products
   useEffect(() => {
     if (!navGuid) { setNavTerm(null); return; }
-    fetch('/api/glossary/term/' + encodeURIComponent(navGuid))
+    fetch(credAppend('/api/glossary/term/' + encodeURIComponent(navGuid), creds))
       .then(function(r) { return r.ok ? r.json() : null; })
       .then(function(data) { if (data) { setNavTerm(data); setSelectedItem(data.guid); } })
       .catch(function() {});
@@ -2111,7 +2134,7 @@ function GlossaryView({ navGuid }) {
   useEffect(() => {
     setGlossaryState('loading');
     setGlossaryError('');
-    fetch('/api/glossary')
+    fetch(credAppend('/api/glossary', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const list = (data.glossaries || []).sort((a, b) => (a.displayName || '').localeCompare(b.displayName || ''));
@@ -2134,8 +2157,8 @@ function GlossaryView({ navGuid }) {
     setTermDetailState('idle');
     setFilterText('');
     Promise.all([
-      fetch('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/folders').then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
-      fetch('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/terms').then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/folders', creds)).then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/terms', creds)).then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
     ])
     .then(([fData, tData]) => {
       setFolders(fData.folders || []);
@@ -2156,7 +2179,7 @@ function GlossaryView({ navGuid }) {
     setSelectedItem(null);
     setTermDetail(null);
     setTermDetailState('idle');
-    fetch('/api/glossary-terms?q=' + encodeURIComponent(sq))
+    fetch(credAppend('/api/glossary-terms?q=' + encodeURIComponent(sq), creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => { setSearchTerms(data.terms || []); setSearchState('ready'); })
       .catch(err => { setSearchError(err.message); setSearchState('idle'); });
@@ -2218,7 +2241,7 @@ function GlossaryView({ navGuid }) {
     if (navTerm && navTerm.guid === selectedItem) { setTermDetail(navTerm); setTermDetailState('ready'); return; }
     setTermDetail(null);
     setTermDetailState('loading');
-    fetch('/api/glossary/term/' + encodeURIComponent(selectedItem))
+    fetch(credAppend('/api/glossary/term/' + encodeURIComponent(selectedItem), creds))
       .then(r => r.ok ? r.json() : null)
       .then(data => { setTermDetail(data || null); setTermDetailState(data ? 'ready' : 'error'); })
       .catch(() => setTermDetailState('error'));
@@ -2432,6 +2455,7 @@ function RefDataTreeNode({ item, byGuid, depth, selected, onSelect, expanded, to
 }
 
 function ReferenceDataView() {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [loadState, setLoadState] = useState('loading');
   const [attempt, setAttempt]     = useState(0);
@@ -2444,7 +2468,7 @@ function ReferenceDataView() {
   useEffect(function() {
     setLoadState('loading');
     setError('');
-    fetch('/api/reference-data?page_size=500')
+    fetch(credAppend('/api/reference-data?page_size=500', creds))
       .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function(data) {
         const list = data.definitions || [];
@@ -2618,6 +2642,7 @@ function DigitalTreeNode({ node, depth, selectedGuid, onSelect, expanded, toggle
 }
 
 function DigitalProductsView({ onNavigateToGlossary }) {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [treeW, onTreeDivDown] = useResizable(300);
   const [catState, setCatState]     = useState('loading');
@@ -2637,7 +2662,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
   useEffect(() => {
     setCatState('loading');
     setCatError('');
-    fetch('/api/digital-products/catalogs')
+    fetch(credAppend('/api/digital-products/catalogs', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const list = (data.catalogs || []).slice().sort((a, b) => (a.displayName || '').localeCompare(b.displayName || ''));
@@ -2656,7 +2681,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
     setTreeData(null);
     setSelectedNode(null);
     setSelectedNodeObj(null);
-    fetch('/api/digital-products/catalogs/' + encodeURIComponent(selectedCat) + '/tree')
+    fetch(credAppend('/api/digital-products/catalogs/' + encodeURIComponent(selectedCat) + '/tree', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         setTreeData(data);
@@ -2812,7 +2837,59 @@ const _SPLASH_CAPABILITIES = [
   },
 ];
 
-function SplashScreen({ onNavigate }) {
+function ConnectionForm({ saveCreds }) {
+  const creds = React.useContext(CredContext);
+  const [form, setForm] = React.useState({
+    url:      creds.url,
+    server:   creds.server,
+    userId:   creds.userId,
+    password: creds.password,
+  });
+  const [saved, setSaved] = React.useState(false);
+  function set(k, v) { setForm(function(f) { return Object.assign({}, f, { [k]: v }); }); setSaved(false); }
+  function onSubmit(e) {
+    e.preventDefault();
+    saveCreds(form);
+    setSaved(true);
+  }
+  var fieldStyle = { fontSize: 12, padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit', width: '100%', boxSizing: 'border-box' };
+  var labelStyle = { fontSize: 11, color: 'var(--dim)', marginBottom: 2, display: 'block' };
+  var rowStyle   = { display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 };
+  return React.createElement('div', {
+    style: { background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 8, padding: '16px 20px', marginBottom: 32 }
+  },
+    React.createElement('div', { style: { fontSize: 13, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 } }, 'Connection Settings'),
+    React.createElement('form', { onSubmit: onSubmit },
+      React.createElement('div', { style: { display: 'grid', gridTemplateColumns: '2fr 1fr 1fr 1fr auto', gap: 8, alignItems: 'end' } },
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'Platform URL'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.url, placeholder: 'https://localhost:9443', onChange: function(e) { set('url', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'View Server'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.server, placeholder: 'qs-view-server', onChange: function(e) { set('server', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'User ID'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.userId, placeholder: 'erinoverview', onChange: function(e) { set('userId', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'Password'),
+          React.createElement('input', { style: fieldStyle, type: 'password', value: form.password, placeholder: 'secret', onChange: function(e) { set('password', e.target.value); } })
+        ),
+        React.createElement('button', {
+          type: 'submit',
+          style: { padding: '6px 14px', borderRadius: 5, border: '1px solid rgba(96,165,250,.4)', background: saved ? 'rgba(52,211,153,.12)' : 'rgba(96,165,250,.1)', color: saved ? '#34d399' : 'var(--accent)', cursor: 'pointer', fontSize: 12, fontWeight: 600, whiteSpace: 'nowrap' }
+        }, saved ? '✔ Saved' : 'Connect')
+      ),
+      React.createElement('p', { style: { margin: '8px 0 0', fontSize: 11, color: 'var(--dim)' } },
+        'Leave fields empty to use server defaults from environment variables. Settings are saved to browser local storage.'
+      )
+    )
+  );
+}
+
+function SplashScreen({ onNavigate, saveCreds }) {
   var cardStyle = {
     background: 'var(--surface)',
     border: '1px solid var(--border)',
@@ -2842,12 +2919,13 @@ function SplashScreen({ onNavigate }) {
         style: { fontSize: 26, fontWeight: 700, margin: '0 0 8px', color: 'var(--fg)' }
       }, 'Egeria Explorer'),
       React.createElement('p', {
-        style: { fontSize: 14, color: 'var(--muted)', margin: '0 0 36px', lineHeight: 1.65, maxWidth: 660 }
+        style: { fontSize: 14, color: 'var(--muted)', margin: '0 0 28px', lineHeight: 1.65, maxWidth: 660 }
       },
         'A lightweight exploration tool for your Egeria metadata ecosystem. ' +
         'Browse the open metadata type system, business glossaries, reference data, digital products, ' +
         'and view-server REST APIs — all connected live to your running Egeria platform.'
       ),
+      React.createElement(ConnectionForm, { saveCreds: saveCreds }),
       React.createElement('div', {
         style: {
           display: 'grid',
@@ -2913,12 +2991,6 @@ function ValidValueDetail({ item }) {
   );
 }
 
-// Standard Egeria property names — click to look up their registered valid values
-const _COMMON_PROPS = [
-  'contentStatus', 'activityStatus', 'governanceStatus',
-  'operationalStatus', 'confidentiality', 'criticality',
-  'retention', 'projectStatus',
-];
 
 function ValidValueEntry({ val }) {
   if (!val) return null;
@@ -2932,14 +3004,36 @@ function ValidValueEntry({ val }) {
 }
 
 function ValidValuesView() {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
-  // Left: property name input + common presets
+  // Left: property name input + dynamic presets from Egeria
   const [propertyName, setPropertyName] = useState('');
   const [submittedProp, setSubmittedProp] = useState('');
+  const [knownProps, setKnownProps] = useState([]);
+  const [propsState, setPropsState] = useState('loading'); // 'loading' | 'ready' | 'error'
+  const [propsError, setPropsError] = useState('');
   // Right: loaded values for the submitted property
   const [values, setValues] = useState([]);
   const [loadState, setLoadState] = useState('idle');
   const [error, setError] = useState('');
+
+  // Fetch list of properties that have registered valid values
+  useEffect(() => {
+    setPropsState('loading');
+    setPropsError('');
+    fetch(credAppend('/api/valid-values/properties', creds))
+      .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(data => {
+        if (data && Array.isArray(data.properties)) {
+          setKnownProps(data.properties);
+          setPropsState('ready');
+        } else {
+          setKnownProps([]);
+          setPropsState('ready');
+        }
+      })
+      .catch(err => { setPropsError(err.message); setPropsState('error'); });
+  }, [creds]);
 
   const lookup = useCallback((prop) => {
     const p = (prop || '').trim();
@@ -2948,7 +3042,7 @@ function ValidValuesView() {
     setLoadState('loading');
     setError('');
     setValues([]);
-    fetch('/api/valid-values/lookup?property_name=' + encodeURIComponent(p))
+    fetch(credAppend('/api/valid-values/lookup?property_name=' + encodeURIComponent(p), creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const sorted = (data.values || []).slice().sort((a, b) => {
@@ -2960,7 +3054,7 @@ function ValidValuesView() {
         setLoadState('ready');
       })
       .catch(err => { setError(err.message); setLoadState('error'); });
-  }, []);
+  }, [creds]);
 
   return React.createElement("div", { className: "body" },
     // Left: property selector
@@ -2970,9 +3064,14 @@ function ValidValuesView() {
         React.createElement("input", { name: "pn", type: "text", placeholder: "e.g. contentStatus", value: propertyName, onChange: e => setPropertyName(e.target.value), style: { flex: 1, fontSize: 13, padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit' } }),
         React.createElement("button", { type: "submit", style: { padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit', cursor: 'pointer', fontSize: 12 } }, "Go")
       ),
-      React.createElement("div", { style: { padding: '6px 12px', fontSize: 11, color: 'var(--dim)', borderBottom: '1px solid var(--border)' } }, "Standard Egeria property names:"),
+      React.createElement("div", { style: { padding: '6px 12px', fontSize: 11, color: 'var(--dim)', borderBottom: '1px solid var(--border)' } },
+        propsState === 'loading' ? "Loading properties…"
+        : propsState === 'error' ? React.createElement("span", { style: { color: '#d44' }, title: propsError }, "⚠ " + propsError)
+        : knownProps.length === 0 ? "No registered properties found"
+        : "Properties with registered values:"
+      ),
       React.createElement("div", { className: "tree-scroll" },
-        _COMMON_PROPS.map(p =>
+        knownProps.map(p =>
           React.createElement("div", {
             key: p,
             className: "tree-item" + (submittedProp === p ? " sel" : ""),
@@ -3076,18 +3175,20 @@ function RestApiView() {
       .catch(function(e) { setCatError(String(e)); });
   }, []);
 
+  const creds = React.useContext(CredContext);
+
   // Load OpenAPI endpoint list
   function loadOpenApi() {
     setApiLoading(true);
     setApiError('');
-    fetch('/api/rest-apis')
+    fetch(credAppend('/api/rest-apis', creds))
       .then(function(r) { return r.json(); })
       .then(function(d) { setOpenapi(d); setApiLoading(false); })
       .catch(function(e) { setApiError(String(e)); setApiLoading(false); });
   }
 
   function refreshOpenApi() {
-    fetch('/api/rest-apis/refresh', { method: 'POST' })
+    fetch(credAppend('/api/rest-apis/refresh', creds), { method: 'POST' })
       .then(function() { loadOpenApi(); });
   }
 
@@ -3440,6 +3541,21 @@ const AREA_NAMES = {
   "7": "Area 7 — Lineage"
 };
 function App() {
+  const [creds, setCreds] = useState(function() {
+    try {
+      var s = localStorage.getItem('egeria-creds');
+      return s ? JSON.parse(s) : { url: '', server: 'qs-view-server', userId: 'erinoverview', password: 'secret' };
+    } catch(e) { return { url: '', server: 'qs-view-server', userId: 'erinoverview', password: 'secret' }; }
+  });
+  const [connected, setConnected] = useState(function() {
+    try { return !!localStorage.getItem('egeria-creds'); } catch(e) { return false; }
+  });
+  const saveCreds = useCallback(function(c) {
+    setCreds(c);
+    setConnected(true);
+    try { localStorage.setItem('egeria-creds', JSON.stringify(c)); } catch(e) {}
+  }, []);
+
   const [loadState, setLoadState] = useState('loading');
   const [error, setError]         = useState('');
   const [rawData, setRawData]     = useState(null);
@@ -3460,7 +3576,7 @@ function App() {
   // Fetch type data once
   useEffect(() => {
     setLoadState('loading');
-    fetch('/api/types').then(r => {
+    fetch(credAppend('/api/types', creds)).then(r => {
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r.json();
     }).then(data => {
@@ -3526,20 +3642,21 @@ function App() {
 
   const { entities = {}, classifications = {}, relationships = {}, allEntities = {} } = data;
 
-  return /*#__PURE__*/React.createElement(React.Fragment, null,
+  return /*#__PURE__*/React.createElement(CredContext.Provider, { value: creds },
+  /*#__PURE__*/React.createElement(React.Fragment, null,
     // Header
     /*#__PURE__*/React.createElement("div", { className: "header" },
       /*#__PURE__*/React.createElement("img", { src: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJQAAACUCAMAAABC4vDmAAAAilBMVEX///9wzNsAAAAkICFmydkhHR5ry9oZFBX7+/v7/v72+/z29vYeGhvb8fXLy8vw8PCN1eEJAADb29sPBgno6Ohbxtfu+PoVDxBzcnJramrh4eG1tbXV1dU+PT2Pj4+w4eliYWHAv79SUVGfnp6j3OasrKzG6e99fHxFREQrKCk0MTJ/0N6Ih4daWFkY3gLWAAAJN0lEQVR4nO1caZeqOBDVxBhb4oI44oat2DZq6///e1MVlyeQVV8L58zcb9pIl7m1V2Gj8d/CbtavWoQSdiQmdZMqSDkli6qlKGBLKDssq5YijzllNJ5VLUUegz2njIyrFiOHYB1SSrZVi5HDOEWZsqrFyGGURhS0PKhajkdsYk4BpEam11lFglIQi5+rFuWO8ZoAdWQNBMZ18ecLEcMZ8V1nGtfFTQVTwiiNjptGow/CkUHVAgE2CXgCFq6lLHtBya5qiRrBiqCG31wmxD5eOX/zAxwTDdPR7TWhYl8xf1sBXkCQ091jDo7iN7OEycR6yXiGGh4mD04A7Y9sCtd9ONzLCd8/za8P8yUjqeFkmssKVlEpJHe/mj+9vyHT5J9ms/VpvGSHGh4fCmnmLqJRISZ/tprt1t84q2HbJtQKqSPJvPD2BtznuiRUs/31ukx4n2bLcOaDVMaVVekPS07FMf9WD75gs20+dgdMpEyGLzfYR2h1Cjc5F4ySwntf8nbd12T6+IHv1v7R6/koAk8QlahDdA5loS73G74m1LeFvNEBZCKpOhdHoYqJ3uWG36/IhJZn0vJlDGYX6oLJEYQqiXsh8AUL/BhK8rQqMMdcjmQdH6EmzeZrBFosbyTwnMpmd4OKvqsFWhyfAb2W8ePBEc9JL9OYlhUd8ZIFXsnTWV6AJYtBpsYipjxVvN+9WKAlcmnw2TaSd0KZpobPb0MNt5KB9lMWeLE87UcX4MejdenteX95y6EwIKtTT0ngP09YYFeSN9RRPwIt5klRjfspWFxyzam25Szhdu9nXein2Z+kMWW8kMLN14QzAEmkI1BkCTdYTEgHy8cgAc9xE2zmo+wABQxlURgTqd99DnJrPv+UC7VYyBzIyzvyjJCIgQ+gbLXNkksHD11CMfV0u78aFrc5jSAryTnrTkqjiB0ZX4N/H9Hp9Sp+1nQ5niCwZ455ywJ5lzcXi/6YiASMrx9KWeRluh6VN4GWww3OXO0WIbKIOF1uDuQkX2VgDWSkvBD+R9OPQIsf2WBHTN28wAqUEHFVpTnkyeKgaXNY2Chdbsl5Ek5jja13MhLxMLpxtggxK92qS1KL08nDZhlSVbRV5mKaZn/O5lpTKA/Li0BbFJ/yUpWix5YLPCxlk9+WQj7AZqzoozzGG32CFKqdqLMFWuMS6vLao8canGKdXVySIwcCP20RnAoa+jXIcUij9uyOFmizvMYI1dyrGR3gJ1Q1WMOh1EXY6zJI3WK/ti/kVUyVFiOcLNCaPwdrLRcaLFQx6Q4HC7RXGmB77KDhQomACSoS/eRIEtg2ENhtWjPCDXYydYWeCn2ijUkSlvLEyfGvCI0MFUwZHUJMJY+VQJc6/yh8PCdisLWooNECnToiSIY7e0F/52AUJhcqLa9trlwhGGvz7pJEixlQR2Jrh3+iN6+L5VlKRLBvx4nLeLWPYiriw5FbR+5Sb5oKAqXltWy1mKLjq8IADwnSA7LfYMpu5ftigeXLvvCgmraInSl642XsDhFWWyLKHOPRRJ2ZfLuQd/HnduMLpgRl2rvPG76VLnToVEgP9oIdNJVATqoMkyifyYxsjBf7vdIdWDvc8yMzhYwHnCAPjlL3eDRUabRbg3QERWj68P0NR7GjUIqK1FGppPaUukMfQxwGNG0zmELWuTJozRIMkDlOIbuyEVomqiuPyqJVy8Jg8ZSYrg4Grr5fanRT4bdtLXMEhHz+2Lw7GWPtZuUYJQ26Iz1V2+ipNgWhtsSwIbUhoVvslmFGY2WXEGS0QIgy/LE2XkSlztkfrELHFZyvloY8hN2B7gpCjQ9MaD38SdvzLPxbc+45NImMKJ5UYxpSFqn3ATszt2y+ayGoaxtRlIQa4MAoJiQ5Z9vdZrmcjwfB1eT6UMS4eH/LqOV2knoCi4qOTgJDL6QoEeZO0SHZn2ezDDCFolWom1jlf2n22pYSq+gSAANctbmDMSE4jwEc2y129i4Zujm+yRmT/pqi85TA0QOHU4o5F4Kxu4DCZdVs6JIxmfNPCDOi1FpdYezp71ZZtk73RxGSC6LUYcnTYnl30eVlmhg4B3rSYhTe85vpdwbj+Wi5XPYRS4fExSm2NSwWOE4EOxbyETkqdrAyBWxDzj8wWeAgFTQuDj9AjZ5clHIJt1cYLFDlEDfYE3tKJhfLu1/7o4+Pp7gUz3aQ+NFnZLqS59geNgwJdyHl+/xb2/JbbvAgD6EnUPbxCkJFzy1PWndDCrj211R/IqXWMNSnz6wpSvKaLpZ3g77zOYtpdCoKpZs1mnBp+HotU2kJhJBccJ8o1Kl8oQW+5MnP6CxwfizyBzoVegvVdXabj+jpZu1T4C+nQiiUV28P8e1PHuLSrSo7EdnDfCySF7G/UD17OaCE1gLBVeZ0qB/70+dteTfoCISUmImHADyGLN1TqCcs7wYNgYO9yK9uHFhk2i4po/eE5d0w0RAoRwgPUfnM3cd/iGvD98m1IB2BR07lUP2KLfGLfdY5mRmykC83+5eC0XB9fzknLPa46YtLXVoLPOVmQMGae+RT1rGHFbohYYKPD93VahF5PErkNWNXQ1pguQJCAgW9J+vMfdj25D5QDh8aAiEuU34c3V+5pglPb07loLNAKPZofEsXOuu9Y8/uRcu730bTSpNSJdez6pzd+Osp+63+kBaoUILODKXaX/Vq4Naclqvfr1jeDUigKofpZKhXwuspBhTqryzJw51ayjoowLPiuqUfJSY/rdeWmR9upYnnHXSi+vaiEr2/9OCFHpJBFlX/HFEeW7mK5J0N/zJ2+DDfMyXWr2LDcNd6WqtHMSEO4ga4You4WoyS2LS/XxHGKJXfXscbME+4U3/6vRiDXjFWo0d8JfoM19OrlqKIhWlPuDJMoXA+1uupf9lir+FRbT0Wht4Hol/Urw6zqH4eVE4offZ334IRdV2EeSNwmhQ9N876PXRwuapuoQa35/8XygmzGgqFOhXWTdHB+vwWsN8B9FP7uvkp763wdyCLaOw/Y/tlYJZQt1/m6ns/JvIG4NNQ9fl1oAuW2ueIKkQaKxaGKsaW1K9GXsS4v1y1FHnsQua2Ffg+BBm4KFYrLR9vBf6sWlQnv7nj2IvltVLyzkHgT82k9UruaMyJ7qHeyjA6n2vX1gACfyGF+hf8Gpg9oMbnbwAAAABJRU5ErkJggg==", alt: "Egeria", style: { height: 28, width: 'auto', borderRadius: 4 } }),
       /*#__PURE__*/React.createElement("span", { style: { fontFamily: 'ui-monospace,monospace', fontSize: 11, color: 'var(--dim)', letterSpacing: 3, textTransform: 'uppercase' } }, "Egeria"),
       /*#__PURE__*/React.createElement("span", { style: { width: 1, height: 14, background: 'var(--border)', display: 'inline-block' } }),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'splash' ? " on" : ""), onClick: () => setSection('splash') }, "⌂ Home"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'type-system' ? " on" : ""), onClick: () => { setSection('type-system'); setView('types'); } }, "Type Explorer"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'glossary' ? " on" : ""), onClick: () => setSection('glossary') }, "Glossary"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'reference-data' ? " on" : ""), onClick: () => setSection('reference-data') }, "Reference Data"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'digital-products' ? " on" : ""), onClick: () => setSection('digital-products') }, "Digital Products"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), onClick: () => setSection('report-specs') }, "Report Specs"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), onClick: () => setSection('valid-values') }, "Valid Values"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), onClick: () => setSection('rest-apis') }, "REST APIs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'type-system' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => { setSection('type-system'); setView('types'); } }, "Type Explorer"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'glossary' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('glossary') }, "Glossary"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'reference-data' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('reference-data') }, "Reference Data"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'digital-products' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('digital-products') }, "Digital Products"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('report-specs') }, "Report Specs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('valid-values') }, "Valid Values"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('rest-apis') }, "REST APIs"),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
       section === 'type-system' && /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
       section === 'type-system' && view === 'types' && /*#__PURE__*/React.createElement("select", {
@@ -3565,7 +3682,7 @@ function App() {
     ),
     // Body \u2014 dispatches to section, then to Type System sub-view
     section === 'splash'
-      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); } })
+      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); }, saveCreds: saveCreds })
       : section === 'report-specs'
       ? React.createElement(ReportSpecView, null)
       : section === 'glossary'
@@ -3595,7 +3712,7 @@ function App() {
             )
           )
         )
-  );
+  ));
 }
 ReactDOM.createRoot(document.getElementById('root')).render(/*#__PURE__*/React.createElement(App, null));</script>
 </body>

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/valid_values_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/valid_values_handler.py
@@ -5,7 +5,9 @@ Copyright Contributors to the ODPi Egeria project.
 Valid Metadata Values Explorer — FastAPI router.
 
 Endpoints:
-  GET /api/valid-values/lookup   → valid values registered for a specific Egeria property name
+  GET /api/valid-values/properties  → property names that have registered valid values
+  GET /api/valid-values/lookup      → valid values for a specific Egeria property name
+  GET /api/valid-values/debug       → raw find_metadata_elements response (for diagnosis)
 """
 
 import os
@@ -17,30 +19,194 @@ from loguru import logger
 
 router = APIRouter(tags=["valid-values"])
 
+_FIND_BODY = {
+    "class": "FindRequestBody",
+    "metadataElementTypeName": "ValidMetadataValue",
+    "searchProperties": {
+        "class": "SearchProperties",
+        "conditions": [{"property": "preferredValue", "operator": "IS_NULL"}],
+        "matchCriteria": "ANY",
+    },
+}
 
-def _get_manager():
+
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ReferenceDataManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
+
+
+def _get_expert(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import MetadataExpert
+    import pyegeria
+    pyegeria.enable_ssl_check = False
+    pyegeria.disable_ssl_warnings = True
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _extract_name_from_element(el) -> str:
+    """Extract the property name from a ValidMetadataValue element.
+
+    Raw find_metadata_elements returns elements where the property name is stored
+    under the key "identifier" (not "propertyName") in elementProperties.
+    """
+    if isinstance(el, str):
+        return el.strip() if el.strip() else ""
+
+    if not isinstance(el, dict):
+        return ""
+
+    # Processed pyegeria format: el["properties"]["propertyName"] or ["identifier"]
+    props = el.get("properties")
+    if isinstance(props, dict):
+        name = props.get("propertyName") or props.get("identifier") or ""
+        if name:
+            return name
+
+    # Raw OpenMetadata format — propertiesAsStrings is the fastest path
+    el_props = el.get("elementProperties")
+    if isinstance(el_props, dict):
+        props_as_str = el_props.get("propertiesAsStrings") or {}
+        name = props_as_str.get("identifier") or ""
+        if name:
+            return name
+        # Fall back to full propertyValueMap
+        prop_map = el_props.get("propertyValueMap") or {}
+        prop_entry = prop_map.get("identifier") or {}
+        if isinstance(prop_entry, dict):
+            name = prop_entry.get("primitiveValue") or ""
+            if name:
+                return name
+
+    return el.get("identifier") or el.get("propertyName") or ""
+
+
+def _names_from_raw(raw) -> set:
+    """Extract unique property names regardless of whether raw is a list or a response dict."""
+    names: set[str] = set()
+
+    if isinstance(raw, str):
+        # NO_ELEMENTS_FOUND sentinel or unexpected string — nothing to parse
+        logger.warning(f"find_metadata_elements returned string: {raw[:200]}")
+        return names
+
+    # Some pyegeria versions return the full response dict rather than just the elements list
+    if isinstance(raw, dict):
+        logger.info(f"find_metadata_elements returned dict with keys: {list(raw.keys())[:10]}")
+        # Try "elementsAsStrings" — simple list of property name strings
+        for item in (raw.get("elementsAsStrings") or []):
+            n = _extract_name_from_element(item)
+            if n:
+                names.add(n)
+        # Also try structured "elements"
+        for item in (raw.get("elements") or []):
+            n = _extract_name_from_element(item)
+            if n:
+                names.add(n)
+        return names
+
+    if not isinstance(raw, list):
+        logger.warning(f"find_metadata_elements returned unexpected type {type(raw).__name__}")
+        return names
+
+    for el in raw:
+        n = _extract_name_from_element(el)
+        if n:
+            names.add(n)
+    return names
+
+
+@router.get("/api/valid-values/debug", summary="Debug: raw find_metadata_elements response structure")
+def debug_valid_value_properties(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    """Return diagnostic information about the raw find_metadata_elements response."""
+    try:
+        mgr = _get_expert(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_metadata_elements(_FIND_BODY)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"find_metadata_elements failed: {exc}")
+
+    first = None
+    if isinstance(raw, list) and raw:
+        first = raw[0]
+    elif isinstance(raw, dict):
+        elems = raw.get("elements") or raw.get("elementsAsStrings") or []
+        first = elems[0] if elems else None
+
+    return JSONResponse({
+        "raw_type":        type(raw).__name__,
+        "raw_length":      len(raw) if isinstance(raw, (list, str)) else None,
+        "raw_keys":        list(raw.keys()) if isinstance(raw, dict) else None,
+        "first_item_type": type(first).__name__ if first is not None else None,
+        "first_item_keys": list(first.keys()) if isinstance(first, dict) else None,
+        "first_item":      first,
+        "names_extracted": sorted(_names_from_raw(raw)),
+    })
+
+
+@router.get("/api/valid-values/properties", summary="List property names that have registered valid values")
+def get_valid_value_properties(
+    url:     Optional[str] = Query(None, description="Egeria platform URL (overrides env)"),
+    server:  Optional[str] = Query(None, description="View server name (overrides env)"),
+    user_id: Optional[str] = Query(None, description="User ID (overrides env)"),
+    user_pwd:Optional[str] = Query(None, description="Password (overrides env)"),
+):
+    """
+    Return the sorted list of property names that have at least one registered valid value.
+    Uses find_metadata_elements to query ValidMetadataValue entries where preferredValue IS_NULL
+    (these are the header registrations that identify a property as having a controlled vocabulary).
+    """
+    try:
+        mgr = _get_expert(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create MetadataExpert")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_metadata_elements(_FIND_BODY)
+    except Exception as exc:
+        logger.exception("find_metadata_elements failed")
+        raise HTTPException(status_code=500, detail=f"Property list retrieval failed: {exc}")
+
+    names = _names_from_raw(raw)
+    logger.info(f"find_metadata_elements: type={type(raw).__name__} → {len(names)} unique property names: {sorted(names)}")
+    return JSONResponse({"properties": sorted(names), "total": len(names)})
 
 
 @router.get("/api/valid-values/lookup", summary="Look up valid values for an Egeria property name")
 def lookup_valid_values(
     property_name: str           = Query(..., description="Egeria property name to look up"),
     type_name:     Optional[str] = Query(None, description="Optional: restrict to a specific Egeria type name"),
+    url:     Optional[str] = Query(None, description="Egeria platform URL (overrides env)"),
+    server:  Optional[str] = Query(None, description="View server name (overrides env)"),
+    user_id: Optional[str] = Query(None, description="User ID (overrides env)"),
+    user_pwd:Optional[str] = Query(None, description="Password (overrides env)"),
 ):
     """
     Return valid metadata values registered for a given Egeria property name.
     Optionally restrict results to a specific open metadata type.
-    These represent the allowed values for properties like contentStatus, operationalStatus, etc.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/README.md
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/README.md
@@ -350,7 +350,7 @@ Browse pyegeria's client-side report format specifications. These are not stored
 
 Look up the registered valid values for a specific Egeria property name. Uses Egeria's controlled vocabulary registry (`get_valid_metadata_values`), which is separate from the Reference Data sets.
 
-- Left panel: a text input for any property name, plus quick-access buttons for standard Egeria property names (`contentStatus`, `activityStatus`, `governanceStatus`, etc.).
+- Left panel: on tab open, a sidebar is pre-populated with all property names that have registered valid values (via `GET /api/valid-values/properties`). Click a name to look it up, or type any property name directly.
 - Right panel: the ordered list of allowed values for the selected property, with display names, preferred values, and descriptions.
 
 #### REST APIs
@@ -476,6 +476,10 @@ Response: `{ guid, mermaidGraph }`. `mermaidGraph` is an empty string if no diag
 
 #### Valid Values
 
+**`GET /api/valid-values/properties`** — List all property names that have at least one registered valid value.
+
+Response: `{ properties: [string, ...], total: N }`. Used by the Valid Values tab to pre-populate the sidebar. Queries `ValidMetadataValue` entries where `preferredValue IS_NULL` (these are the header registrations). Property names are extracted from `elementProperties.propertiesAsStrings.identifier` in the raw OpenMetadata response.
+
 **`GET /api/valid-values/lookup`** — Valid values for a property name.
 
 Query params: `property_name` (required), `type_name` (optional).
@@ -513,7 +517,7 @@ For the extension history and remaining open work, see [Extending the TypeExplor
 | `glossary_handler.py` | `/api/glossary*`; uses `graph_query_depth=1` for terms; GUID-deduplicates before returning |
 | `digital_products_handler.py` | `/api/digital-products`; recursive tree via `get_collection_members` with `graph_query_depth=0` |
 | `mermaid_handler.py` | `/api/mermaid/{guid}`; uses `MetadataExpert.get_anchored_element_graph` |
-| `valid_values_handler.py` | `/api/valid-values/lookup`; uses `ReferenceDataManager.get_valid_metadata_values` |
+| `valid_values_handler.py` | `/api/valid-values/properties` (pre-populates sidebar via `MetadataExpert.find_metadata_elements`); `/api/valid-values/lookup` (values for a name via `ReferenceDataManager.get_valid_metadata_values`) |
 | `report_specs_handler.py` | `/api/report-specs`; reads local pyegeria report spec objects; no Egeria connection |
 | `rest_api_handler.py` | `/api/request-bodies`, `/api/rest-apis`; catalog + live OpenAPI endpoint discovery |
 | `pyegeria_handler.py` | FastAPI app entry point; mounts all routers |

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/digital_products_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/digital_products_handler.py
@@ -14,6 +14,7 @@ Endpoints:
 """
 
 import os
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -29,13 +30,13 @@ _CONTAINER_TYPES = {
 }
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import CollectionManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -156,10 +157,14 @@ def _build_tree(mgr, collection_guid: str, visited: set, depth: int = 0) -> list
 def get_catalogs(
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(100, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return all DigitalProductCatalog collections (paginated through all available collections)."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -177,14 +182,20 @@ def get_catalogs(
 
 @router.get("/api/digital-products/catalogs/{catalog_guid}/tree",
             summary="Full hierarchy tree for a catalog")
-def get_catalog_tree(catalog_guid: str):
+def get_catalog_tree(
+    catalog_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return the full recursive hierarchy tree for a DigitalProductCatalog.
 
     Tree nodes: {guid, typeName, displayName, ..., isContainer: bool, children: [node...]}
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -204,10 +215,16 @@ def get_catalog_tree(catalog_guid: str):
 
 
 @router.get("/api/digital-products/{node_guid}", summary="Get detail for any product/collection node")
-def get_node(node_guid: str):
+def get_node(
+    node_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return detail for a single digital product or family node."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create CollectionManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/glossary_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/glossary_handler.py
@@ -22,13 +22,13 @@ from loguru import logger
 router = APIRouter(tags=["glossary"])
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import GlossaryManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = GlossaryManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = GlossaryManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -156,10 +156,14 @@ def _serialize_term(term: dict) -> dict:
 def get_glossaries(
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(100, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return all Egeria glossaries with summary information."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -191,10 +195,14 @@ def get_glossary_folders(
     collection_guid: str,
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(200, ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """Return the CollectionFolder children of a glossary (organisational hierarchy)."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -223,6 +231,10 @@ def get_terms_in_collection(
     collection_guid: str,
     start_from: int = Query(0,   ge=0),
     page_size:  int = Query(500, ge=1, le=2000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return GlossaryTerms that are members of the given collection (glossary or folder).
@@ -231,7 +243,7 @@ def get_terms_in_collection(
     then filters for GlossaryTerm type elements. Much faster than a full-table scan.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -259,13 +271,17 @@ def search_all_terms(
     q:          str = Query("*",   description="Search string; use * to return all"),
     start_from: int = Query(0,     ge=0),
     page_size:  int = Query(200,   ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Search for GlossaryTerms across all glossaries using a text search string.
     Terms can belong to multiple glossaries; this view is independent of glossary membership.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -302,10 +318,16 @@ def search_all_terms(
 
 
 @router.get("/api/glossary/term/{term_guid}", summary="Get a single term by GUID")
-def get_term(term_guid: str):
+def get_term(
+    term_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return full detail for a single glossary term."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create GlossaryManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/mermaid_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/mermaid_handler.py
@@ -10,37 +10,38 @@ Endpoints:
 """
 
 import os
-from fastapi import APIRouter, HTTPException
+from typing import Optional
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 from loguru import logger
 
 router = APIRouter(tags=["mermaid"])
 
 
-def _get_classifier():
+def _get_classifier(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ClassificationExplorer
     import pyegeria
     pyegeria.enable_ssl_check = False
     pyegeria.disable_ssl_warnings = True
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ClassificationExplorer(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ClassificationExplorer(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
 
-def _get_expert():
+def _get_expert(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import MetadataExpert
     import pyegeria
     pyegeria.enable_ssl_check = False
     pyegeria.disable_ssl_warnings = True
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -52,14 +53,20 @@ def _normalise(graph) -> str:
 
 
 @router.get("/api/mermaid/{guid}/anchored", summary="Get full anchored element graph")
-def get_anchored_graph(guid: str):
+def get_anchored_graph(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return a Mermaid diagram showing the element and all its anchored elements.
     Uses MetadataExpert.get_anchored_element_graph — a broader, more expensive traversal.
     Returns {guid, mermaidGraph}.
     """
     try:
-        mgr = _get_expert()
+        mgr = _get_expert(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create MetadataExpert")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -74,14 +81,20 @@ def get_anchored_graph(guid: str):
 
 
 @router.get("/api/mermaid/{guid}", summary="Get context diagram for an element (graph_query_depth=5)")
-def get_mermaid_graph(guid: str):
+def get_mermaid_graph(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """
     Return a Mermaid context diagram using ClassificationExplorer.get_element_by_guid.
     Extracts the top-level mermaidGraph field from the response.
     Returns {guid, mermaidGraph}.
     """
     try:
-        mgr = _get_classifier()
+        mgr = _get_classifier(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ClassificationManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/reference_data_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/reference_data_handler.py
@@ -20,13 +20,13 @@ from loguru import logger
 router = APIRouter(tags=["reference-data"])
 
 
-def _get_manager():
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ReferenceDataManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -88,6 +88,10 @@ def get_valid_value_definitions(
     q:          Optional[str] = Query(None, description="Search string (substring match, case-insensitive). Defaults to all."),
     start_from: int           = Query(0,   ge=0),
     page_size:  int           = Query(200, ge=1, le=1000),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return valid value definitions from Egeria.
@@ -96,7 +100,7 @@ def get_valid_value_definitions(
     Returns a flat list suitable for client-side grouping by typeName (ValidValueSet vs ValidValueDefinition).
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -139,6 +143,10 @@ def get_valid_value_definitions(
 def get_metadata_values(
     property_name: str           = Query(..., description="Property name to look up valid values for"),
     type_name:     Optional[str] = Query(None, description="Optional: restrict to a specific open metadata type"),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
 ):
     """
     Return the valid metadata values registered for a given property name.
@@ -146,7 +154,7 @@ def get_metadata_values(
     Does not require Egeria connection (uses local ValidMetadataManager registry).
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
@@ -169,10 +177,16 @@ def get_metadata_values(
 
 
 @router.get("/api/reference-data/{vv_guid}", summary="Get a valid value definition by GUID")
-def get_valid_value_definition(vv_guid: str):
+def get_valid_value_definition(
+    vv_guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
     """Return full detail for a single valid value definition."""
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer-architecture.md
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer-architecture.md
@@ -24,6 +24,7 @@ Browser
   │  GET /api/digital-products/{guid}            (node detail)
   │  GET /api/mermaid/{guid}           (context diagram — graph_query_depth=5)
   │  GET /api/mermaid/{guid}/anchored  (full anchored element graph)
+  │  GET /api/valid-values/properties  (property names that have registered valid values)
   │  GET /api/valid-values/lookup      (valid values for a property name)
   │  GET /api/request-bodies           (Layer 1 request body catalog — no Egeria needed)
   │  GET /api/rest-apis                (OpenAPI endpoint catalog)
@@ -75,7 +76,8 @@ Apache and the FastAPI server run in separate containers on the same Docker netw
 | Digital Products tree | `GET /api/digital-products/catalogs/{guid}/tree` | Catalog selected |
 | Context diagram | `GET /api/mermaid/{guid}` — `get_metadata_element_by_guid` at depth=5 | User clicks "▦ Load Context Diagram" |
 | Full anchored graph | `GET /api/mermaid/{guid}/anchored` — `get_anchored_element_graph` | User clicks "▦ Load Full Graph" |
-| Valid Values | `GET /api/valid-values/lookup?property_name=…` | User selects or enters a property name |
+| Valid Values — property list | `GET /api/valid-values/properties` | First time tab is opened (pre-populates sidebar) |
+| Valid Values — lookup | `GET /api/valid-values/lookup?property_name=…` | User selects or enters a property name |
 | REST APIs — body catalog | `GET /api/request-bodies` | REST APIs tab is opened (no Egeria needed) |
 | REST APIs — endpoints | `GET /api/rest-apis` | User clicks "Load API Endpoints" in the toolbar |
 
@@ -201,6 +203,7 @@ The Reference Data view displays a hierarchy: root-level ValidValueSets as tree 
 |---------|---------|-------------|
 | `ValidMetadataManager` | `type_system_handler.py` | `get_all_entity_defs`, `get_all_relationship_defs`, `get_all_classification_defs` |
 | `ReferenceDataManager` | `reference_data_handler.py`, `valid_values_handler.py` | `find_valid_value_definitions`, `get_valid_metadata_values` |
+| `MetadataExpert` | `valid_values_handler.py` | `find_metadata_elements` (properties list — raw OpenMetadata format) |
 | `GlossaryManager` | `glossary_handler.py` | `find_glossaries`, `find_glossary_terms`, `get_term_by_guid`, `get_collection_members` |
 | `CollectionManager` | `digital_products_handler.py` | `find_collections`, `get_collection_members`, `get_collection_by_guid` |
 | `MetadataExpert` | `mermaid_handler.py` | `get_metadata_element_by_guid` (depth=5), `get_anchored_element_graph` |
@@ -274,6 +277,20 @@ This table answers the question "where does the data actually come from?" for ea
 Fixed upstream in pyegeria (the method now uses `_extract_typedef_list()` and accepts `get_inherited_attributes` / `get_relationship_attributes` parameters). The monkey-patch that previously existed in `type_system_handler.py` has been removed.
 
 This incident is a worked example of the pyegeria upgrade process — see [Upgrading pyegeria](#upgrading-pyegeria) below.
+
+### find_metadata_elements returns raw OpenMetadata format
+
+`MetadataExpert.find_metadata_elements(body)` returns elements in raw OpenMetadata format — **not** the processed pyegeria format returned by manager methods like `find_valid_value_definitions`. There is no `elementHeader` / `properties` split; instead each element has:
+
+```
+el["elementGUID"]                                                      # top-level GUID
+el["elementProperties"]["propertiesAsStrings"]["identifier"]          # fastest path — string value
+el["elementProperties"]["propertyValueMap"]["identifier"]["primitiveValue"]  # full structure
+```
+
+The property name field is `"identifier"`, not `"propertyName"`. Code that looks for `"propertyName"` in `propertyValueMap` will silently find nothing.
+
+The `propertiesAsStrings` shortcut is preferred for extraction — it contains the same string values without the type wrapper objects.
 
 ### MetadataExpert vs MetadataExplorer
 

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -154,6 +154,7 @@
                 padding: 4px 12px; cursor: pointer; font-size: 13px; color: var(--muted);
                 font-family: inherit; line-height: 1.5; }
     .view-tab.on { color: var(--accent); font-weight: 600; border-bottom-color: var(--accent); }
+    .view-tab:disabled { opacity: 0.35; cursor: not-allowed; }
     .theme-btn { background: var(--card); border: 1px solid var(--border); color: var(--muted);
                  border-radius: 20px; padding: 3px 12px; cursor: pointer; font-size: 12px;
                  font-family: inherit; }
@@ -536,6 +537,26 @@ const {
   useRef
 } = React;
 
+// ── Credential context ────────────────────────────────────────────────────────
+// Provides Egeria connection params to all child components without prop-drilling.
+const CredContext = React.createContext({ url: '', server: '', userId: '', password: '' });
+
+function credQS(creds) {
+  var p = new URLSearchParams();
+  if (creds && creds.url)      p.set('url',      creds.url);
+  if (creds && creds.server)   p.set('server',   creds.server);
+  if (creds && creds.userId)   p.set('user_id',  creds.userId);
+  if (creds && creds.password) p.set('user_pwd', creds.password);
+  var s = p.toString();
+  return s ? '?' + s : '';
+}
+
+function credAppend(base, creds) {
+  var qs = credQS(creds);
+  if (!qs) return base;
+  return base + (base.includes('?') ? '&' + qs.slice(1) : qs);
+}
+
 // ── Markdown renderer ─────────────────────────────────────────────────────────
 function MermaidDiagram({ code }) {
   const ref = React.useRef(null);
@@ -588,11 +609,12 @@ function DiagramPanel({ fetchUrl, label, buttonLabel }) {
   const [code, setCode] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [visible, setVisible] = React.useState(true);
+  const creds = React.useContext(CredContext);
 
   React.useEffect(function() {
     if (!open) return;
     setCode(null);
-    fetch(fetchUrl)
+    fetch(credAppend(fetchUrl, creds))
       .then(function(r) { return r.ok ? r.json() : null; })
       .then(function(data) { setCode(data && data.mermaidGraph ? data.mermaidGraph : ''); })
       .catch(function() { setCode(''); });
@@ -2061,6 +2083,7 @@ function GlossaryTermDetail({ term, onNavigateToTerm }) {
 }
 
 function GlossaryView({ navGuid }) {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [glossaryState, setGlossaryState] = useState('loading');
   const [glossaryAttempt, setGlossaryAttempt] = useState(0);
@@ -2095,7 +2118,7 @@ function GlossaryView({ navGuid }) {
   // Fetch term when cross-navigated from Digital Products
   useEffect(() => {
     if (!navGuid) { setNavTerm(null); return; }
-    fetch('/api/glossary/term/' + encodeURIComponent(navGuid))
+    fetch(credAppend('/api/glossary/term/' + encodeURIComponent(navGuid), creds))
       .then(function(r) { return r.ok ? r.json() : null; })
       .then(function(data) { if (data) { setNavTerm(data); setSelectedItem(data.guid); } })
       .catch(function() {});
@@ -2111,7 +2134,7 @@ function GlossaryView({ navGuid }) {
   useEffect(() => {
     setGlossaryState('loading');
     setGlossaryError('');
-    fetch('/api/glossary')
+    fetch(credAppend('/api/glossary', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const list = (data.glossaries || []).sort((a, b) => (a.displayName || '').localeCompare(b.displayName || ''));
@@ -2134,8 +2157,8 @@ function GlossaryView({ navGuid }) {
     setTermDetailState('idle');
     setFilterText('');
     Promise.all([
-      fetch('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/folders').then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
-      fetch('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/terms').then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/folders', creds)).then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/terms', creds)).then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }),
     ])
     .then(([fData, tData]) => {
       setFolders(fData.folders || []);
@@ -2156,7 +2179,7 @@ function GlossaryView({ navGuid }) {
     setSelectedItem(null);
     setTermDetail(null);
     setTermDetailState('idle');
-    fetch('/api/glossary-terms?q=' + encodeURIComponent(sq))
+    fetch(credAppend('/api/glossary-terms?q=' + encodeURIComponent(sq), creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => { setSearchTerms(data.terms || []); setSearchState('ready'); })
       .catch(err => { setSearchError(err.message); setSearchState('idle'); });
@@ -2218,7 +2241,7 @@ function GlossaryView({ navGuid }) {
     if (navTerm && navTerm.guid === selectedItem) { setTermDetail(navTerm); setTermDetailState('ready'); return; }
     setTermDetail(null);
     setTermDetailState('loading');
-    fetch('/api/glossary/term/' + encodeURIComponent(selectedItem))
+    fetch(credAppend('/api/glossary/term/' + encodeURIComponent(selectedItem), creds))
       .then(r => r.ok ? r.json() : null)
       .then(data => { setTermDetail(data || null); setTermDetailState(data ? 'ready' : 'error'); })
       .catch(() => setTermDetailState('error'));
@@ -2432,6 +2455,7 @@ function RefDataTreeNode({ item, byGuid, depth, selected, onSelect, expanded, to
 }
 
 function ReferenceDataView() {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [loadState, setLoadState] = useState('loading');
   const [attempt, setAttempt]     = useState(0);
@@ -2444,7 +2468,7 @@ function ReferenceDataView() {
   useEffect(function() {
     setLoadState('loading');
     setError('');
-    fetch('/api/reference-data?page_size=500')
+    fetch(credAppend('/api/reference-data?page_size=500', creds))
       .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function(data) {
         const list = data.definitions || [];
@@ -2618,6 +2642,7 @@ function DigitalTreeNode({ node, depth, selectedGuid, onSelect, expanded, toggle
 }
 
 function DigitalProductsView({ onNavigateToGlossary }) {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [treeW, onTreeDivDown] = useResizable(300);
   const [catState, setCatState]     = useState('loading');
@@ -2637,7 +2662,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
   useEffect(() => {
     setCatState('loading');
     setCatError('');
-    fetch('/api/digital-products/catalogs')
+    fetch(credAppend('/api/digital-products/catalogs', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const list = (data.catalogs || []).slice().sort((a, b) => (a.displayName || '').localeCompare(b.displayName || ''));
@@ -2656,7 +2681,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
     setTreeData(null);
     setSelectedNode(null);
     setSelectedNodeObj(null);
-    fetch('/api/digital-products/catalogs/' + encodeURIComponent(selectedCat) + '/tree')
+    fetch(credAppend('/api/digital-products/catalogs/' + encodeURIComponent(selectedCat) + '/tree', creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         setTreeData(data);
@@ -2812,7 +2837,59 @@ const _SPLASH_CAPABILITIES = [
   },
 ];
 
-function SplashScreen({ onNavigate }) {
+function ConnectionForm({ saveCreds }) {
+  const creds = React.useContext(CredContext);
+  const [form, setForm] = React.useState({
+    url:      creds.url,
+    server:   creds.server,
+    userId:   creds.userId,
+    password: creds.password,
+  });
+  const [saved, setSaved] = React.useState(false);
+  function set(k, v) { setForm(function(f) { return Object.assign({}, f, { [k]: v }); }); setSaved(false); }
+  function onSubmit(e) {
+    e.preventDefault();
+    saveCreds(form);
+    setSaved(true);
+  }
+  var fieldStyle = { fontSize: 12, padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit', width: '100%', boxSizing: 'border-box' };
+  var labelStyle = { fontSize: 11, color: 'var(--dim)', marginBottom: 2, display: 'block' };
+  var rowStyle   = { display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 };
+  return React.createElement('div', {
+    style: { background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 8, padding: '16px 20px', marginBottom: 32 }
+  },
+    React.createElement('div', { style: { fontSize: 13, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 } }, 'Connection Settings'),
+    React.createElement('form', { onSubmit: onSubmit },
+      React.createElement('div', { style: { display: 'grid', gridTemplateColumns: '2fr 1fr 1fr 1fr auto', gap: 8, alignItems: 'end' } },
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'Platform URL'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.url, placeholder: 'https://localhost:9443', onChange: function(e) { set('url', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'View Server'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.server, placeholder: 'qs-view-server', onChange: function(e) { set('server', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'User ID'),
+          React.createElement('input', { style: fieldStyle, type: 'text', value: form.userId, placeholder: 'erinoverview', onChange: function(e) { set('userId', e.target.value); } })
+        ),
+        React.createElement('div', { style: rowStyle },
+          React.createElement('label', { style: labelStyle }, 'Password'),
+          React.createElement('input', { style: fieldStyle, type: 'password', value: form.password, placeholder: 'secret', onChange: function(e) { set('password', e.target.value); } })
+        ),
+        React.createElement('button', {
+          type: 'submit',
+          style: { padding: '6px 14px', borderRadius: 5, border: '1px solid rgba(96,165,250,.4)', background: saved ? 'rgba(52,211,153,.12)' : 'rgba(96,165,250,.1)', color: saved ? '#34d399' : 'var(--accent)', cursor: 'pointer', fontSize: 12, fontWeight: 600, whiteSpace: 'nowrap' }
+        }, saved ? '✔ Saved' : 'Connect')
+      ),
+      React.createElement('p', { style: { margin: '8px 0 0', fontSize: 11, color: 'var(--dim)' } },
+        'Leave fields empty to use server defaults from environment variables. Settings are saved to browser local storage.'
+      )
+    )
+  );
+}
+
+function SplashScreen({ onNavigate, saveCreds }) {
   var cardStyle = {
     background: 'var(--surface)',
     border: '1px solid var(--border)',
@@ -2842,12 +2919,13 @@ function SplashScreen({ onNavigate }) {
         style: { fontSize: 26, fontWeight: 700, margin: '0 0 8px', color: 'var(--fg)' }
       }, 'Egeria Explorer'),
       React.createElement('p', {
-        style: { fontSize: 14, color: 'var(--muted)', margin: '0 0 36px', lineHeight: 1.65, maxWidth: 660 }
+        style: { fontSize: 14, color: 'var(--muted)', margin: '0 0 28px', lineHeight: 1.65, maxWidth: 660 }
       },
         'A lightweight exploration tool for your Egeria metadata ecosystem. ' +
         'Browse the open metadata type system, business glossaries, reference data, digital products, ' +
         'and view-server REST APIs — all connected live to your running Egeria platform.'
       ),
+      React.createElement(ConnectionForm, { saveCreds: saveCreds }),
       React.createElement('div', {
         style: {
           display: 'grid',
@@ -2913,12 +2991,6 @@ function ValidValueDetail({ item }) {
   );
 }
 
-// Standard Egeria property names — click to look up their registered valid values
-const _COMMON_PROPS = [
-  'contentStatus', 'activityStatus', 'governanceStatus',
-  'operationalStatus', 'confidentiality', 'criticality',
-  'retention', 'projectStatus',
-];
 
 function ValidValueEntry({ val }) {
   if (!val) return null;
@@ -2932,14 +3004,36 @@ function ValidValueEntry({ val }) {
 }
 
 function ValidValuesView() {
+  const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
-  // Left: property name input + common presets
+  // Left: property name input + dynamic presets from Egeria
   const [propertyName, setPropertyName] = useState('');
   const [submittedProp, setSubmittedProp] = useState('');
+  const [knownProps, setKnownProps] = useState([]);
+  const [propsState, setPropsState] = useState('loading'); // 'loading' | 'ready' | 'error'
+  const [propsError, setPropsError] = useState('');
   // Right: loaded values for the submitted property
   const [values, setValues] = useState([]);
   const [loadState, setLoadState] = useState('idle');
   const [error, setError] = useState('');
+
+  // Fetch list of properties that have registered valid values
+  useEffect(() => {
+    setPropsState('loading');
+    setPropsError('');
+    fetch(credAppend('/api/valid-values/properties', creds))
+      .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(data => {
+        if (data && Array.isArray(data.properties)) {
+          setKnownProps(data.properties);
+          setPropsState('ready');
+        } else {
+          setKnownProps([]);
+          setPropsState('ready');
+        }
+      })
+      .catch(err => { setPropsError(err.message); setPropsState('error'); });
+  }, [creds]);
 
   const lookup = useCallback((prop) => {
     const p = (prop || '').trim();
@@ -2948,7 +3042,7 @@ function ValidValuesView() {
     setLoadState('loading');
     setError('');
     setValues([]);
-    fetch('/api/valid-values/lookup?property_name=' + encodeURIComponent(p))
+    fetch(credAppend('/api/valid-values/lookup?property_name=' + encodeURIComponent(p), creds))
       .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(data => {
         const sorted = (data.values || []).slice().sort((a, b) => {
@@ -2960,7 +3054,7 @@ function ValidValuesView() {
         setLoadState('ready');
       })
       .catch(err => { setError(err.message); setLoadState('error'); });
-  }, []);
+  }, [creds]);
 
   return React.createElement("div", { className: "body" },
     // Left: property selector
@@ -2970,9 +3064,14 @@ function ValidValuesView() {
         React.createElement("input", { name: "pn", type: "text", placeholder: "e.g. contentStatus", value: propertyName, onChange: e => setPropertyName(e.target.value), style: { flex: 1, fontSize: 13, padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit' } }),
         React.createElement("button", { type: "submit", style: { padding: '4px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit', cursor: 'pointer', fontSize: 12 } }, "Go")
       ),
-      React.createElement("div", { style: { padding: '6px 12px', fontSize: 11, color: 'var(--dim)', borderBottom: '1px solid var(--border)' } }, "Standard Egeria property names:"),
+      React.createElement("div", { style: { padding: '6px 12px', fontSize: 11, color: 'var(--dim)', borderBottom: '1px solid var(--border)' } },
+        propsState === 'loading' ? "Loading properties…"
+        : propsState === 'error' ? React.createElement("span", { style: { color: '#d44' }, title: propsError }, "⚠ " + propsError)
+        : knownProps.length === 0 ? "No registered properties found"
+        : "Properties with registered values:"
+      ),
       React.createElement("div", { className: "tree-scroll" },
-        _COMMON_PROPS.map(p =>
+        knownProps.map(p =>
           React.createElement("div", {
             key: p,
             className: "tree-item" + (submittedProp === p ? " sel" : ""),
@@ -3076,18 +3175,20 @@ function RestApiView() {
       .catch(function(e) { setCatError(String(e)); });
   }, []);
 
+  const creds = React.useContext(CredContext);
+
   // Load OpenAPI endpoint list
   function loadOpenApi() {
     setApiLoading(true);
     setApiError('');
-    fetch('/api/rest-apis')
+    fetch(credAppend('/api/rest-apis', creds))
       .then(function(r) { return r.json(); })
       .then(function(d) { setOpenapi(d); setApiLoading(false); })
       .catch(function(e) { setApiError(String(e)); setApiLoading(false); });
   }
 
   function refreshOpenApi() {
-    fetch('/api/rest-apis/refresh', { method: 'POST' })
+    fetch(credAppend('/api/rest-apis/refresh', creds), { method: 'POST' })
       .then(function() { loadOpenApi(); });
   }
 
@@ -3440,6 +3541,21 @@ const AREA_NAMES = {
   "7": "Area 7 — Lineage"
 };
 function App() {
+  const [creds, setCreds] = useState(function() {
+    try {
+      var s = localStorage.getItem('egeria-creds');
+      return s ? JSON.parse(s) : { url: '', server: 'qs-view-server', userId: 'erinoverview', password: 'secret' };
+    } catch(e) { return { url: '', server: 'qs-view-server', userId: 'erinoverview', password: 'secret' }; }
+  });
+  const [connected, setConnected] = useState(function() {
+    try { return !!localStorage.getItem('egeria-creds'); } catch(e) { return false; }
+  });
+  const saveCreds = useCallback(function(c) {
+    setCreds(c);
+    setConnected(true);
+    try { localStorage.setItem('egeria-creds', JSON.stringify(c)); } catch(e) {}
+  }, []);
+
   const [loadState, setLoadState] = useState('loading');
   const [error, setError]         = useState('');
   const [rawData, setRawData]     = useState(null);
@@ -3460,7 +3576,7 @@ function App() {
   // Fetch type data once
   useEffect(() => {
     setLoadState('loading');
-    fetch('/api/types').then(r => {
+    fetch(credAppend('/api/types', creds)).then(r => {
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r.json();
     }).then(data => {
@@ -3526,20 +3642,21 @@ function App() {
 
   const { entities = {}, classifications = {}, relationships = {}, allEntities = {} } = data;
 
-  return /*#__PURE__*/React.createElement(React.Fragment, null,
+  return /*#__PURE__*/React.createElement(CredContext.Provider, { value: creds },
+  /*#__PURE__*/React.createElement(React.Fragment, null,
     // Header
     /*#__PURE__*/React.createElement("div", { className: "header" },
       /*#__PURE__*/React.createElement("img", { src: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJQAAACUCAMAAABC4vDmAAAAilBMVEX///9wzNsAAAAkICFmydkhHR5ry9oZFBX7+/v7/v72+/z29vYeGhvb8fXLy8vw8PCN1eEJAADb29sPBgno6Ohbxtfu+PoVDxBzcnJramrh4eG1tbXV1dU+PT2Pj4+w4eliYWHAv79SUVGfnp6j3OasrKzG6e99fHxFREQrKCk0MTJ/0N6Ih4daWFkY3gLWAAAJN0lEQVR4nO1caZeqOBDVxBhb4oI44oat2DZq6///e1MVlyeQVV8L58zcb9pIl7m1V2Gj8d/CbtavWoQSdiQmdZMqSDkli6qlKGBLKDssq5YijzllNJ5VLUUegz2njIyrFiOHYB1SSrZVi5HDOEWZsqrFyGGURhS0PKhajkdsYk4BpEam11lFglIQi5+rFuWO8ZoAdWQNBMZ18ecLEcMZ8V1nGtfFTQVTwiiNjptGow/CkUHVAgE2CXgCFq6lLHtBya5qiRrBiqCG31wmxD5eOX/zAxwTDdPR7TWhYl8xf1sBXkCQ091jDo7iN7OEycR6yXiGGh4mD04A7Y9sCtd9ONzLCd8/za8P8yUjqeFkmssKVlEpJHe/mj+9vyHT5J9ms/VpvGSHGh4fCmnmLqJRISZ/tprt1t84q2HbJtQKqSPJvPD2BtznuiRUs/31ukx4n2bLcOaDVMaVVekPS07FMf9WD75gs20+dgdMpEyGLzfYR2h1Cjc5F4ySwntf8nbd12T6+IHv1v7R6/koAk8QlahDdA5loS73G74m1LeFvNEBZCKpOhdHoYqJ3uWG36/IhJZn0vJlDGYX6oLJEYQqiXsh8AUL/BhK8rQqMMdcjmQdH6EmzeZrBFosbyTwnMpmd4OKvqsFWhyfAb2W8ePBEc9JL9OYlhUd8ZIFXsnTWV6AJYtBpsYipjxVvN+9WKAlcmnw2TaSd0KZpobPb0MNt5KB9lMWeLE87UcX4MejdenteX95y6EwIKtTT0ngP09YYFeSN9RRPwIt5klRjfspWFxyzam25Szhdu9nXein2Z+kMWW8kMLN14QzAEmkI1BkCTdYTEgHy8cgAc9xE2zmo+wABQxlURgTqd99DnJrPv+UC7VYyBzIyzvyjJCIgQ+gbLXNkksHD11CMfV0u78aFrc5jSAryTnrTkqjiB0ZX4N/H9Hp9Sp+1nQ5niCwZ455ywJ5lzcXi/6YiASMrx9KWeRluh6VN4GWww3OXO0WIbKIOF1uDuQkX2VgDWSkvBD+R9OPQIsf2WBHTN28wAqUEHFVpTnkyeKgaXNY2Chdbsl5Ek5jja13MhLxMLpxtggxK92qS1KL08nDZhlSVbRV5mKaZn/O5lpTKA/Li0BbFJ/yUpWix5YLPCxlk9+WQj7AZqzoozzGG32CFKqdqLMFWuMS6vLao8canGKdXVySIwcCP20RnAoa+jXIcUij9uyOFmizvMYI1dyrGR3gJ1Q1WMOh1EXY6zJI3WK/ti/kVUyVFiOcLNCaPwdrLRcaLFQx6Q4HC7RXGmB77KDhQomACSoS/eRIEtg2ENhtWjPCDXYydYWeCn2ijUkSlvLEyfGvCI0MFUwZHUJMJY+VQJc6/yh8PCdisLWooNECnToiSIY7e0F/52AUJhcqLa9trlwhGGvz7pJEixlQR2Jrh3+iN6+L5VlKRLBvx4nLeLWPYiriw5FbR+5Sb5oKAqXltWy1mKLjq8IADwnSA7LfYMpu5ftigeXLvvCgmraInSl642XsDhFWWyLKHOPRRJ2ZfLuQd/HnduMLpgRl2rvPG76VLnToVEgP9oIdNJVATqoMkyifyYxsjBf7vdIdWDvc8yMzhYwHnCAPjlL3eDRUabRbg3QERWj68P0NR7GjUIqK1FGppPaUukMfQxwGNG0zmELWuTJozRIMkDlOIbuyEVomqiuPyqJVy8Jg8ZSYrg4Grr5fanRT4bdtLXMEhHz+2Lw7GWPtZuUYJQ26Iz1V2+ipNgWhtsSwIbUhoVvslmFGY2WXEGS0QIgy/LE2XkSlztkfrELHFZyvloY8hN2B7gpCjQ9MaD38SdvzLPxbc+45NImMKJ5UYxpSFqn3ATszt2y+ayGoaxtRlIQa4MAoJiQ5Z9vdZrmcjwfB1eT6UMS4eH/LqOV2knoCi4qOTgJDL6QoEeZO0SHZn2ezDDCFolWom1jlf2n22pYSq+gSAANctbmDMSE4jwEc2y129i4Zujm+yRmT/pqi85TA0QOHU4o5F4Kxu4DCZdVs6JIxmfNPCDOi1FpdYezp71ZZtk73RxGSC6LUYcnTYnl30eVlmhg4B3rSYhTe85vpdwbj+Wi5XPYRS4fExSm2NSwWOE4EOxbyETkqdrAyBWxDzj8wWeAgFTQuDj9AjZ5clHIJt1cYLFDlEDfYE3tKJhfLu1/7o4+Pp7gUz3aQ+NFnZLqS59geNgwJdyHl+/xb2/JbbvAgD6EnUPbxCkJFzy1PWndDCrj211R/IqXWMNSnz6wpSvKaLpZ3g77zOYtpdCoKpZs1mnBp+HotU2kJhJBccJ8o1Kl8oQW+5MnP6CxwfizyBzoVegvVdXabj+jpZu1T4C+nQiiUV28P8e1PHuLSrSo7EdnDfCySF7G/UD17OaCE1gLBVeZ0qB/70+dteTfoCISUmImHADyGLN1TqCcs7wYNgYO9yK9uHFhk2i4po/eE5d0w0RAoRwgPUfnM3cd/iGvD98m1IB2BR07lUP2KLfGLfdY5mRmykC83+5eC0XB9fzknLPa46YtLXVoLPOVmQMGae+RT1rGHFbohYYKPD93VahF5PErkNWNXQ1pguQJCAgW9J+vMfdj25D5QDh8aAiEuU34c3V+5pglPb07loLNAKPZofEsXOuu9Y8/uRcu730bTSpNSJdez6pzd+Osp+63+kBaoUILODKXaX/Vq4Naclqvfr1jeDUigKofpZKhXwuspBhTqryzJw51ayjoowLPiuqUfJSY/rdeWmR9upYnnHXSi+vaiEr2/9OCFHpJBFlX/HFEeW7mK5J0N/zJ2+DDfMyXWr2LDcNd6WqtHMSEO4ga4You4WoyS2LS/XxHGKJXfXscbME+4U3/6vRiDXjFWo0d8JfoM19OrlqKIhWlPuDJMoXA+1uupf9lir+FRbT0Wht4Hol/Urw6zqH4eVE4offZ334IRdV2EeSNwmhQ9N876PXRwuapuoQa35/8XygmzGgqFOhXWTdHB+vwWsN8B9FP7uvkp763wdyCLaOw/Y/tlYJZQt1/m6ns/JvIG4NNQ9fl1oAuW2ueIKkQaKxaGKsaW1K9GXsS4v1y1FHnsQua2Ffg+BBm4KFYrLR9vBf6sWlQnv7nj2IvltVLyzkHgT82k9UruaMyJ7qHeyjA6n2vX1gACfyGF+hf8Gpg9oMbnbwAAAABJRU5ErkJggg==", alt: "Egeria", style: { height: 28, width: 'auto', borderRadius: 4 } }),
       /*#__PURE__*/React.createElement("span", { style: { fontFamily: 'ui-monospace,monospace', fontSize: 11, color: 'var(--dim)', letterSpacing: 3, textTransform: 'uppercase' } }, "Egeria"),
       /*#__PURE__*/React.createElement("span", { style: { width: 1, height: 14, background: 'var(--border)', display: 'inline-block' } }),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'splash' ? " on" : ""), onClick: () => setSection('splash') }, "⌂ Home"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'type-system' ? " on" : ""), onClick: () => { setSection('type-system'); setView('types'); } }, "Type Explorer"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'glossary' ? " on" : ""), onClick: () => setSection('glossary') }, "Glossary"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'reference-data' ? " on" : ""), onClick: () => setSection('reference-data') }, "Reference Data"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'digital-products' ? " on" : ""), onClick: () => setSection('digital-products') }, "Digital Products"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), onClick: () => setSection('report-specs') }, "Report Specs"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), onClick: () => setSection('valid-values') }, "Valid Values"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), onClick: () => setSection('rest-apis') }, "REST APIs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'type-system' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => { setSection('type-system'); setView('types'); } }, "Type Explorer"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'glossary' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('glossary') }, "Glossary"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'reference-data' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('reference-data') }, "Reference Data"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'digital-products' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('digital-products') }, "Digital Products"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('report-specs') }, "Report Specs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('valid-values') }, "Valid Values"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('rest-apis') }, "REST APIs"),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
       section === 'type-system' && /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
       section === 'type-system' && view === 'types' && /*#__PURE__*/React.createElement("select", {
@@ -3565,7 +3682,7 @@ function App() {
     ),
     // Body \u2014 dispatches to section, then to Type System sub-view
     section === 'splash'
-      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); } })
+      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); }, saveCreds: saveCreds })
       : section === 'report-specs'
       ? React.createElement(ReportSpecView, null)
       : section === 'glossary'
@@ -3595,7 +3712,7 @@ function App() {
             )
           )
         )
-  );
+  ));
 }
 ReactDOM.createRoot(document.getElementById('root')).render(/*#__PURE__*/React.createElement(App, null));</script>
 </body>

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/valid_values_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/valid_values_handler.py
@@ -5,7 +5,9 @@ Copyright Contributors to the ODPi Egeria project.
 Valid Metadata Values Explorer — FastAPI router.
 
 Endpoints:
-  GET /api/valid-values/lookup   → valid values registered for a specific Egeria property name
+  GET /api/valid-values/properties  → property names that have registered valid values
+  GET /api/valid-values/lookup      → valid values for a specific Egeria property name
+  GET /api/valid-values/debug       → raw find_metadata_elements response (for diagnosis)
 """
 
 import os
@@ -17,30 +19,194 @@ from loguru import logger
 
 router = APIRouter(tags=["valid-values"])
 
+_FIND_BODY = {
+    "class": "FindRequestBody",
+    "metadataElementTypeName": "ValidMetadataValue",
+    "searchProperties": {
+        "class": "SearchProperties",
+        "conditions": [{"property": "preferredValue", "operator": "IS_NULL"}],
+        "matchCriteria": "ANY",
+    },
+}
 
-def _get_manager():
+
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
     from pyegeria import ReferenceDataManager
-    url    = os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
-    server = os.environ.get("EGERIA_VIEW_SERVER",   "view-server")
-    user   = os.environ.get("EGERIA_USER",          "erinoverview")
-    pwd    = os.environ.get("EGERIA_USER_PASSWORD",  "secret")
-    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user, user_pwd=pwd)
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = ReferenceDataManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
     mgr.create_egeria_bearer_token()
     return mgr
+
+
+def _get_expert(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import MetadataExpert
+    import pyegeria
+    pyegeria.enable_ssl_check = False
+    pyegeria.disable_ssl_warnings = True
+    url     = url     or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server  = server  or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id = user_id or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = MetadataExpert(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _extract_name_from_element(el) -> str:
+    """Extract the property name from a ValidMetadataValue element.
+
+    Raw find_metadata_elements returns elements where the property name is stored
+    under the key "identifier" (not "propertyName") in elementProperties.
+    """
+    if isinstance(el, str):
+        return el.strip() if el.strip() else ""
+
+    if not isinstance(el, dict):
+        return ""
+
+    # Processed pyegeria format: el["properties"]["propertyName"] or ["identifier"]
+    props = el.get("properties")
+    if isinstance(props, dict):
+        name = props.get("propertyName") or props.get("identifier") or ""
+        if name:
+            return name
+
+    # Raw OpenMetadata format — propertiesAsStrings is the fastest path
+    el_props = el.get("elementProperties")
+    if isinstance(el_props, dict):
+        props_as_str = el_props.get("propertiesAsStrings") or {}
+        name = props_as_str.get("identifier") or ""
+        if name:
+            return name
+        # Fall back to full propertyValueMap
+        prop_map = el_props.get("propertyValueMap") or {}
+        prop_entry = prop_map.get("identifier") or {}
+        if isinstance(prop_entry, dict):
+            name = prop_entry.get("primitiveValue") or ""
+            if name:
+                return name
+
+    return el.get("identifier") or el.get("propertyName") or ""
+
+
+def _names_from_raw(raw) -> set:
+    """Extract unique property names regardless of whether raw is a list or a response dict."""
+    names: set[str] = set()
+
+    if isinstance(raw, str):
+        # NO_ELEMENTS_FOUND sentinel or unexpected string — nothing to parse
+        logger.warning(f"find_metadata_elements returned string: {raw[:200]}")
+        return names
+
+    # Some pyegeria versions return the full response dict rather than just the elements list
+    if isinstance(raw, dict):
+        logger.info(f"find_metadata_elements returned dict with keys: {list(raw.keys())[:10]}")
+        # Try "elementsAsStrings" — simple list of property name strings
+        for item in (raw.get("elementsAsStrings") or []):
+            n = _extract_name_from_element(item)
+            if n:
+                names.add(n)
+        # Also try structured "elements"
+        for item in (raw.get("elements") or []):
+            n = _extract_name_from_element(item)
+            if n:
+                names.add(n)
+        return names
+
+    if not isinstance(raw, list):
+        logger.warning(f"find_metadata_elements returned unexpected type {type(raw).__name__}")
+        return names
+
+    for el in raw:
+        n = _extract_name_from_element(el)
+        if n:
+            names.add(n)
+    return names
+
+
+@router.get("/api/valid-values/debug", summary="Debug: raw find_metadata_elements response structure")
+def debug_valid_value_properties(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    """Return diagnostic information about the raw find_metadata_elements response."""
+    try:
+        mgr = _get_expert(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_metadata_elements(_FIND_BODY)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"find_metadata_elements failed: {exc}")
+
+    first = None
+    if isinstance(raw, list) and raw:
+        first = raw[0]
+    elif isinstance(raw, dict):
+        elems = raw.get("elements") or raw.get("elementsAsStrings") or []
+        first = elems[0] if elems else None
+
+    return JSONResponse({
+        "raw_type":        type(raw).__name__,
+        "raw_length":      len(raw) if isinstance(raw, (list, str)) else None,
+        "raw_keys":        list(raw.keys()) if isinstance(raw, dict) else None,
+        "first_item_type": type(first).__name__ if first is not None else None,
+        "first_item_keys": list(first.keys()) if isinstance(first, dict) else None,
+        "first_item":      first,
+        "names_extracted": sorted(_names_from_raw(raw)),
+    })
+
+
+@router.get("/api/valid-values/properties", summary="List property names that have registered valid values")
+def get_valid_value_properties(
+    url:     Optional[str] = Query(None, description="Egeria platform URL (overrides env)"),
+    server:  Optional[str] = Query(None, description="View server name (overrides env)"),
+    user_id: Optional[str] = Query(None, description="User ID (overrides env)"),
+    user_pwd:Optional[str] = Query(None, description="Password (overrides env)"),
+):
+    """
+    Return the sorted list of property names that have at least one registered valid value.
+    Uses find_metadata_elements to query ValidMetadataValue entries where preferredValue IS_NULL
+    (these are the header registrations that identify a property as having a controlled vocabulary).
+    """
+    try:
+        mgr = _get_expert(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create MetadataExpert")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_metadata_elements(_FIND_BODY)
+    except Exception as exc:
+        logger.exception("find_metadata_elements failed")
+        raise HTTPException(status_code=500, detail=f"Property list retrieval failed: {exc}")
+
+    names = _names_from_raw(raw)
+    logger.info(f"find_metadata_elements: type={type(raw).__name__} → {len(names)} unique property names: {sorted(names)}")
+    return JSONResponse({"properties": sorted(names), "total": len(names)})
 
 
 @router.get("/api/valid-values/lookup", summary="Look up valid values for an Egeria property name")
 def lookup_valid_values(
     property_name: str           = Query(..., description="Egeria property name to look up"),
     type_name:     Optional[str] = Query(None, description="Optional: restrict to a specific Egeria type name"),
+    url:     Optional[str] = Query(None, description="Egeria platform URL (overrides env)"),
+    server:  Optional[str] = Query(None, description="View server name (overrides env)"),
+    user_id: Optional[str] = Query(None, description="User ID (overrides env)"),
+    user_pwd:Optional[str] = Query(None, description="Password (overrides env)"),
 ):
     """
     Return valid metadata values registered for a given Egeria property name.
     Optionally restrict results to a specific open metadata type.
-    These represent the allowed values for properties like contentStatus, operationalStatus, etc.
     """
     try:
-        mgr = _get_manager()
+        mgr = _get_manager(url, server, user_id, user_pwd)
     except Exception as exc:
         logger.exception("Failed to create ReferenceDataManager")
         raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")


### PR DESCRIPTION
  - valid_values_handler: fix _extract_name_from_element() to look for find_metadata_elements response stores the property name under "identifier" via both propertiesAsStrings and propertyValueMap
  - digital_products_handler: remove stray "ye" typo that caused an IndentationError on startup
  - type-explorer.html: add connected state so non-Home tabs are disabled until the user clicks Connect; add /api/valid-values/properties fetch to pre-populate the Valid Values sidebar; default server to qs-view-server across all credential forms and env-var defaults
  - All handlers: change default EGERIA_VIEW_SERVER fallback from "view-server" to "qs-view-server"
  - Docs: document /api/valid-values/properties endpoint, find_metadata_elements raw format quirk (identifier field), and tab data-fetch table update