### PR TITLE
 Add Data Design tab and Solution Architect tab to Egeria Explorer

### DIFF
--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/data_design_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/data_design_handler.py
@@ -1,0 +1,423 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.
+
+Data Design Explorer — FastAPI router.
+
+Type hierarchy (https://egeria-project.org/types/5/):
+  DataSpec        → subtype of Collection (use CollectionManager.find_collections / get_collection)
+  DataStructure   → use DataDesigner.find_data_structures / get_data_structure_by_guid
+  DataField       → use DataDesigner.find_data_fields / get_data_field_by_guid; sub-fields nest inside
+  DataGrain       → subtype of DataValueSpecification (use _search_data_value_specs + typeName filter)
+  DataClass       → subtype of DataValueSpecification (same endpoint as DataGrain, different typeName)
+
+Note: DataValueSpecification defines *values*, not structure.  DataSpec/Structure/Field define structure.
+DataDesigner.find_data_value_specifications is broken (calls self._async_post, absent ≤6.0.12.3);
+  _search_data_value_specs() calls /by-search-string directly as a workaround.
+
+Endpoints:
+  GET /api/data-design/specs              → list all Data Specs (Collection subtype)
+  GET /api/data-design/specs/{guid}       → detail for a Data Spec
+  GET /api/data-design/structures         → list all Data Structures
+  GET /api/data-design/structures/{guid}  → detail for a Data Structure
+  GET /api/data-design/fields             → list all Data Fields
+  GET /api/data-design/fields/{guid}      → detail for a Data Field
+  GET /api/data-design/grains             → list all Data Grains (subtype of DataValueSpecification)
+  GET /api/data-design/grains/{guid}      → detail for a Data Grain
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+router = APIRouter(tags=["data-design"])
+
+
+def _get_designer(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import DataDesigner
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = DataDesigner(server, url, user_id, user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _get_collection_mgr(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import CollectionManager
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+
+def _props(el: dict) -> dict:
+    return el.get("properties") or {}
+
+
+def _header(el: dict) -> dict:
+    return el.get("elementHeader") or {}
+
+
+def _type_name(el: dict) -> str:
+    return (_header(el).get("type") or {}).get("typeName", "") or ""
+
+
+def _base(el: dict) -> dict:
+    p = _props(el)
+    return {
+        "guid":          _header(el).get("guid", ""),
+        "typeName":      _type_name(el),
+        "displayName":   p.get("displayName", "") or p.get("name", "") or "",
+        "qualifiedName": p.get("qualifiedName", "") or "",
+        "description":   p.get("description", "") or "",
+    }
+
+
+def _zip_refs(guids: list, names: list, qnames: list = None) -> list:
+    """Zip parallel guid/name/qname arrays into [{guid, displayName, qualifiedName}]."""
+    qnames = qnames or []
+    return [
+        {
+            "guid":          guids[i],
+            "displayName":   names[i] if i < len(names) else "",
+            "qualifiedName": qnames[i] if i < len(qnames) else "",
+        }
+        for i in range(len(guids or []))
+    ]
+
+
+def _safe_list(raw) -> list:
+    return raw if isinstance(raw, list) else []
+
+
+def _search_data_value_specs(mgr) -> list:
+    """Call /by-search-string directly — find_data_value_specifications uses _async_post (absent ≤6.0.12.3)."""
+    endpoint = (
+        f"{mgr.platform_url}/servers/{mgr.view_server}"
+        f"/api/open-metadata/data-designer/data-value-specifications/by-search-string"
+    )
+    body = {"class": "SearchStringRequestBody", "searchString": "", "startFrom": 0, "pageSize": 500}
+    loop = asyncio.get_event_loop()
+    resp = loop.run_until_complete(mgr._async_make_request("POST", endpoint, body))
+    if hasattr(resp, "json"):
+        return resp.json().get("elements", []) or []
+    if isinstance(resp, dict):
+        return resp.get("elements", []) or []
+    return []
+
+
+def _first(raw) -> dict | None:
+    if isinstance(raw, list):
+        return raw[0] if raw else None
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
+def _rels(mgr, element: dict) -> dict:
+    try:
+        return mgr.get_data_rel_elements_dict(element) or {}
+    except Exception:
+        return {}
+
+
+def _serialize_spec(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "versionIdentifier": p.get("versionIdentifier", "") or "",
+        "namespace":         p.get("namespace", "") or p.get("namespacePath", "") or "",
+        "mermaidGraph":      el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_structure(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "versionIdentifier": p.get("versionIdentifier", "") or "",
+        "namespace":         p.get("namespace", "") or p.get("namespacePath", "") or "",
+        "mermaidGraph":      el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_field(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "dataType":      p.get("dataType", "") or "",
+        "isNullable":    bool(p.get("isNullable", False)),
+        "defaultValue":  p.get("defaultValue", "") or "",
+        "minimumLength": p.get("minimumLength", 0) or 0,
+        "length":        p.get("length", 0) or 0,
+        "mermaidGraph":  el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_grain(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "dataType":    p.get("dataType", "") or "",
+        "mermaidGraph": el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+# ── List endpoints ─────────────────────────────────────────────────────────────
+
+@router.get("/api/data-design/specs", summary="List all Data Specs (Collection subtype)")
+def list_specs(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_collection_mgr(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_collections(search_string="*", metadata_element_type="DataSpec",
+                                    graph_query_depth=0, output_format="JSON")
+        items = sorted(
+            [_serialize_spec(e) for e in _safe_list(raw)],
+            key=lambda x: (x.get("displayName") or "").lower(),
+        )
+        return JSONResponse({"specs": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_specs failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/structures", summary="List all Data Structures")
+def list_structures(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_data_structures(search_string="*", graph_query_depth=0, output_format="JSON")
+        items = sorted([_serialize_structure(e) for e in _safe_list(raw)],
+                       key=lambda x: (x.get("displayName") or "").lower())
+        return JSONResponse({"structures": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_structures failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/fields", summary="List all Data Fields")
+def list_fields(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_data_fields(search_string="*", graph_query_depth=0, output_format="JSON")
+        items = sorted([_serialize_field(e) for e in _safe_list(raw)],
+                       key=lambda x: (x.get("displayName") or "").lower())
+        return JSONResponse({"fields": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_fields failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/grains", summary="List all Data Grains")
+def list_grains(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = _search_data_value_specs(mgr)
+        items = sorted(
+            [_serialize_grain(e) for e in _safe_list(raw) if _type_name(e) == "DataGrain"],
+            key=lambda x: (x.get("displayName") or "").lower(),
+        )
+        return JSONResponse({"grains": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_grains failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# ── Detail endpoints ───────────────────────────────────────────────────────────
+
+@router.get("/api/data-design/specs/{guid}", summary="Detail for a Data Spec")
+def get_spec(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_collection_mgr(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_collection_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Spec {guid!r} not found")
+        node = _serialize_spec(element)
+        # Fetch members separately — get_collection_by_guid doesn't traverse relationships
+        members = []
+        try:
+            members_raw = mgr.get_collection_members(
+                collection_guid=guid,
+                output_format="JSON",
+                page_size=200,
+                body={"class": "ResultsRequestBody", "graphQueryDepth": 0},
+            )
+            for m in _safe_list(members_raw):
+                rh = (m.get("elementHeader") or {})
+                rp = (m.get("properties") or {})
+                g  = rh.get("guid", "")
+                if g:
+                    members.append({
+                        "guid":          g,
+                        "displayName":   rp.get("displayName") or rp.get("name") or "",
+                        "qualifiedName": rp.get("qualifiedName") or "",
+                        "typeName":      (rh.get("type") or {}).get("typeName") or "",
+                    })
+        except Exception:
+            logger.warning(f"get_collection_members failed for DataSpec {guid}")
+        node["containsDataStructures"] = [m for m in members if m.get("typeName") == "DataStructure"]
+        node["members"] = members
+        # Parent collections (e.g. DataDictionaries) — embedded in the element's relationship list
+        parent_refs = []
+        for m in _safe_list(element.get("memberOfCollections")):
+            re = m.get("relatedElement") or m
+            rh = re.get("elementHeader") or {}
+            rp = re.get("properties") or {}
+            g  = rh.get("guid", "")
+            if g:
+                parent_refs.append({
+                    "guid":          g,
+                    "displayName":   rp.get("displayName") or rp.get("name") or "",
+                    "qualifiedName": rp.get("qualifiedName") or "",
+                    "typeName":      (rh.get("type") or {}).get("typeName") or "",
+                })
+        node["memberOfCollections"] = parent_refs
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_spec failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/structures/{guid}", summary="Detail for a Data Structure")
+def get_structure(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_structure_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Structure {guid!r} not found")
+        node = _serialize_structure(element)
+        r = _rels(mgr, element)
+        node["containsDataFields"] = _zip_refs(r.get("member_data_field_guids", []),    r.get("member_data_field_names", []),   r.get("member_data_fields", []))
+        node["memberOfDataSpecs"]  = _zip_refs(r.get("member_of_data_spec_guids", []),  r.get("member_of_data_spec_names", []), r.get("in_data_spec", []))
+        node["memberOfDataDicts"]  = _zip_refs(r.get("member_of_data_dicts_guids", []), r.get("member_of_data_dicts_names", []),r.get("in_data_dictionary", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_structure failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/fields/{guid}", summary="Detail for a Data Field")
+def get_field(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_field_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Field {guid!r} not found")
+        node = _serialize_field(element)
+        r = _rels(mgr, element)
+        node["assignedMeanings"]     = _zip_refs(r.get("assigned_meanings_guids", []),  r.get("assigned_meanings_names", []),  r.get("assigned_meanings_qnames", []))
+        node["partOfDataStructures"] = _zip_refs(r.get("data_structure_guids", []),     r.get("data_structure_names", []),     r.get("in_data_structure", []))
+        node["assignedDataClasses"]  = _zip_refs(r.get("data_class_guids", []),         r.get("data_class_names", []),         r.get("data_class_qnames", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_field failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/grains/{guid}", summary="Detail for a Data Grain")
+def get_grain(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_grain_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Grain {guid!r} not found")
+        node = _serialize_grain(element)
+        r = _rels(mgr, element)
+        node["assignedDataValueSpecs"] = _zip_refs(r.get("assigned_data_value_spec_guids", []), r.get("assigned_data_value_spec_names", []), r.get("assigned_data_value_spec_qnames", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_grain failed")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/digital_products_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/digital_products_handler.py
@@ -27,6 +27,7 @@ _CONTAINER_TYPES = {
     "DigitalProductCatalog", "DigitalProductFamily",
     "Collection", "RootCollection", "FolderCollection",
     "DataSpecCollection", "DataDictionary",
+    "DigitalProduct", "TabularDataSetCollection",
 }
 
 

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/glossary_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/glossary_handler.py
@@ -121,6 +121,31 @@ def _folder_memberships(term: dict) -> list:
     return folders
 
 
+def _extract_classifications(header: dict) -> list:
+    """Return [{typeName, properties}] from elementHeader.classifications, excluding
+    TemplateSubstitute (handled separately via the templateSubstitute sibling key)."""
+    result = []
+    for cls in (header.get("classifications") or []):
+        if not isinstance(cls, dict):
+            continue
+        cls_header = cls.get("classificationHeader") or cls.get("header") or cls
+        type_name  = (cls_header.get("type") or {}).get("typeName") or cls_header.get("classificationName") or ""
+        if not type_name or type_name == "TemplateSubstitute":
+            continue
+        cls_props = cls.get("classificationProperties") or cls.get("properties") or {}
+        flat_props = {}
+        if isinstance(cls_props, dict):
+            prop_map = cls_props.get("propertyValueMap") or {}
+            for k, v in prop_map.items():
+                flat_props[k] = v.get("primitiveValue", "") if isinstance(v, dict) else str(v)
+            if not flat_props:
+                for k, v in cls_props.items():
+                    if k not in ("class", "propertyValueMap", "propertiesAsStrings"):
+                        flat_props[k] = str(v)
+        result.append({"typeName": type_name, "properties": flat_props})
+    return result
+
+
 def _serialize_term(term: dict) -> dict:
     props  = _props(term)
     header = _header(term)
@@ -145,6 +170,7 @@ def _serialize_term(term: dict) -> dict:
         "folders":                _folder_memberships(term),
         "isTemplateSubstitute":   is_template_substitute,
         "isSourcedFromTemplate":  is_sourced_from_template,
+        "classifications":        _extract_classifications(header),
         "relationships":          {label: items for key, label in _TERM_REL_KEYS
                                    if (items := _related_elements(term.get(key)))},
     }

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/pyegeria_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/pyegeria_handler.py
@@ -166,6 +166,10 @@ from mermaid_handler import router as mermaid_router
 app.include_router(mermaid_router)
 from rest_api_handler import router as rest_api_router
 app.include_router(rest_api_router)
+from solution_architect_handler import router as solution_architect_router
+app.include_router(solution_architect_router)
+from data_design_handler import router as data_design_router
+app.include_router(data_design_router)
 # Mount the MCP SSE application
 # FastMCP.sse_app() returns a Starlette app with /sse and /messages routes
 mcp_app = mcp_server.sse_app()

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/solution_architect_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/solution_architect_handler.py
@@ -1,0 +1,304 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.
+
+Solution Architect Explorer — FastAPI router.
+
+Endpoints:
+  GET /api/solution/blueprints                       → list all solution blueprints
+  GET /api/solution/blueprints/{guid}                → full detail for a blueprint
+  GET /api/solution/components                       → list all solution components
+  GET /api/solution/components/{guid}                → full detail for a component
+  GET /api/solution/components/{guid}/implementations → concrete implementations
+"""
+
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+router = APIRouter(tags=["solution-architect"])
+
+
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import SolutionArchitect
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",   "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",    "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",           "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD",  "secret")
+    mgr = SolutionArchitect(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _props(element: dict) -> dict:
+    return element.get("properties") or {}
+
+
+def _header(element: dict) -> dict:
+    return element.get("elementHeader") or {}
+
+
+def _type_name(element: dict) -> str:
+    return (_header(element).get("type") or {}).get("typeName", "") or ""
+
+
+def _rel_list(element: dict, key: str) -> list:
+    """Return the raw relationship list for a given key, normalising None → []."""
+    return element.get(key) or []
+
+
+def _serialize_rel_entries(rel_list: list) -> list:
+    """Convert [{relatedElement: {elementHeader, properties}}, ...] → [{guid, displayName, qualifiedName, typeName}]."""
+    result = []
+    for rel in rel_list:
+        re = rel.get("relatedElement") or {}
+        rh = re.get("elementHeader") or {}
+        rp = re.get("properties") or {}
+        g  = rh.get("guid", "")
+        if g:
+            result.append({
+                "guid":          g,
+                "displayName":   rp.get("displayName") or rp.get("name") or "",
+                "qualifiedName": rp.get("qualifiedName") or "",
+                "typeName":      (rh.get("type") or {}).get("typeName") or "",
+            })
+    return result
+
+
+def _serialize_blueprint_summary(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":              header.get("guid", ""),
+        "displayName":       props.get("displayName") or props.get("name") or "",
+        "qualifiedName":     props.get("qualifiedName") or "",
+        "description":       props.get("description") or "",
+        "versionIdentifier": props.get("versionIdentifier") or "",
+        "lifecycleStatus":   props.get("lifecycleStatus") or "",
+        "userDefinedStatus": props.get("userDefinedStatus") or "",
+        "status":            header.get("status") or "",
+        "typeName":          _type_name(element),
+    }
+
+
+def _serialize_blueprint_detail(element: dict) -> dict:
+    detail = _serialize_blueprint_summary(element)
+    detail["mermaidGraph"] = element.get("mermaidGraph") or ""
+    # Components linked to this blueprint (nestedComponents or collectionMembers key varies by depth)
+    components = _serialize_rel_entries(_rel_list(element, "nestedComponents"))
+    if not components:
+        components = _serialize_rel_entries(_rel_list(element, "solutionComponents"))
+    if not components:
+        # collectionMembers includes component-type entries at graph_query_depth >= 1
+        components = _serialize_rel_entries(_rel_list(element, "collectionMembers"))
+    detail["components"] = components
+    return detail
+
+
+def _serialize_component_summary(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":              header.get("guid", ""),
+        "displayName":       props.get("displayName") or props.get("name") or "",
+        "qualifiedName":     props.get("qualifiedName") or "",
+        "description":       props.get("description") or "",
+        "componentType":     props.get("componentType") or "",
+        "versionIdentifier": props.get("versionIdentifier") or "",
+        "lifecycleStatus":   props.get("lifecycleStatus") or "",
+        "userDefinedStatus": props.get("userDefinedStatus") or "",
+        "status":            header.get("status") or "",
+        "typeName":          _type_name(element),
+    }
+
+
+def _serialize_component_detail(element: dict) -> dict:
+    detail = _serialize_component_summary(element)
+    detail["mermaidGraph"] = element.get("mermaidGraph") or ""
+
+    # Parent blueprints come from memberOfCollections filtered by SolutionBlueprint typeName
+    raw_collections = _rel_list(element, "memberOfCollections")
+    blueprints = _serialize_rel_entries([
+        m for m in raw_collections
+        if (m.get("relatedElement") or {}).get("elementHeader", {}).get("type", {}).get("typeName") == "SolutionBlueprint"
+    ])
+
+    detail["parentComponents"]  = _serialize_rel_entries(_rel_list(element, "usedInSolutionComponents"))
+    detail["subComponents"]     = _serialize_rel_entries(_rel_list(element, "nestedSolutionComponents"))
+    detail["blueprints"]        = blueprints
+    detail["actors"]            = _serialize_rel_entries(_rel_list(element, "actors"))
+    detail["wiredTo"]           = _serialize_rel_entries(_rel_list(element, "wiredTo"))
+    detail["wiredFrom"]         = _serialize_rel_entries(_rel_list(element, "wiredFrom"))
+    return detail
+
+
+def _serialize_implementation(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":          header.get("guid", ""),
+        "displayName":   props.get("displayName") or props.get("name") or "",
+        "qualifiedName": props.get("qualifiedName") or "",
+        "description":   props.get("description") or "",
+        "typeName":      _type_name(element),
+        "status":        header.get("status") or "",
+    }
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────────
+
+@router.get("/api/solution/blueprints", summary="List all solution blueprints")
+def list_blueprints(
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_solution_blueprints(
+            search_string="*",
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("find_solution_blueprints failed")
+        raise HTTPException(status_code=500, detail=f"Blueprint retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    blueprints = [_serialize_blueprint_summary(b) for b in raw]
+    blueprints.sort(key=lambda b: (b.get("displayName") or "").lower())
+    return JSONResponse({"blueprints": blueprints, "total": len(blueprints)})
+
+
+@router.get("/api/solution/blueprints/{guid}", summary="Get a single solution blueprint by GUID")
+def get_blueprint(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_blueprint_by_guid(guid, output_format="JSON")
+    except Exception as exc:
+        logger.exception("get_solution_blueprint_by_guid failed")
+        raise HTTPException(status_code=500, detail=f"Blueprint retrieval failed: {exc}")
+
+    if not raw or isinstance(raw, str):
+        raise HTTPException(status_code=404, detail=f"Blueprint {guid!r} not found")
+
+    return JSONResponse(_serialize_blueprint_detail(raw))
+
+
+@router.get("/api/solution/components", summary="List all solution components")
+def list_components(
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_solution_components(
+            search_string="*",
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("find_solution_components failed")
+        raise HTTPException(status_code=500, detail=f"Component retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    components = [_serialize_component_summary(c) for c in raw]
+    components.sort(key=lambda c: (c.get("displayName") or "").lower())
+    return JSONResponse({"components": components, "total": len(components)})
+
+
+@router.get("/api/solution/components/{guid}", summary="Get a single solution component by GUID")
+def get_component(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_component_by_guid(guid, output_format="JSON")
+    except Exception as exc:
+        logger.exception("get_solution_component_by_guid failed")
+        raise HTTPException(status_code=500, detail=f"Component retrieval failed: {exc}")
+
+    if not raw or isinstance(raw, str):
+        raise HTTPException(status_code=404, detail=f"Component {guid!r} not found")
+
+    return JSONResponse(_serialize_component_detail(raw))
+
+
+@router.get("/api/solution/components/{guid}/implementations", summary="Get implementations of a solution component")
+def get_component_implementations(
+    guid: str,
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_component_implementations(
+            solution_component_guid=guid,
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("get_solution_component_implementations failed")
+        raise HTTPException(status_code=500, detail=f"Implementations retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    implementations = [_serialize_implementation(i) for i in raw]
+    return JSONResponse({"implementations": implementations, "total": len(implementations), "component": guid})

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/type-explorer.html
@@ -1010,7 +1010,8 @@ function TypeDetail({
   name,
   entities,
   relationships,
-  onSelect
+  onSelect,
+  onNavigateProp
 }) {
   const [tab, setTab] = useState('props');
   const [showInherited, setShowInherited] = useState(true);
@@ -1153,12 +1154,17 @@ function TypeDetail({
     return /*#__PURE__*/React.createElement("tr", {
       key: i,
       className: [isOwn ? 'own-row' : '', p.deprecated ? 'depr-row' : ''].filter(Boolean).join(' ')
-    }, /*#__PURE__*/React.createElement("td", null, /*#__PURE__*/React.createElement("span", {
-      className: p.deprecated ? "mono depr" : "mono",
-      style: {
-        color: isOwn ? '#93c5fd' : 'var(--text)'
-      }
-    }, p.name), p.req && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
+    }, /*#__PURE__*/React.createElement("td", null, onNavigateProp
+      ? /*#__PURE__*/React.createElement("button", {
+          className: p.deprecated ? "mono depr" : "mono",
+          onClick: function() { onNavigateProp(p.name); },
+          title: "Look up valid values for " + p.name,
+          style: { background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: isOwn ? '#93c5fd' : 'var(--accent)', textDecoration: 'underline dotted', fontFamily: 'inherit', fontSize: 'inherit' }
+        }, p.name)
+      : /*#__PURE__*/React.createElement("span", {
+          className: p.deprecated ? "mono depr" : "mono",
+          style: { color: isOwn ? '#93c5fd' : 'var(--text)' }
+        }, p.name), p.req && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
       kind: "req"
     }, "req")), isOwn && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
       kind: "own"
@@ -1928,17 +1934,30 @@ function ReportSpecView() {
         )
       ),
       React.createElement('div', { className: 'tree-scroll' },
-        filtered.map(s => React.createElement('div', {
-          key: s.name,
-          className: 'tree-item' + (selected === s.name ? ' sel' : ''),
-          onClick: () => { setHistory([]); setSelected(s.name); }
-        },
-          React.createElement('span', { className: 'type-name' }, s.name),
-          s.family && React.createElement('span', {
-            className: 'badge',
-            style: { background: 'rgba(100,116,139,.1)', color: '#94a3b8', border: '0.5px solid rgba(100,116,139,.3)', fontSize: 9 }
-          }, s.family)
-        ))
+        (function() {
+          var byFamily = {};
+          filtered.forEach(function(s) {
+            var fam = s.family || 'General';
+            if (!byFamily[fam]) byFamily[fam] = [];
+            byFamily[fam].push(s);
+          });
+          var famNames = Object.keys(byFamily).sort();
+          var rows = [];
+          famNames.forEach(function(fam) {
+            rows.push(React.createElement('div', {
+              key: 'hdr-' + fam,
+              style: { padding: '6px 12px 3px', fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--dim)', borderTop: '1px solid rgba(26,45,72,.4)', marginTop: rows.length ? 4 : 0 }
+            }, fam + ' (' + byFamily[fam].length + ')'));
+            byFamily[fam].forEach(function(s) {
+              rows.push(React.createElement('div', {
+                key: s.name,
+                className: 'tree-item' + (selected === s.name ? ' sel' : ''),
+                onClick: function() { setHistory([]); setSelected(s.name); }
+              }, React.createElement('span', { className: 'type-name' }, s.name)));
+            });
+          });
+          return rows;
+        })()
       )
     ),
     React.createElement(ResizeDivider, { onMouseDown: onDivDown }),
@@ -2045,9 +2064,18 @@ function GlossaryTermDetail({ term, onNavigateToTerm }) {
       !term.isTemplateSubstitute && term.isSourcedFromTemplate && React.createElement("span", { className: "badge", style: { background: 'rgba(245,158,11,.08)', color: '#fbbf24', border: '0.5px solid rgba(245,158,11,.25)', fontSize: 11 } }, "From Template")
     ),
     React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 8 } }, term.guid),
-    folderList.length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 } },
+    folderList.length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8 } },
       React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, "Folders:"),
       folderList.map(f => React.createElement("span", { key: f.guid, className: "badge", style: { fontSize: 11, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, f.displayName || f.guid))
+    ),
+    (term.classifications || []).length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 } },
+      React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, "Classifications:"),
+      term.classifications.map(function(c) {
+        var tip = Object.keys(c.properties || {}).length > 0 ? JSON.stringify(c.properties, null, 2) : '';
+        return React.createElement("span", { key: c.typeName, className: "badge", title: tip,
+          style: { fontSize: 11, background: 'rgba(168,85,247,.1)', color: '#c084fc', border: '0.5px solid rgba(168,85,247,.25)' }
+        }, c.typeName);
+      })
     ),
     term.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(term.description)),
     React.createElement(MermaidSection, { guid: term.guid }),
@@ -2265,11 +2293,12 @@ function GlossaryView({ navGuid }) {
   const middleLoading = isSearchMode ? searchState === 'loading' : scopeState === 'loading';
   const middleError   = isSearchMode ? searchError : scopeError;
   const middleCounts  = isSearchMode
-    ? ('Terms (' + filteredSearchTerms.length + (filteredSearchTerms.length !== searchTerms.length ? '/' + searchTerms.length : '') + ')')
+    ? ('Terms (' + filteredSearchTerms.length + (filteredSearchTerms.length !== searchTerms.length ? '/' + searchTerms.length : '') + ')' + (searchTerms.length >= 200 ? ' ⚠ first 200 shown' : ''))
     : (scopeState === 'loading' ? 'Loading…' : (
         folders.length + ' folder' + (folders.length !== 1 ? 's' : '') +
         ', ' + filteredTerms.length + (filteredTerms.length !== terms.length - templateTermCount ? '/' + (terms.length - templateTermCount) : '') + ' term' + ((terms.length - templateTermCount) !== 1 ? 's' : '') +
-        (!showTemplates && templateTermCount > 0 ? ' · ' + templateTermCount + ' template' + (templateTermCount !== 1 ? 's' : '') + ' hidden' : '')
+        (!showTemplates && templateTermCount > 0 ? ' · ' + templateTermCount + ' template' + (templateTermCount !== 1 ? 's' : '') + ' hidden' : '') +
+        (terms.length >= 500 ? ' ⚠ first 500 shown' : '')
       ));
 
   return React.createElement("div", { className: "body" },
@@ -2558,7 +2587,7 @@ function ReferenceDataView() {
 
 // ── Digital Products Explorer ─────────────────────────────────────────────────
 
-function DigitalProductDetail({ product, onNavigateToGlossary }) {
+function DigitalProductDetail({ product, onNavigateToGlossary, onNavigateToDataSpec }) {
   if (!product) return null;
   const fields = [
     ['Qualified Name',   product.qualifiedName],
@@ -2578,6 +2607,45 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
     product.typeName === 'GlossaryTerm' || product.typeName === 'Glossary' || product.typeName === 'GlossaryCategory'
   );
 
+  // Group children by typeName for the members section
+  const children = product.children || [];
+  const memberGroups = {};
+  children.forEach(function(child) {
+    const tn = child.typeName || 'Unknown';
+    if (!memberGroups[tn]) memberGroups[tn] = [];
+    memberGroups[tn].push(child);
+  });
+  const memberTypeNames = Object.keys(memberGroups).sort();
+
+  // Colour coding for known member types
+  function memberBadgeStyle(tn) {
+    if (tn === 'DataSpecCollection') return { background: 'rgba(74,222,128,.1)', color: '#86efac', border: '0.5px solid rgba(74,222,128,.25)' };
+    if (tn.startsWith('TabularDataSet')) return { background: 'rgba(251,191,36,.1)', color: '#fcd34d', border: '0.5px solid rgba(251,191,36,.25)' };
+    return { background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' };
+  }
+
+  function renderMemberGroup(tn, members) {
+    const isDataSpec = tn === 'DataSpecCollection';
+    const isTabular  = tn.startsWith('TabularDataSet');
+    return React.createElement("div", { key: tn, style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 12, color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 6 } },
+        tn + " (" + members.length + ")"
+      ),
+      members.map(function(m) {
+        return React.createElement("div", { key: m.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '5px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, m.displayName || m.qualifiedName || m.guid),
+          React.createElement("span", { className: "badge", style: Object.assign({ fontSize: 9 }, memberBadgeStyle(m.typeName || tn)) }, m.typeName || tn),
+          isDataSpec && React.createElement("button", {
+            onClick: function() { onNavigateToDataSpec && onNavigateToDataSpec(m.guid); },
+            disabled: !onNavigateToDataSpec,
+            title: onNavigateToDataSpec ? 'View in Data Design tab' : 'Data Design tab coming in Phase 3',
+            style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(74,222,128,.4)', background: onNavigateToDataSpec ? 'rgba(74,222,128,.1)' : 'transparent', color: onNavigateToDataSpec ? '#86efac' : 'var(--dim)', cursor: onNavigateToDataSpec ? 'pointer' : 'not-allowed', fontSize: 11, opacity: onNavigateToDataSpec ? 1 : 0.5 }
+          }, "View Data Spec →")
+        );
+      })
+    );
+  }
+
   return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
     React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
       React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, product.displayName || product.qualifiedName),
@@ -2590,7 +2658,7 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
     React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, product.guid),
     product.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(product.description)),
     React.createElement(MermaidSection, { guid: product.guid }),
-    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13 } },
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
       React.createElement("tbody", null,
         fields.map(function([label, value]) {
           return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
@@ -2599,6 +2667,10 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
           );
         })
       )
+    ),
+    memberTypeNames.length > 0 && React.createElement("div", null,
+      React.createElement("div", { style: { fontWeight: 700, fontSize: 13, marginBottom: 12, paddingBottom: 6, borderBottom: '1px solid var(--border)', color: 'var(--accent)' } }, "Members"),
+      memberTypeNames.map(function(tn) { return renderMemberGroup(tn, memberGroups[tn]); })
     )
   );
 }
@@ -2641,7 +2713,7 @@ function DigitalTreeNode({ node, depth, selectedGuid, onSelect, expanded, toggle
   );
 }
 
-function DigitalProductsView({ onNavigateToGlossary }) {
+function DigitalProductsView({ onNavigateToGlossary, onNavigateToDataSpec }) {
   const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [treeW, onTreeDivDown] = useResizable(300);
@@ -2767,7 +2839,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
     // Node detail (right)
     React.createElement("div", { className: "main" },
       selectedNodeObj
-        ? React.createElement(DigitalProductDetail, { product: selectedNodeObj, onNavigateToGlossary: onNavigateToGlossary })
+        ? React.createElement(DigitalProductDetail, { product: selectedNodeObj, onNavigateToGlossary: onNavigateToGlossary, onNavigateToDataSpec: onNavigateToDataSpec })
         : React.createElement("div", { className: "center" },
             React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a node to view details")
           )
@@ -3003,7 +3075,7 @@ function ValidValueEntry({ val }) {
   );
 }
 
-function ValidValuesView() {
+function ValidValuesView({ navProp }) {
   const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   // Left: property name input + dynamic presets from Egeria
@@ -3055,6 +3127,11 @@ function ValidValuesView() {
       })
       .catch(err => { setError(err.message); setLoadState('error'); });
   }, [creds]);
+
+  // Auto-lookup when navigated from another section (e.g. Type System property click)
+  useEffect(() => {
+    if (navProp) { setPropertyName(navProp); lookup(navProp); }
+  }, [navProp]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   return React.createElement("div", { className: "body" },
     // Left: property selector
@@ -3540,6 +3617,468 @@ const AREA_NAMES = {
   "6": "Area 6 — Data Stores",
   "7": "Area 7 — Lineage"
 };
+// ── Solution Architect ─────────────────────────────────────────────────────────
+
+// ── Data Design tab ──────────────────────────────────────────────────────────
+function DataDesignView({ navSpecGuid, onNavigateToGlossary }) {
+  const creds = React.useContext(CredContext);
+  const [subNav, setSubNav] = React.useState('specs');
+  const [listStates, setListStates] = React.useState({
+    specs:      { st: 'idle', items: [] },
+    structures: { st: 'idle', items: [] },
+    fields:     { st: 'idle', items: [] },
+    grains:     { st: 'idle', items: [] },
+  });
+  const [selGuid, setSelGuid] = React.useState(null);
+  const [detail, setDetail] = React.useState(null);
+  const [detailSt, setDetailSt] = React.useState('idle');
+  const [sideW, onSideDivDown] = useResizable(260);
+
+  function updateList(nav, patch) {
+    setListStates(function(prev) { return Object.assign({}, prev, { [nav]: Object.assign({}, prev[nav], patch) }); });
+  }
+
+  function loadItems(nav) {
+    updateList(nav, { st: 'loading' });
+    fetch(credAppend('/api/data-design/' + nav, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(d) { updateList(nav, { st: 'ready', items: d[nav] || [] }); })
+      .catch(function(err) { updateList(nav, { st: 'error', items: [], error: err.message }); });
+  }
+
+  function loadDetail(nav, guid) {
+    setSelGuid(guid);
+    setDetailSt('loading');
+    setDetail(null);
+    fetch(credAppend('/api/data-design/' + nav + '/' + guid, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(d) { setDetail(d); setDetailSt('ready'); })
+      .catch(function() { setDetailSt('error'); });
+  }
+
+  function switchAndSelect(nav, guid) {
+    setSubNav(nav);
+    if (listStates[nav].st === 'idle') loadItems(nav);
+    loadDetail(nav, guid);
+  }
+
+  React.useEffect(function() { loadItems('specs'); }, []);
+
+  React.useEffect(function() {
+    if (listStates[subNav].st === 'idle') loadItems(subNav);
+  }, [subNav]);
+
+  React.useEffect(function() {
+    if (navSpecGuid) switchAndSelect('specs', navSpecGuid);
+  }, [navSpecGuid]);
+
+  const SUB_NAVS = [
+    { key: 'specs',      label: 'Data Specs',      color: '#7dd3fc' },
+    { key: 'structures', label: 'Data Structures',  color: '#a5b4fc' },
+    { key: 'fields',     label: 'Data Fields',      color: '#5eead4' },
+    { key: 'grains',     label: 'Data Grains',      color: '#fda4af' },
+  ];
+
+  function relSection(title, items, onClick, btnColor) {
+    if (!items || items.length === 0) return null;
+    return React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 6, color: 'var(--accent)' } }, title + " (" + items.length + ")"),
+      items.map(function(item, i) {
+        return React.createElement("div", { key: item.guid || i, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, item.displayName || item.qualifiedName),
+          onClick && React.createElement("button", {
+            onClick: function() { onClick(item.guid); },
+            style: { flexShrink: 0, padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(125,211,252,.4)', background: 'rgba(125,211,252,.1)', color: btnColor || '#7dd3fc', cursor: 'pointer', fontSize: 11 }
+          }, "View →")
+        );
+      })
+    );
+  }
+
+  function renderDetail() {
+    if (detailSt === 'loading') return React.createElement("div", { className: "center" }, React.createElement("div", { className: "spinner" }));
+    if (detailSt === 'error') return React.createElement("div", { className: "center" }, React.createElement("span", { style: { color: '#f87171' } }, "Failed to load"));
+    if (!detail) return React.createElement("div", { className: "center" },
+      React.createElement("span", { style: { color: 'var(--dim)', fontSize: 13 } }, "Select an item from the list")
+    );
+
+    const colorMap = { specs: '#7dd3fc', structures: '#a5b4fc', fields: '#5eead4', grains: '#fda4af' };
+    const color = colorMap[subNav] || '#7dd3fc';
+
+    const fields = [
+      ['Qualified Name', detail.qualifiedName],
+      ['Version',        detail.versionIdentifier],
+      ['Namespace',      detail.namespace],
+      ['Data Type',      detail.dataType],
+      subNav === 'fields' ? ['Is Nullable',   detail.isNullable != null ? String(detail.isNullable) : ''] : null,
+      subNav === 'fields' ? ['Default Value', detail.defaultValue] : null,
+      subNav === 'fields' ? ['Min Length',    detail.minimumLength ? String(detail.minimumLength) : ''] : null,
+      subNav === 'fields' ? ['Length',        detail.length ? String(detail.length) : ''] : null,
+    ].filter(function(r) { return r && r[1] && String(r[1]).trim(); });
+
+    return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+      React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+        React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, detail.displayName || detail.qualifiedName),
+        React.createElement("span", { className: "badge", style: { background: 'rgba(125,211,252,.1)', color: color, border: '0.5px solid rgba(125,211,252,.3)' } }, detail.typeName || '')
+      ),
+      React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, detail.guid),
+      detail.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(detail.description)),
+      React.createElement(MermaidSection, { guid: detail.guid }),
+      fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+        React.createElement("tbody", null,
+          fields.map(function(row) {
+            return React.createElement("tr", { key: row[0], style: { borderTop: '1px solid var(--border)' } },
+              React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, row[0]),
+              React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(row[1])))
+            );
+          })
+        )
+      ),
+      subNav === 'specs'      && relSection("Contains Data Structures",   detail.containsDataStructures, function(g) { switchAndSelect('structures', g); }, '#a5b4fc'),
+      subNav === 'specs'      && relSection("Other Members",             (detail.members||[]).filter(function(m){ return m.typeName !== 'DataStructure'; }), null, '#e2e8f0'),
+      subNav === 'specs'      && relSection("Member of Collections",     detail.memberOfCollections,   null, '#7dd3fc'),
+      subNav === 'structures' && relSection("Contains Data Fields",      detail.containsDataFields,    function(g) { switchAndSelect('fields', g); }, '#5eead4'),
+      subNav === 'structures' && relSection("Member of Data Specs",      detail.memberOfDataSpecs,     null, '#7dd3fc'),
+      subNav === 'structures' && relSection("Member of Data Dicts",      detail.memberOfDataDicts,     null, '#7dd3fc'),
+      subNav === 'fields'     && relSection("Assigned Glossary Terms",   detail.assignedMeanings,      function(g) { onNavigateToGlossary && onNavigateToGlossary(g); }, '#86efac'),
+      subNav === 'fields'     && relSection("Part of Data Structures",   detail.partOfDataStructures,  function(g) { switchAndSelect('structures', g); }, '#a5b4fc'),
+      subNav === 'fields'     && relSection("Assigned Data Classes",     detail.assignedDataClasses,   null, '#7dd3fc'),
+      subNav === 'grains'     && relSection("Assigned Data Value Specs", detail.assignedDataValueSpecs, function(g) { switchAndSelect('specs', g); }, '#7dd3fc')
+    );
+  }
+
+  const curList = listStates[subNav];
+
+  return React.createElement("div", { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', gap: 4, padding: '8px 12px', borderBottom: '1px solid var(--border)', background: 'var(--surface)', flexShrink: 0 } },
+      SUB_NAVS.map(function(n) {
+        const st = listStates[n.key];
+        const active = subNav === n.key;
+        return React.createElement("button", {
+          key: n.key,
+          onClick: function() {
+            if (subNav === n.key) return;
+            setSubNav(n.key);
+            setSelGuid(null);
+            setDetail(null);
+            setDetailSt('idle');
+          },
+          style: { padding: '5px 14px', borderRadius: 5, border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: active ? 700 : 400, background: active ? 'rgba(125,211,252,.15)' : 'transparent', color: active ? n.color : 'var(--dim)', transition: 'all .15s' }
+        },
+          n.label,
+          st.st === 'ready' && st.items.length > 0 && React.createElement("span", { style: { marginLeft: 5, fontSize: 10, background: 'rgba(125,211,252,.1)', color: n.color, borderRadius: 10, padding: '1px 5px' } }, st.items.length)
+        );
+      })
+    ),
+    React.createElement("div", { style: { display: 'flex', flex: 1, overflow: 'hidden' } },
+      React.createElement("div", { style: { width: sideW, borderRight: '1px solid var(--border)', overflowY: 'auto', flexShrink: 0 } },
+        curList.st === 'loading'
+          ? React.createElement("div", { className: "center", style: { padding: 20 } }, React.createElement("div", { className: "spinner" }))
+          : curList.st === 'error'
+          ? React.createElement("div", { style: { padding: 12, color: '#f87171', fontSize: 13 } }, "Error: " + (curList.error || ''))
+          : curList.items.length === 0 && curList.st === 'ready'
+          ? React.createElement("div", { style: { padding: 12, color: 'var(--dim)', fontSize: 13 } }, "None found")
+          : curList.items.map(function(item) {
+              const active = item.guid === selGuid;
+              return React.createElement("div", {
+                key: item.guid,
+                onClick: function() { loadDetail(subNav, item.guid); },
+                style: { padding: '7px 12px', cursor: 'pointer', borderBottom: '1px solid var(--border)', background: active ? 'var(--hover)' : 'transparent', color: active ? 'var(--fg)' : 'var(--muted)' }
+              },
+                React.createElement("div", { style: { fontSize: 13, fontWeight: active ? 600 : 400, lineHeight: 1.3 } }, item.displayName || item.qualifiedName || item.guid),
+                item.description && React.createElement("div", { style: { fontSize: 11, color: 'var(--dim)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, item.description)
+              );
+            })
+      ),
+      React.createElement(ResizeDivider, { onMouseDown: onSideDivDown }),
+      React.createElement("div", { style: { flex: 1, overflow: 'hidden' } }, renderDetail())
+    )
+  );
+}
+
+function SolutionBlueprintDetail({ blueprint, onNavigateToComponent }) {
+  const [implState, setImplState] = useState('idle');
+  if (!blueprint) return null;
+  const fields = [
+    ['Qualified Name',     blueprint.qualifiedName],
+    ['Version',           blueprint.versionIdentifier],
+    ['Lifecycle Status',  blueprint.lifecycleStatus],
+    ['User Defined Status', blueprint.userDefinedStatus],
+    ['Status',            blueprint.status],
+  ].filter(([, v]) => v && String(v).trim());
+
+  return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+      React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, blueprint.displayName || blueprint.qualifiedName),
+      React.createElement("span", { className: "badge", style: { background: 'rgba(167,139,250,.1)', color: '#c4b5fd', border: '0.5px solid rgba(167,139,250,.3)' } }, blueprint.typeName || 'SolutionBlueprint')
+    ),
+    React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, blueprint.guid),
+    blueprint.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(blueprint.description)),
+    React.createElement(MermaidSection, { guid: blueprint.guid }),
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+      React.createElement("tbody", null,
+        fields.map(function([label, value]) {
+          return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
+            React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, label),
+            React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(value)))
+          );
+        })
+      )
+    ),
+    blueprint.components && blueprint.components.length > 0 && React.createElement("div", null,
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 8, color: 'var(--accent)' } }, "Solution Components (" + blueprint.components.length + ")"),
+      React.createElement("div", { style: { display: 'flex', flexDirection: 'column', gap: 4 } },
+        blueprint.components.map(function(c) {
+          return React.createElement("div", { key: c.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+            React.createElement("span", { style: { flex: 1 } }, c.displayName || c.qualifiedName),
+            c.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, c.typeName),
+            onNavigateToComponent && React.createElement("button", {
+              onClick: function() { onNavigateToComponent(c.guid); },
+              style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(167,139,250,.4)', background: 'rgba(167,139,250,.1)', color: '#c4b5fd', cursor: 'pointer', fontSize: 11 }
+            }, "View →")
+          );
+        })
+      )
+    )
+  );
+}
+
+function SolutionComponentDetail({ component, onNavigateToBlueprint, onNavigateToComponent }) {
+  const creds = React.useContext(CredContext);
+  const [implState, setImplState] = useState('idle');
+  const [implementations, setImplementations] = useState([]);
+
+  function loadImplementations() {
+    if (implState !== 'idle') return;
+    setImplState('loading');
+    fetch(credAppend('/api/solution/components/' + component.guid + '/implementations', creds))
+      .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(data => { setImplementations(data.implementations || []); setImplState('done'); })
+      .catch(() => setImplState('error'));
+  }
+
+  if (!component) return null;
+  const fields = [
+    ['Qualified Name',      component.qualifiedName],
+    ['Component Type',      component.componentType],
+    ['Version',            component.versionIdentifier],
+    ['Lifecycle Status',   component.lifecycleStatus],
+    ['User Defined Status', component.userDefinedStatus],
+    ['Status',             component.status],
+  ].filter(([, v]) => v && String(v).trim());
+
+  function relSection(title, items, onClick) {
+    if (!items || items.length === 0) return null;
+    return React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 6, color: 'var(--accent)' } }, title + " (" + items.length + ")"),
+      items.map(function(item) {
+        return React.createElement("div", { key: item.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, item.displayName || item.qualifiedName),
+          item.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, item.typeName),
+          onClick && React.createElement("button", {
+            onClick: function() { onClick(item.guid); },
+            style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(167,139,250,.4)', background: 'rgba(167,139,250,.1)', color: '#c4b5fd', cursor: 'pointer', fontSize: 11 }
+          }, "View →")
+        );
+      })
+    );
+  }
+
+  return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+      React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, component.displayName || component.qualifiedName),
+      React.createElement("span", { className: "badge", style: { background: 'rgba(96,165,250,.1)', color: '#93c5fd', border: '0.5px solid rgba(96,165,250,.3)' } }, component.typeName || 'SolutionComponent')
+    ),
+    React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, component.guid),
+    component.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(component.description)),
+    React.createElement(MermaidSection, { guid: component.guid }),
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+      React.createElement("tbody", null,
+        fields.map(function([label, value]) {
+          return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
+            React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, label),
+            React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(value)))
+          );
+        })
+      )
+    ),
+    relSection("Parent Blueprints", component.blueprints, onNavigateToBlueprint),
+    relSection("Parent Components", component.parentComponents, onNavigateToComponent),
+    relSection("Sub-components", component.subComponents, onNavigateToComponent),
+    relSection("Actors", component.actors, null),
+    relSection("Wired To", component.wiredTo, onNavigateToComponent),
+    relSection("Wired From", component.wiredFrom, onNavigateToComponent),
+    React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 } },
+        React.createElement("div", { style: { fontWeight: 600, fontSize: 13, color: 'var(--accent)' } }, "Implementations"),
+        implState === 'idle' && React.createElement("button", {
+          onClick: loadImplementations,
+          style: { padding: '2px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--hover)', cursor: 'pointer', fontSize: 11 }
+        }, "Load"),
+        implState === 'loading' && React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)' } }, "Loading…"),
+        implState === 'error' && React.createElement("span", { style: { fontSize: 11, color: '#f87171' } }, "Failed to load"),
+      ),
+      implState === 'done' && implementations.length === 0 && React.createElement("div", { style: { fontSize: 13, color: 'var(--dim)' } }, "No implementations found"),
+      implState === 'done' && implementations.map(function(impl) {
+        return React.createElement("div", { key: impl.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, impl.displayName || impl.qualifiedName),
+          impl.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(74,222,128,.1)', color: '#86efac', border: '0.5px solid rgba(74,222,128,.25)' } }, impl.typeName)
+        );
+      })
+    )
+  );
+}
+
+function SolutionArchitectView() {
+  const creds = React.useContext(CredContext);
+  const [sideW, onDivDown] = useResizable(260);
+  const [subNav, setSubNav] = useState('blueprints'); // 'blueprints' | 'components'
+
+  const [bpState, setBpState]   = useState('loading');
+  const [bpAttempt, setBpAttempt] = useState(0);
+  const [blueprints, setBlueprints] = useState([]);
+  const [bpError, setBpError]   = useState('');
+  const [selectedBp, setSelectedBp] = useState(null);
+  const [bpDetail, setBpDetail] = useState(null);
+  const [bpDetailState, setBpDetailState] = useState('idle');
+
+  const [compState, setCompState]   = useState('idle');
+  const [compAttempt, setCompAttempt] = useState(0);
+  const [components, setComponents] = useState([]);
+  const [compError, setCompError]   = useState('');
+  const [selectedComp, setSelectedComp] = useState(null);
+  const [compDetail, setCompDetail] = useState(null);
+  const [compDetailState, setCompDetailState] = useState('idle');
+
+  // Load blueprints
+  useEffect(function() {
+    setBpState('loading'); setBpError('');
+    fetch(credAppend('/api/solution/blueprints', creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setBlueprints(data.blueprints || []); setBpState('ready'); })
+      .catch(function(e) { setBpError(e.message); setBpState('error'); });
+  }, [bpAttempt]);
+
+  // Load components when sub-nav switches to components (lazy)
+  useEffect(function() {
+    if (subNav !== 'components' || compState !== 'idle') return;
+    setCompState('loading'); setCompError('');
+    fetch(credAppend('/api/solution/components', creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setComponents(data.components || []); setCompState('ready'); })
+      .catch(function(e) { setCompError(e.message); setCompState('error'); });
+  }, [subNav, compAttempt]);
+
+  // Fetch blueprint detail when selection changes
+  useEffect(function() {
+    if (!selectedBp) { setBpDetail(null); return; }
+    setBpDetailState('loading');
+    fetch(credAppend('/api/solution/blueprints/' + selectedBp, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setBpDetail(data); setBpDetailState('ready'); })
+      .catch(function() { setBpDetailState('error'); });
+  }, [selectedBp]);
+
+  // Fetch component detail when selection changes
+  useEffect(function() {
+    if (!selectedComp) { setCompDetail(null); return; }
+    setCompDetailState('loading');
+    fetch(credAppend('/api/solution/components/' + selectedComp, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setCompDetail(data); setCompDetailState('ready'); })
+      .catch(function() { setCompDetailState('error'); });
+  }, [selectedComp]);
+
+  function onNavigateToBlueprint(guid) {
+    setSubNav('blueprints');
+    setSelectedBp(guid);
+  }
+
+  function onNavigateToComponent(guid) {
+    setSubNav('components');
+    if (compState === 'idle') setCompAttempt(function(a) { return a + 1; });
+    setSelectedComp(guid);
+  }
+
+  const sidebar = React.createElement("div", { style: { width: sideW, minWidth: sideW, display: 'flex', flexDirection: 'column', borderRight: '1px solid var(--border)', overflowY: 'auto', height: '100%' } },
+    // Sub-nav toggle
+    React.createElement("div", { style: { display: 'flex', borderBottom: '1px solid var(--border)', flexShrink: 0 } },
+      React.createElement("button", { onClick: function() { setSubNav('blueprints'); }, style: { flex: 1, padding: '8px 0', background: 'none', border: 'none', cursor: 'pointer', fontWeight: subNav === 'blueprints' ? 700 : 400, color: subNav === 'blueprints' ? 'var(--accent)' : 'var(--fg)', borderBottom: subNav === 'blueprints' ? '2px solid var(--accent)' : '2px solid transparent', fontSize: 13 } }, "Blueprints"),
+      React.createElement("button", { onClick: function() { setSubNav('components'); }, style: { flex: 1, padding: '8px 0', background: 'none', border: 'none', cursor: 'pointer', fontWeight: subNav === 'components' ? 700 : 400, color: subNav === 'components' ? 'var(--accent)' : 'var(--fg)', borderBottom: subNav === 'components' ? '2px solid var(--accent)' : '2px solid transparent', fontSize: 13 } }, "Components")
+    ),
+    // Blueprints list
+    subNav === 'blueprints' && React.createElement("div", { style: { overflowY: 'auto', flex: 1 } },
+      bpState === 'loading' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading blueprints…"),
+      bpState === 'error' && React.createElement("div", { style: { padding: 16 } },
+        React.createElement("div", { style: { color: '#f87171', fontSize: 13, marginBottom: 8 } }, "Error: " + bpError),
+        React.createElement("button", { className: "view-tab on", onClick: function() { setBpAttempt(function(a) { return a + 1; }); } }, "Retry")
+      ),
+      bpState === 'ready' && blueprints.length === 0 && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "No blueprints found"),
+      bpState === 'ready' && blueprints.map(function(bp) {
+        return React.createElement("div", {
+          key: bp.guid,
+          className: "tree-item" + (selectedBp === bp.guid ? " sel" : ""),
+          onClick: function() { setSelectedBp(bp.guid); },
+          title: bp.qualifiedName || bp.guid,
+        },
+          React.createElement("span", { className: "type-name" }, bp.displayName || bp.qualifiedName),
+          bp.lifecycleStatus && React.createElement("span", { className: "badge", style: { fontSize: 9, background: 'rgba(167,139,250,.1)', color: '#c4b5fd', border: '0.5px solid rgba(167,139,250,.3)', marginLeft: 4 } }, bp.lifecycleStatus)
+        );
+      })
+    ),
+    // Components list
+    subNav === 'components' && React.createElement("div", { style: { overflowY: 'auto', flex: 1 } },
+      compState === 'idle' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading components…"),
+      compState === 'loading' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading components…"),
+      compState === 'error' && React.createElement("div", { style: { padding: 16 } },
+        React.createElement("div", { style: { color: '#f87171', fontSize: 13, marginBottom: 8 } }, "Error: " + compError),
+        React.createElement("button", { className: "view-tab on", onClick: function() { setCompAttempt(function(a) { return a + 1; }); } }, "Retry")
+      ),
+      compState === 'ready' && components.length === 0 && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "No components found"),
+      compState === 'ready' && components.map(function(c) {
+        return React.createElement("div", {
+          key: c.guid,
+          className: "tree-item" + (selectedComp === c.guid ? " sel" : ""),
+          onClick: function() { setSelectedComp(c.guid); },
+          title: c.qualifiedName || c.guid,
+        },
+          React.createElement("span", { className: "type-name" }, c.displayName || c.qualifiedName),
+          c.componentType && React.createElement("span", { className: "badge", style: { fontSize: 9, background: 'rgba(96,165,250,.1)', color: '#93c5fd', border: '0.5px solid rgba(96,165,250,.3)', marginLeft: 4 } }, c.componentType)
+        );
+      })
+    )
+  );
+
+  const mainPanel = React.createElement("div", { className: "main", style: { flex: 1, overflowY: 'auto' } },
+    subNav === 'blueprints' && React.createElement(React.Fragment, null,
+      !selectedBp && React.createElement("div", { className: "center" },
+        React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a blueprint from the sidebar")
+      ),
+      selectedBp && bpDetailState === 'loading' && React.createElement("div", { style: { padding: 24, color: 'var(--dim)' } }, "Loading…"),
+      selectedBp && bpDetailState === 'error' && React.createElement("div", { style: { padding: 24, color: '#f87171' } }, "Failed to load blueprint detail"),
+      selectedBp && bpDetailState === 'ready' && bpDetail && React.createElement(SolutionBlueprintDetail, { blueprint: bpDetail, onNavigateToComponent: onNavigateToComponent })
+    ),
+    subNav === 'components' && React.createElement(React.Fragment, null,
+      !selectedComp && React.createElement("div", { className: "center" },
+        React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a component from the sidebar")
+      ),
+      selectedComp && compDetailState === 'loading' && React.createElement("div", { style: { padding: 24, color: 'var(--dim)' } }, "Loading…"),
+      selectedComp && compDetailState === 'error' && React.createElement("div", { style: { padding: 24, color: '#f87171' } }, "Failed to load component detail"),
+      selectedComp && compDetailState === 'ready' && compDetail && React.createElement(SolutionComponentDetail, {
+        component: compDetail,
+        onNavigateToBlueprint: onNavigateToBlueprint,
+        onNavigateToComponent: onNavigateToComponent
+      })
+    )
+  );
+
+  return React.createElement("div", { className: "body" },
+    sidebar,
+    React.createElement(ResizeDivider, { onMouseDown: onDivDown }),
+    mainPanel
+  );
+}
+
 function App() {
   const [creds, setCreds] = useState(function() {
     try {
@@ -3565,10 +4104,22 @@ function App() {
   const [view, setView]           = useState('types'); // 'types' | 'attrs'
   const [section, setSection]     = useState('splash'); // 'splash' | 'type-system' | 'reference-data' | 'digital-products' | 'glossary' | 'report-specs' | 'valid-values'
   const [glossaryNavGuid, setGlossaryNavGuid] = useState(null);
+  const [validValuesNavProp, setValidValuesNavProp] = useState(null);
+  const [dataDesignNavGuid, setDataDesignNavGuid] = useState(null);
 
   const onNavigateToGlossary = useCallback(function(guid) {
     setSection('glossary');
     setGlossaryNavGuid(guid);
+  }, []);
+
+  const onNavigateToValidValues = useCallback(function(propName) {
+    setValidValuesNavProp(propName);
+    setSection('valid-values');
+  }, []);
+
+  const onNavigateToDataSpec = useCallback(function(guid) {
+    setDataDesignNavGuid(guid);
+    setSection('data-design');
   }, []);
 
   const [typeSideW, onTypeDivDown] = useResizable(254);
@@ -3657,6 +4208,8 @@ function App() {
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('report-specs') }, "Report Specs"),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('valid-values') }, "Valid Values"),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('rest-apis') }, "REST APIs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'solution-architect' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('solution-architect') }, "Solution Architect"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'data-design' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('data-design') }, "Data Design"),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
       section === 'type-system' && /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
       section === 'type-system' && view === 'types' && /*#__PURE__*/React.createElement("select", {
@@ -3690,11 +4243,15 @@ function App() {
       : section === 'reference-data'
       ? React.createElement(ReferenceDataView, null)
       : section === 'digital-products'
-      ? React.createElement(DigitalProductsView, { onNavigateToGlossary: onNavigateToGlossary })
+      ? React.createElement(DigitalProductsView, { onNavigateToGlossary: onNavigateToGlossary, onNavigateToDataSpec: onNavigateToDataSpec })
       : section === 'valid-values'
-      ? React.createElement(ValidValuesView, null)
+      ? React.createElement(ValidValuesView, { navProp: validValuesNavProp })
       : section === 'rest-apis'
       ? React.createElement(RestApiView, null)
+      : section === 'solution-architect'
+      ? React.createElement(SolutionArchitectView, null)
+      : section === 'data-design'
+      ? React.createElement(DataDesignView, { navSpecGuid: dataDesignNavGuid, onNavigateToGlossary: onNavigateToGlossary })
       : section !== 'type-system'
       ? /*#__PURE__*/React.createElement(PlaceholderView, { section: section })
       : view === 'attrs'
@@ -3703,7 +4260,7 @@ function App() {
           /*#__PURE__*/React.createElement(Sidebar, { selected: selected, onSelect: onSelect, data: data, width: typeSideW }),
           /*#__PURE__*/React.createElement(ResizeDivider, { onMouseDown: onTypeDivDown }),
           /*#__PURE__*/React.createElement("div", { className: "main" },
-            selected.kind === 'type' && (entities[selected.name] || allEntities[selected.name]) && /*#__PURE__*/React.createElement(TypeDetail, { name: selected.name, entities: allEntities, relationships: relationships, onSelect: onSelect }),
+            selected.kind === 'type' && (entities[selected.name] || allEntities[selected.name]) && /*#__PURE__*/React.createElement(TypeDetail, { name: selected.name, entities: allEntities, relationships: relationships, onSelect: onSelect, onNavigateProp: onNavigateToValidValues }),
             selected.kind === 'classif' && classifications[selected.name] && /*#__PURE__*/React.createElement(ClassifDetail, { name: selected.name, classifications: classifications }),
             selected.kind === 'rel' && relationships[selected.name] && /*#__PURE__*/React.createElement(RelDetail, { name: selected.name, relationships: relationships, onSelect: onSelect }),
             !selected.name && /*#__PURE__*/React.createElement("div", { className: "center" },

--- a/compose-configs/egeria-freshstart/PyegeriaWebHandler/valid_values_handler.py
+++ b/compose-configs/egeria-freshstart/PyegeriaWebHandler/valid_values_handler.py
@@ -7,7 +7,6 @@ Valid Metadata Values Explorer — FastAPI router.
 Endpoints:
   GET /api/valid-values/properties  → property names that have registered valid values
   GET /api/valid-values/lookup      → valid values for a specific Egeria property name
-  GET /api/valid-values/debug       → raw find_metadata_elements response (for diagnosis)
 """
 
 import os
@@ -125,42 +124,6 @@ def _names_from_raw(raw) -> set:
         if n:
             names.add(n)
     return names
-
-
-@router.get("/api/valid-values/debug", summary="Debug: raw find_metadata_elements response structure")
-def debug_valid_value_properties(
-    url:     Optional[str] = Query(None),
-    server:  Optional[str] = Query(None),
-    user_id: Optional[str] = Query(None),
-    user_pwd:Optional[str] = Query(None),
-):
-    """Return diagnostic information about the raw find_metadata_elements response."""
-    try:
-        mgr = _get_expert(url, server, user_id, user_pwd)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
-
-    try:
-        raw = mgr.find_metadata_elements(_FIND_BODY)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"find_metadata_elements failed: {exc}")
-
-    first = None
-    if isinstance(raw, list) and raw:
-        first = raw[0]
-    elif isinstance(raw, dict):
-        elems = raw.get("elements") or raw.get("elementsAsStrings") or []
-        first = elems[0] if elems else None
-
-    return JSONResponse({
-        "raw_type":        type(raw).__name__,
-        "raw_length":      len(raw) if isinstance(raw, (list, str)) else None,
-        "raw_keys":        list(raw.keys()) if isinstance(raw, dict) else None,
-        "first_item_type": type(first).__name__ if first is not None else None,
-        "first_item_keys": list(first.keys()) if isinstance(first, dict) else None,
-        "first_item":      first,
-        "names_extracted": sorted(_names_from_raw(raw)),
-    })
 
 
 @router.get("/api/valid-values/properties", summary="List property names that have registered valid values")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/data_design_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/data_design_handler.py
@@ -1,0 +1,423 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.
+
+Data Design Explorer — FastAPI router.
+
+Type hierarchy (https://egeria-project.org/types/5/):
+  DataSpec        → subtype of Collection (use CollectionManager.find_collections / get_collection)
+  DataStructure   → use DataDesigner.find_data_structures / get_data_structure_by_guid
+  DataField       → use DataDesigner.find_data_fields / get_data_field_by_guid; sub-fields nest inside
+  DataGrain       → subtype of DataValueSpecification (use _search_data_value_specs + typeName filter)
+  DataClass       → subtype of DataValueSpecification (same endpoint as DataGrain, different typeName)
+
+Note: DataValueSpecification defines *values*, not structure.  DataSpec/Structure/Field define structure.
+DataDesigner.find_data_value_specifications is broken (calls self._async_post, absent ≤6.0.12.3);
+  _search_data_value_specs() calls /by-search-string directly as a workaround.
+
+Endpoints:
+  GET /api/data-design/specs              → list all Data Specs (Collection subtype)
+  GET /api/data-design/specs/{guid}       → detail for a Data Spec
+  GET /api/data-design/structures         → list all Data Structures
+  GET /api/data-design/structures/{guid}  → detail for a Data Structure
+  GET /api/data-design/fields             → list all Data Fields
+  GET /api/data-design/fields/{guid}      → detail for a Data Field
+  GET /api/data-design/grains             → list all Data Grains (subtype of DataValueSpecification)
+  GET /api/data-design/grains/{guid}      → detail for a Data Grain
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+router = APIRouter(tags=["data-design"])
+
+
+def _get_designer(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import DataDesigner
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = DataDesigner(server, url, user_id, user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _get_collection_mgr(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import CollectionManager
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",  "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",   "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",          "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD", "secret")
+    mgr = CollectionManager(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+
+def _props(el: dict) -> dict:
+    return el.get("properties") or {}
+
+
+def _header(el: dict) -> dict:
+    return el.get("elementHeader") or {}
+
+
+def _type_name(el: dict) -> str:
+    return (_header(el).get("type") or {}).get("typeName", "") or ""
+
+
+def _base(el: dict) -> dict:
+    p = _props(el)
+    return {
+        "guid":          _header(el).get("guid", ""),
+        "typeName":      _type_name(el),
+        "displayName":   p.get("displayName", "") or p.get("name", "") or "",
+        "qualifiedName": p.get("qualifiedName", "") or "",
+        "description":   p.get("description", "") or "",
+    }
+
+
+def _zip_refs(guids: list, names: list, qnames: list = None) -> list:
+    """Zip parallel guid/name/qname arrays into [{guid, displayName, qualifiedName}]."""
+    qnames = qnames or []
+    return [
+        {
+            "guid":          guids[i],
+            "displayName":   names[i] if i < len(names) else "",
+            "qualifiedName": qnames[i] if i < len(qnames) else "",
+        }
+        for i in range(len(guids or []))
+    ]
+
+
+def _safe_list(raw) -> list:
+    return raw if isinstance(raw, list) else []
+
+
+def _search_data_value_specs(mgr) -> list:
+    """Call /by-search-string directly — find_data_value_specifications uses _async_post (absent ≤6.0.12.3)."""
+    endpoint = (
+        f"{mgr.platform_url}/servers/{mgr.view_server}"
+        f"/api/open-metadata/data-designer/data-value-specifications/by-search-string"
+    )
+    body = {"class": "SearchStringRequestBody", "searchString": "", "startFrom": 0, "pageSize": 500}
+    loop = asyncio.get_event_loop()
+    resp = loop.run_until_complete(mgr._async_make_request("POST", endpoint, body))
+    if hasattr(resp, "json"):
+        return resp.json().get("elements", []) or []
+    if isinstance(resp, dict):
+        return resp.get("elements", []) or []
+    return []
+
+
+def _first(raw) -> dict | None:
+    if isinstance(raw, list):
+        return raw[0] if raw else None
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
+def _rels(mgr, element: dict) -> dict:
+    try:
+        return mgr.get_data_rel_elements_dict(element) or {}
+    except Exception:
+        return {}
+
+
+def _serialize_spec(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "versionIdentifier": p.get("versionIdentifier", "") or "",
+        "namespace":         p.get("namespace", "") or p.get("namespacePath", "") or "",
+        "mermaidGraph":      el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_structure(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "versionIdentifier": p.get("versionIdentifier", "") or "",
+        "namespace":         p.get("namespace", "") or p.get("namespacePath", "") or "",
+        "mermaidGraph":      el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_field(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "dataType":      p.get("dataType", "") or "",
+        "isNullable":    bool(p.get("isNullable", False)),
+        "defaultValue":  p.get("defaultValue", "") or "",
+        "minimumLength": p.get("minimumLength", 0) or 0,
+        "length":        p.get("length", 0) or 0,
+        "mermaidGraph":  el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+def _serialize_grain(el: dict) -> dict:
+    p = _props(el)
+    n = _base(el)
+    n.update({
+        "dataType":    p.get("dataType", "") or "",
+        "mermaidGraph": el.get("mermaidGraph", "") or p.get("mermaidGraph", "") or "",
+    })
+    return n
+
+
+# ── List endpoints ─────────────────────────────────────────────────────────────
+
+@router.get("/api/data-design/specs", summary="List all Data Specs (Collection subtype)")
+def list_specs(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_collection_mgr(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_collections(search_string="*", metadata_element_type="DataSpec",
+                                    graph_query_depth=0, output_format="JSON")
+        items = sorted(
+            [_serialize_spec(e) for e in _safe_list(raw)],
+            key=lambda x: (x.get("displayName") or "").lower(),
+        )
+        return JSONResponse({"specs": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_specs failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/structures", summary="List all Data Structures")
+def list_structures(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_data_structures(search_string="*", graph_query_depth=0, output_format="JSON")
+        items = sorted([_serialize_structure(e) for e in _safe_list(raw)],
+                       key=lambda x: (x.get("displayName") or "").lower())
+        return JSONResponse({"structures": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_structures failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/fields", summary="List all Data Fields")
+def list_fields(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.find_data_fields(search_string="*", graph_query_depth=0, output_format="JSON")
+        items = sorted([_serialize_field(e) for e in _safe_list(raw)],
+                       key=lambda x: (x.get("displayName") or "").lower())
+        return JSONResponse({"fields": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_fields failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/grains", summary="List all Data Grains")
+def list_grains(
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = _search_data_value_specs(mgr)
+        items = sorted(
+            [_serialize_grain(e) for e in _safe_list(raw) if _type_name(e) == "DataGrain"],
+            key=lambda x: (x.get("displayName") or "").lower(),
+        )
+        return JSONResponse({"grains": items, "total": len(items)})
+    except Exception as exc:
+        logger.exception("list_grains failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# ── Detail endpoints ───────────────────────────────────────────────────────────
+
+@router.get("/api/data-design/specs/{guid}", summary="Detail for a Data Spec")
+def get_spec(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_collection_mgr(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_collection_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Spec {guid!r} not found")
+        node = _serialize_spec(element)
+        # Fetch members separately — get_collection_by_guid doesn't traverse relationships
+        members = []
+        try:
+            members_raw = mgr.get_collection_members(
+                collection_guid=guid,
+                output_format="JSON",
+                page_size=200,
+                body={"class": "ResultsRequestBody", "graphQueryDepth": 0},
+            )
+            for m in _safe_list(members_raw):
+                rh = (m.get("elementHeader") or {})
+                rp = (m.get("properties") or {})
+                g  = rh.get("guid", "")
+                if g:
+                    members.append({
+                        "guid":          g,
+                        "displayName":   rp.get("displayName") or rp.get("name") or "",
+                        "qualifiedName": rp.get("qualifiedName") or "",
+                        "typeName":      (rh.get("type") or {}).get("typeName") or "",
+                    })
+        except Exception:
+            logger.warning(f"get_collection_members failed for DataSpec {guid}")
+        node["containsDataStructures"] = [m for m in members if m.get("typeName") == "DataStructure"]
+        node["members"] = members
+        # Parent collections (e.g. DataDictionaries) — embedded in the element's relationship list
+        parent_refs = []
+        for m in _safe_list(element.get("memberOfCollections")):
+            re = m.get("relatedElement") or m
+            rh = re.get("elementHeader") or {}
+            rp = re.get("properties") or {}
+            g  = rh.get("guid", "")
+            if g:
+                parent_refs.append({
+                    "guid":          g,
+                    "displayName":   rp.get("displayName") or rp.get("name") or "",
+                    "qualifiedName": rp.get("qualifiedName") or "",
+                    "typeName":      (rh.get("type") or {}).get("typeName") or "",
+                })
+        node["memberOfCollections"] = parent_refs
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_spec failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/structures/{guid}", summary="Detail for a Data Structure")
+def get_structure(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_structure_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Structure {guid!r} not found")
+        node = _serialize_structure(element)
+        r = _rels(mgr, element)
+        node["containsDataFields"] = _zip_refs(r.get("member_data_field_guids", []),    r.get("member_data_field_names", []),   r.get("member_data_fields", []))
+        node["memberOfDataSpecs"]  = _zip_refs(r.get("member_of_data_spec_guids", []),  r.get("member_of_data_spec_names", []), r.get("in_data_spec", []))
+        node["memberOfDataDicts"]  = _zip_refs(r.get("member_of_data_dicts_guids", []), r.get("member_of_data_dicts_names", []),r.get("in_data_dictionary", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_structure failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/fields/{guid}", summary="Detail for a Data Field")
+def get_field(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_field_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Field {guid!r} not found")
+        node = _serialize_field(element)
+        r = _rels(mgr, element)
+        node["assignedMeanings"]     = _zip_refs(r.get("assigned_meanings_guids", []),  r.get("assigned_meanings_names", []),  r.get("assigned_meanings_qnames", []))
+        node["partOfDataStructures"] = _zip_refs(r.get("data_structure_guids", []),     r.get("data_structure_names", []),     r.get("in_data_structure", []))
+        node["assignedDataClasses"]  = _zip_refs(r.get("data_class_guids", []),         r.get("data_class_names", []),         r.get("data_class_qnames", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_field failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/api/data-design/grains/{guid}", summary="Detail for a Data Grain")
+def get_grain(
+    guid: str,
+    url:     Optional[str] = Query(None),
+    server:  Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    user_pwd:Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_designer(url, server, user_id, user_pwd)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+    try:
+        raw = mgr.get_data_grain_by_guid(guid, output_format="JSON")
+        element = _first(raw)
+        if not element:
+            raise HTTPException(status_code=404, detail=f"Grain {guid!r} not found")
+        node = _serialize_grain(element)
+        r = _rels(mgr, element)
+        node["assignedDataValueSpecs"] = _zip_refs(r.get("assigned_data_value_spec_guids", []), r.get("assigned_data_value_spec_names", []), r.get("assigned_data_value_spec_qnames", []))
+        return JSONResponse(node)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("get_grain failed")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/digital_products_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/digital_products_handler.py
@@ -27,6 +27,7 @@ _CONTAINER_TYPES = {
     "DigitalProductCatalog", "DigitalProductFamily",
     "Collection", "RootCollection", "FolderCollection",
     "DataSpecCollection", "DataDictionary",
+    "DigitalProduct", "TabularDataSetCollection",
 }
 
 

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/glossary_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/glossary_handler.py
@@ -121,6 +121,31 @@ def _folder_memberships(term: dict) -> list:
     return folders
 
 
+def _extract_classifications(header: dict) -> list:
+    """Return [{typeName, properties}] from elementHeader.classifications, excluding
+    TemplateSubstitute (handled separately via the templateSubstitute sibling key)."""
+    result = []
+    for cls in (header.get("classifications") or []):
+        if not isinstance(cls, dict):
+            continue
+        cls_header = cls.get("classificationHeader") or cls.get("header") or cls
+        type_name  = (cls_header.get("type") or {}).get("typeName") or cls_header.get("classificationName") or ""
+        if not type_name or type_name == "TemplateSubstitute":
+            continue
+        cls_props = cls.get("classificationProperties") or cls.get("properties") or {}
+        flat_props = {}
+        if isinstance(cls_props, dict):
+            prop_map = cls_props.get("propertyValueMap") or {}
+            for k, v in prop_map.items():
+                flat_props[k] = v.get("primitiveValue", "") if isinstance(v, dict) else str(v)
+            if not flat_props:
+                for k, v in cls_props.items():
+                    if k not in ("class", "propertyValueMap", "propertiesAsStrings"):
+                        flat_props[k] = str(v)
+        result.append({"typeName": type_name, "properties": flat_props})
+    return result
+
+
 def _serialize_term(term: dict) -> dict:
     props  = _props(term)
     header = _header(term)
@@ -145,6 +170,7 @@ def _serialize_term(term: dict) -> dict:
         "folders":                _folder_memberships(term),
         "isTemplateSubstitute":   is_template_substitute,
         "isSourcedFromTemplate":  is_sourced_from_template,
+        "classifications":        _extract_classifications(header),
         "relationships":          {label: items for key, label in _TERM_REL_KEYS
                                    if (items := _related_elements(term.get(key)))},
     }

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/pyegeria_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/pyegeria_handler.py
@@ -166,6 +166,10 @@ from mermaid_handler import router as mermaid_router
 app.include_router(mermaid_router)
 from rest_api_handler import router as rest_api_router
 app.include_router(rest_api_router)
+from solution_architect_handler import router as solution_architect_router
+app.include_router(solution_architect_router)
+from data_design_handler import router as data_design_router
+app.include_router(data_design_router)
 # Mount the MCP SSE application
 # FastMCP.sse_app() returns a Starlette app with /sse and /messages routes
 mcp_app = mcp_server.sse_app()

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/solution_architect_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/solution_architect_handler.py
@@ -1,0 +1,304 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.
+
+Solution Architect Explorer — FastAPI router.
+
+Endpoints:
+  GET /api/solution/blueprints                       → list all solution blueprints
+  GET /api/solution/blueprints/{guid}                → full detail for a blueprint
+  GET /api/solution/components                       → list all solution components
+  GET /api/solution/components/{guid}                → full detail for a component
+  GET /api/solution/components/{guid}/implementations → concrete implementations
+"""
+
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+router = APIRouter(tags=["solution-architect"])
+
+
+def _get_manager(url=None, server=None, user_id=None, user_pwd=None):
+    from pyegeria import SolutionArchitect
+    url      = url      or os.environ.get("EGERIA_PLATFORM_URL",   "https://localhost:9443")
+    server   = server   or os.environ.get("EGERIA_VIEW_SERVER",    "qs-view-server")
+    user_id  = user_id  or os.environ.get("EGERIA_USER",           "erinoverview")
+    user_pwd = user_pwd or os.environ.get("EGERIA_USER_PASSWORD",  "secret")
+    mgr = SolutionArchitect(view_server=server, platform_url=url, user_id=user_id, user_pwd=user_pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _props(element: dict) -> dict:
+    return element.get("properties") or {}
+
+
+def _header(element: dict) -> dict:
+    return element.get("elementHeader") or {}
+
+
+def _type_name(element: dict) -> str:
+    return (_header(element).get("type") or {}).get("typeName", "") or ""
+
+
+def _rel_list(element: dict, key: str) -> list:
+    """Return the raw relationship list for a given key, normalising None → []."""
+    return element.get(key) or []
+
+
+def _serialize_rel_entries(rel_list: list) -> list:
+    """Convert [{relatedElement: {elementHeader, properties}}, ...] → [{guid, displayName, qualifiedName, typeName}]."""
+    result = []
+    for rel in rel_list:
+        re = rel.get("relatedElement") or {}
+        rh = re.get("elementHeader") or {}
+        rp = re.get("properties") or {}
+        g  = rh.get("guid", "")
+        if g:
+            result.append({
+                "guid":          g,
+                "displayName":   rp.get("displayName") or rp.get("name") or "",
+                "qualifiedName": rp.get("qualifiedName") or "",
+                "typeName":      (rh.get("type") or {}).get("typeName") or "",
+            })
+    return result
+
+
+def _serialize_blueprint_summary(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":              header.get("guid", ""),
+        "displayName":       props.get("displayName") or props.get("name") or "",
+        "qualifiedName":     props.get("qualifiedName") or "",
+        "description":       props.get("description") or "",
+        "versionIdentifier": props.get("versionIdentifier") or "",
+        "lifecycleStatus":   props.get("lifecycleStatus") or "",
+        "userDefinedStatus": props.get("userDefinedStatus") or "",
+        "status":            header.get("status") or "",
+        "typeName":          _type_name(element),
+    }
+
+
+def _serialize_blueprint_detail(element: dict) -> dict:
+    detail = _serialize_blueprint_summary(element)
+    detail["mermaidGraph"] = element.get("mermaidGraph") or ""
+    # Components linked to this blueprint (nestedComponents or collectionMembers key varies by depth)
+    components = _serialize_rel_entries(_rel_list(element, "nestedComponents"))
+    if not components:
+        components = _serialize_rel_entries(_rel_list(element, "solutionComponents"))
+    if not components:
+        # collectionMembers includes component-type entries at graph_query_depth >= 1
+        components = _serialize_rel_entries(_rel_list(element, "collectionMembers"))
+    detail["components"] = components
+    return detail
+
+
+def _serialize_component_summary(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":              header.get("guid", ""),
+        "displayName":       props.get("displayName") or props.get("name") or "",
+        "qualifiedName":     props.get("qualifiedName") or "",
+        "description":       props.get("description") or "",
+        "componentType":     props.get("componentType") or "",
+        "versionIdentifier": props.get("versionIdentifier") or "",
+        "lifecycleStatus":   props.get("lifecycleStatus") or "",
+        "userDefinedStatus": props.get("userDefinedStatus") or "",
+        "status":            header.get("status") or "",
+        "typeName":          _type_name(element),
+    }
+
+
+def _serialize_component_detail(element: dict) -> dict:
+    detail = _serialize_component_summary(element)
+    detail["mermaidGraph"] = element.get("mermaidGraph") or ""
+
+    # Parent blueprints come from memberOfCollections filtered by SolutionBlueprint typeName
+    raw_collections = _rel_list(element, "memberOfCollections")
+    blueprints = _serialize_rel_entries([
+        m for m in raw_collections
+        if (m.get("relatedElement") or {}).get("elementHeader", {}).get("type", {}).get("typeName") == "SolutionBlueprint"
+    ])
+
+    detail["parentComponents"]  = _serialize_rel_entries(_rel_list(element, "usedInSolutionComponents"))
+    detail["subComponents"]     = _serialize_rel_entries(_rel_list(element, "nestedSolutionComponents"))
+    detail["blueprints"]        = blueprints
+    detail["actors"]            = _serialize_rel_entries(_rel_list(element, "actors"))
+    detail["wiredTo"]           = _serialize_rel_entries(_rel_list(element, "wiredTo"))
+    detail["wiredFrom"]         = _serialize_rel_entries(_rel_list(element, "wiredFrom"))
+    return detail
+
+
+def _serialize_implementation(element: dict) -> dict:
+    props  = _props(element)
+    header = _header(element)
+    return {
+        "guid":          header.get("guid", ""),
+        "displayName":   props.get("displayName") or props.get("name") or "",
+        "qualifiedName": props.get("qualifiedName") or "",
+        "description":   props.get("description") or "",
+        "typeName":      _type_name(element),
+        "status":        header.get("status") or "",
+    }
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────────
+
+@router.get("/api/solution/blueprints", summary="List all solution blueprints")
+def list_blueprints(
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_solution_blueprints(
+            search_string="*",
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("find_solution_blueprints failed")
+        raise HTTPException(status_code=500, detail=f"Blueprint retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    blueprints = [_serialize_blueprint_summary(b) for b in raw]
+    blueprints.sort(key=lambda b: (b.get("displayName") or "").lower())
+    return JSONResponse({"blueprints": blueprints, "total": len(blueprints)})
+
+
+@router.get("/api/solution/blueprints/{guid}", summary="Get a single solution blueprint by GUID")
+def get_blueprint(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_blueprint_by_guid(guid, output_format="JSON")
+    except Exception as exc:
+        logger.exception("get_solution_blueprint_by_guid failed")
+        raise HTTPException(status_code=500, detail=f"Blueprint retrieval failed: {exc}")
+
+    if not raw or isinstance(raw, str):
+        raise HTTPException(status_code=404, detail=f"Blueprint {guid!r} not found")
+
+    return JSONResponse(_serialize_blueprint_detail(raw))
+
+
+@router.get("/api/solution/components", summary="List all solution components")
+def list_components(
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.find_solution_components(
+            search_string="*",
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("find_solution_components failed")
+        raise HTTPException(status_code=500, detail=f"Component retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    components = [_serialize_component_summary(c) for c in raw]
+    components.sort(key=lambda c: (c.get("displayName") or "").lower())
+    return JSONResponse({"components": components, "total": len(components)})
+
+
+@router.get("/api/solution/components/{guid}", summary="Get a single solution component by GUID")
+def get_component(
+    guid: str,
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_component_by_guid(guid, output_format="JSON")
+    except Exception as exc:
+        logger.exception("get_solution_component_by_guid failed")
+        raise HTTPException(status_code=500, detail=f"Component retrieval failed: {exc}")
+
+    if not raw or isinstance(raw, str):
+        raise HTTPException(status_code=404, detail=f"Component {guid!r} not found")
+
+    return JSONResponse(_serialize_component_detail(raw))
+
+
+@router.get("/api/solution/components/{guid}/implementations", summary="Get implementations of a solution component")
+def get_component_implementations(
+    guid: str,
+    start_from: int = Query(0,   ge=0),
+    page_size:  int = Query(200, ge=1, le=500),
+    url:      Optional[str] = Query(None),
+    server:   Optional[str] = Query(None),
+    user_id:  Optional[str] = Query(None),
+    user_pwd: Optional[str] = Query(None),
+):
+    try:
+        mgr = _get_manager(url, server, user_id, user_pwd)
+    except Exception as exc:
+        logger.exception("Failed to create SolutionArchitect manager")
+        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
+
+    try:
+        raw = mgr.get_solution_component_implementations(
+            solution_component_guid=guid,
+            output_format="JSON",
+            start_from=start_from,
+            page_size=page_size,
+        )
+    except Exception as exc:
+        logger.exception("get_solution_component_implementations failed")
+        raise HTTPException(status_code=500, detail=f"Implementations retrieval failed: {exc}")
+
+    if not isinstance(raw, list):
+        raw = []
+
+    implementations = [_serialize_implementation(i) for i in raw]
+    return JSONResponse({"implementations": implementations, "total": len(implementations), "component": guid})

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -1010,7 +1010,8 @@ function TypeDetail({
   name,
   entities,
   relationships,
-  onSelect
+  onSelect,
+  onNavigateProp
 }) {
   const [tab, setTab] = useState('props');
   const [showInherited, setShowInherited] = useState(true);
@@ -1153,12 +1154,17 @@ function TypeDetail({
     return /*#__PURE__*/React.createElement("tr", {
       key: i,
       className: [isOwn ? 'own-row' : '', p.deprecated ? 'depr-row' : ''].filter(Boolean).join(' ')
-    }, /*#__PURE__*/React.createElement("td", null, /*#__PURE__*/React.createElement("span", {
-      className: p.deprecated ? "mono depr" : "mono",
-      style: {
-        color: isOwn ? '#93c5fd' : 'var(--text)'
-      }
-    }, p.name), p.req && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
+    }, /*#__PURE__*/React.createElement("td", null, onNavigateProp
+      ? /*#__PURE__*/React.createElement("button", {
+          className: p.deprecated ? "mono depr" : "mono",
+          onClick: function() { onNavigateProp(p.name); },
+          title: "Look up valid values for " + p.name,
+          style: { background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: isOwn ? '#93c5fd' : 'var(--accent)', textDecoration: 'underline dotted', fontFamily: 'inherit', fontSize: 'inherit' }
+        }, p.name)
+      : /*#__PURE__*/React.createElement("span", {
+          className: p.deprecated ? "mono depr" : "mono",
+          style: { color: isOwn ? '#93c5fd' : 'var(--text)' }
+        }, p.name), p.req && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
       kind: "req"
     }, "req")), isOwn && /*#__PURE__*/React.createElement("span", null, " ", /*#__PURE__*/React.createElement(Badge, {
       kind: "own"
@@ -1928,17 +1934,30 @@ function ReportSpecView() {
         )
       ),
       React.createElement('div', { className: 'tree-scroll' },
-        filtered.map(s => React.createElement('div', {
-          key: s.name,
-          className: 'tree-item' + (selected === s.name ? ' sel' : ''),
-          onClick: () => { setHistory([]); setSelected(s.name); }
-        },
-          React.createElement('span', { className: 'type-name' }, s.name),
-          s.family && React.createElement('span', {
-            className: 'badge',
-            style: { background: 'rgba(100,116,139,.1)', color: '#94a3b8', border: '0.5px solid rgba(100,116,139,.3)', fontSize: 9 }
-          }, s.family)
-        ))
+        (function() {
+          var byFamily = {};
+          filtered.forEach(function(s) {
+            var fam = s.family || 'General';
+            if (!byFamily[fam]) byFamily[fam] = [];
+            byFamily[fam].push(s);
+          });
+          var famNames = Object.keys(byFamily).sort();
+          var rows = [];
+          famNames.forEach(function(fam) {
+            rows.push(React.createElement('div', {
+              key: 'hdr-' + fam,
+              style: { padding: '6px 12px 3px', fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--dim)', borderTop: '1px solid rgba(26,45,72,.4)', marginTop: rows.length ? 4 : 0 }
+            }, fam + ' (' + byFamily[fam].length + ')'));
+            byFamily[fam].forEach(function(s) {
+              rows.push(React.createElement('div', {
+                key: s.name,
+                className: 'tree-item' + (selected === s.name ? ' sel' : ''),
+                onClick: function() { setHistory([]); setSelected(s.name); }
+              }, React.createElement('span', { className: 'type-name' }, s.name)));
+            });
+          });
+          return rows;
+        })()
       )
     ),
     React.createElement(ResizeDivider, { onMouseDown: onDivDown }),
@@ -2045,9 +2064,18 @@ function GlossaryTermDetail({ term, onNavigateToTerm }) {
       !term.isTemplateSubstitute && term.isSourcedFromTemplate && React.createElement("span", { className: "badge", style: { background: 'rgba(245,158,11,.08)', color: '#fbbf24', border: '0.5px solid rgba(245,158,11,.25)', fontSize: 11 } }, "From Template")
     ),
     React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 8 } }, term.guid),
-    folderList.length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 } },
+    folderList.length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8 } },
       React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, "Folders:"),
       folderList.map(f => React.createElement("span", { key: f.guid, className: "badge", style: { fontSize: 11, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, f.displayName || f.guid))
+    ),
+    (term.classifications || []).length > 0 && React.createElement("div", { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 } },
+      React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, "Classifications:"),
+      term.classifications.map(function(c) {
+        var tip = Object.keys(c.properties || {}).length > 0 ? JSON.stringify(c.properties, null, 2) : '';
+        return React.createElement("span", { key: c.typeName, className: "badge", title: tip,
+          style: { fontSize: 11, background: 'rgba(168,85,247,.1)', color: '#c084fc', border: '0.5px solid rgba(168,85,247,.25)' }
+        }, c.typeName);
+      })
     ),
     term.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(term.description)),
     React.createElement(MermaidSection, { guid: term.guid }),
@@ -2265,11 +2293,12 @@ function GlossaryView({ navGuid }) {
   const middleLoading = isSearchMode ? searchState === 'loading' : scopeState === 'loading';
   const middleError   = isSearchMode ? searchError : scopeError;
   const middleCounts  = isSearchMode
-    ? ('Terms (' + filteredSearchTerms.length + (filteredSearchTerms.length !== searchTerms.length ? '/' + searchTerms.length : '') + ')')
+    ? ('Terms (' + filteredSearchTerms.length + (filteredSearchTerms.length !== searchTerms.length ? '/' + searchTerms.length : '') + ')' + (searchTerms.length >= 200 ? ' ⚠ first 200 shown' : ''))
     : (scopeState === 'loading' ? 'Loading…' : (
         folders.length + ' folder' + (folders.length !== 1 ? 's' : '') +
         ', ' + filteredTerms.length + (filteredTerms.length !== terms.length - templateTermCount ? '/' + (terms.length - templateTermCount) : '') + ' term' + ((terms.length - templateTermCount) !== 1 ? 's' : '') +
-        (!showTemplates && templateTermCount > 0 ? ' · ' + templateTermCount + ' template' + (templateTermCount !== 1 ? 's' : '') + ' hidden' : '')
+        (!showTemplates && templateTermCount > 0 ? ' · ' + templateTermCount + ' template' + (templateTermCount !== 1 ? 's' : '') + ' hidden' : '') +
+        (terms.length >= 500 ? ' ⚠ first 500 shown' : '')
       ));
 
   return React.createElement("div", { className: "body" },
@@ -2558,7 +2587,7 @@ function ReferenceDataView() {
 
 // ── Digital Products Explorer ─────────────────────────────────────────────────
 
-function DigitalProductDetail({ product, onNavigateToGlossary }) {
+function DigitalProductDetail({ product, onNavigateToGlossary, onNavigateToDataSpec }) {
   if (!product) return null;
   const fields = [
     ['Qualified Name',   product.qualifiedName],
@@ -2578,6 +2607,45 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
     product.typeName === 'GlossaryTerm' || product.typeName === 'Glossary' || product.typeName === 'GlossaryCategory'
   );
 
+  // Group children by typeName for the members section
+  const children = product.children || [];
+  const memberGroups = {};
+  children.forEach(function(child) {
+    const tn = child.typeName || 'Unknown';
+    if (!memberGroups[tn]) memberGroups[tn] = [];
+    memberGroups[tn].push(child);
+  });
+  const memberTypeNames = Object.keys(memberGroups).sort();
+
+  // Colour coding for known member types
+  function memberBadgeStyle(tn) {
+    if (tn === 'DataSpecCollection') return { background: 'rgba(74,222,128,.1)', color: '#86efac', border: '0.5px solid rgba(74,222,128,.25)' };
+    if (tn.startsWith('TabularDataSet')) return { background: 'rgba(251,191,36,.1)', color: '#fcd34d', border: '0.5px solid rgba(251,191,36,.25)' };
+    return { background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' };
+  }
+
+  function renderMemberGroup(tn, members) {
+    const isDataSpec = tn === 'DataSpecCollection';
+    const isTabular  = tn.startsWith('TabularDataSet');
+    return React.createElement("div", { key: tn, style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 12, color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 6 } },
+        tn + " (" + members.length + ")"
+      ),
+      members.map(function(m) {
+        return React.createElement("div", { key: m.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '5px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, m.displayName || m.qualifiedName || m.guid),
+          React.createElement("span", { className: "badge", style: Object.assign({ fontSize: 9 }, memberBadgeStyle(m.typeName || tn)) }, m.typeName || tn),
+          isDataSpec && React.createElement("button", {
+            onClick: function() { onNavigateToDataSpec && onNavigateToDataSpec(m.guid); },
+            disabled: !onNavigateToDataSpec,
+            title: onNavigateToDataSpec ? 'View in Data Design tab' : 'Data Design tab coming in Phase 3',
+            style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(74,222,128,.4)', background: onNavigateToDataSpec ? 'rgba(74,222,128,.1)' : 'transparent', color: onNavigateToDataSpec ? '#86efac' : 'var(--dim)', cursor: onNavigateToDataSpec ? 'pointer' : 'not-allowed', fontSize: 11, opacity: onNavigateToDataSpec ? 1 : 0.5 }
+          }, "View Data Spec →")
+        );
+      })
+    );
+  }
+
   return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
     React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
       React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, product.displayName || product.qualifiedName),
@@ -2590,7 +2658,7 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
     React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, product.guid),
     product.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(product.description)),
     React.createElement(MermaidSection, { guid: product.guid }),
-    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13 } },
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
       React.createElement("tbody", null,
         fields.map(function([label, value]) {
           return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
@@ -2599,6 +2667,10 @@ function DigitalProductDetail({ product, onNavigateToGlossary }) {
           );
         })
       )
+    ),
+    memberTypeNames.length > 0 && React.createElement("div", null,
+      React.createElement("div", { style: { fontWeight: 700, fontSize: 13, marginBottom: 12, paddingBottom: 6, borderBottom: '1px solid var(--border)', color: 'var(--accent)' } }, "Members"),
+      memberTypeNames.map(function(tn) { return renderMemberGroup(tn, memberGroups[tn]); })
     )
   );
 }
@@ -2641,7 +2713,7 @@ function DigitalTreeNode({ node, depth, selectedGuid, onSelect, expanded, toggle
   );
 }
 
-function DigitalProductsView({ onNavigateToGlossary }) {
+function DigitalProductsView({ onNavigateToGlossary, onNavigateToDataSpec }) {
   const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   const [treeW, onTreeDivDown] = useResizable(300);
@@ -2767,7 +2839,7 @@ function DigitalProductsView({ onNavigateToGlossary }) {
     // Node detail (right)
     React.createElement("div", { className: "main" },
       selectedNodeObj
-        ? React.createElement(DigitalProductDetail, { product: selectedNodeObj, onNavigateToGlossary: onNavigateToGlossary })
+        ? React.createElement(DigitalProductDetail, { product: selectedNodeObj, onNavigateToGlossary: onNavigateToGlossary, onNavigateToDataSpec: onNavigateToDataSpec })
         : React.createElement("div", { className: "center" },
             React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a node to view details")
           )
@@ -3003,7 +3075,7 @@ function ValidValueEntry({ val }) {
   );
 }
 
-function ValidValuesView() {
+function ValidValuesView({ navProp }) {
   const creds = React.useContext(CredContext);
   const [sideW, onDivDown] = useResizable(254);
   // Left: property name input + dynamic presets from Egeria
@@ -3055,6 +3127,11 @@ function ValidValuesView() {
       })
       .catch(err => { setError(err.message); setLoadState('error'); });
   }, [creds]);
+
+  // Auto-lookup when navigated from another section (e.g. Type System property click)
+  useEffect(() => {
+    if (navProp) { setPropertyName(navProp); lookup(navProp); }
+  }, [navProp]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   return React.createElement("div", { className: "body" },
     // Left: property selector
@@ -3540,6 +3617,468 @@ const AREA_NAMES = {
   "6": "Area 6 — Data Stores",
   "7": "Area 7 — Lineage"
 };
+// ── Solution Architect ─────────────────────────────────────────────────────────
+
+// ── Data Design tab ──────────────────────────────────────────────────────────
+function DataDesignView({ navSpecGuid, onNavigateToGlossary }) {
+  const creds = React.useContext(CredContext);
+  const [subNav, setSubNav] = React.useState('specs');
+  const [listStates, setListStates] = React.useState({
+    specs:      { st: 'idle', items: [] },
+    structures: { st: 'idle', items: [] },
+    fields:     { st: 'idle', items: [] },
+    grains:     { st: 'idle', items: [] },
+  });
+  const [selGuid, setSelGuid] = React.useState(null);
+  const [detail, setDetail] = React.useState(null);
+  const [detailSt, setDetailSt] = React.useState('idle');
+  const [sideW, onSideDivDown] = useResizable(260);
+
+  function updateList(nav, patch) {
+    setListStates(function(prev) { return Object.assign({}, prev, { [nav]: Object.assign({}, prev[nav], patch) }); });
+  }
+
+  function loadItems(nav) {
+    updateList(nav, { st: 'loading' });
+    fetch(credAppend('/api/data-design/' + nav, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(d) { updateList(nav, { st: 'ready', items: d[nav] || [] }); })
+      .catch(function(err) { updateList(nav, { st: 'error', items: [], error: err.message }); });
+  }
+
+  function loadDetail(nav, guid) {
+    setSelGuid(guid);
+    setDetailSt('loading');
+    setDetail(null);
+    fetch(credAppend('/api/data-design/' + nav + '/' + guid, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(d) { setDetail(d); setDetailSt('ready'); })
+      .catch(function() { setDetailSt('error'); });
+  }
+
+  function switchAndSelect(nav, guid) {
+    setSubNav(nav);
+    if (listStates[nav].st === 'idle') loadItems(nav);
+    loadDetail(nav, guid);
+  }
+
+  React.useEffect(function() { loadItems('specs'); }, []);
+
+  React.useEffect(function() {
+    if (listStates[subNav].st === 'idle') loadItems(subNav);
+  }, [subNav]);
+
+  React.useEffect(function() {
+    if (navSpecGuid) switchAndSelect('specs', navSpecGuid);
+  }, [navSpecGuid]);
+
+  const SUB_NAVS = [
+    { key: 'specs',      label: 'Data Specs',      color: '#7dd3fc' },
+    { key: 'structures', label: 'Data Structures',  color: '#a5b4fc' },
+    { key: 'fields',     label: 'Data Fields',      color: '#5eead4' },
+    { key: 'grains',     label: 'Data Grains',      color: '#fda4af' },
+  ];
+
+  function relSection(title, items, onClick, btnColor) {
+    if (!items || items.length === 0) return null;
+    return React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 6, color: 'var(--accent)' } }, title + " (" + items.length + ")"),
+      items.map(function(item, i) {
+        return React.createElement("div", { key: item.guid || i, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, item.displayName || item.qualifiedName),
+          onClick && React.createElement("button", {
+            onClick: function() { onClick(item.guid); },
+            style: { flexShrink: 0, padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(125,211,252,.4)', background: 'rgba(125,211,252,.1)', color: btnColor || '#7dd3fc', cursor: 'pointer', fontSize: 11 }
+          }, "View →")
+        );
+      })
+    );
+  }
+
+  function renderDetail() {
+    if (detailSt === 'loading') return React.createElement("div", { className: "center" }, React.createElement("div", { className: "spinner" }));
+    if (detailSt === 'error') return React.createElement("div", { className: "center" }, React.createElement("span", { style: { color: '#f87171' } }, "Failed to load"));
+    if (!detail) return React.createElement("div", { className: "center" },
+      React.createElement("span", { style: { color: 'var(--dim)', fontSize: 13 } }, "Select an item from the list")
+    );
+
+    const colorMap = { specs: '#7dd3fc', structures: '#a5b4fc', fields: '#5eead4', grains: '#fda4af' };
+    const color = colorMap[subNav] || '#7dd3fc';
+
+    const fields = [
+      ['Qualified Name', detail.qualifiedName],
+      ['Version',        detail.versionIdentifier],
+      ['Namespace',      detail.namespace],
+      ['Data Type',      detail.dataType],
+      subNav === 'fields' ? ['Is Nullable',   detail.isNullable != null ? String(detail.isNullable) : ''] : null,
+      subNav === 'fields' ? ['Default Value', detail.defaultValue] : null,
+      subNav === 'fields' ? ['Min Length',    detail.minimumLength ? String(detail.minimumLength) : ''] : null,
+      subNav === 'fields' ? ['Length',        detail.length ? String(detail.length) : ''] : null,
+    ].filter(function(r) { return r && r[1] && String(r[1]).trim(); });
+
+    return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+      React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+        React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, detail.displayName || detail.qualifiedName),
+        React.createElement("span", { className: "badge", style: { background: 'rgba(125,211,252,.1)', color: color, border: '0.5px solid rgba(125,211,252,.3)' } }, detail.typeName || '')
+      ),
+      React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, detail.guid),
+      detail.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(detail.description)),
+      React.createElement(MermaidSection, { guid: detail.guid }),
+      fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+        React.createElement("tbody", null,
+          fields.map(function(row) {
+            return React.createElement("tr", { key: row[0], style: { borderTop: '1px solid var(--border)' } },
+              React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, row[0]),
+              React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(row[1])))
+            );
+          })
+        )
+      ),
+      subNav === 'specs'      && relSection("Contains Data Structures",   detail.containsDataStructures, function(g) { switchAndSelect('structures', g); }, '#a5b4fc'),
+      subNav === 'specs'      && relSection("Other Members",             (detail.members||[]).filter(function(m){ return m.typeName !== 'DataStructure'; }), null, '#e2e8f0'),
+      subNav === 'specs'      && relSection("Member of Collections",     detail.memberOfCollections,   null, '#7dd3fc'),
+      subNav === 'structures' && relSection("Contains Data Fields",      detail.containsDataFields,    function(g) { switchAndSelect('fields', g); }, '#5eead4'),
+      subNav === 'structures' && relSection("Member of Data Specs",      detail.memberOfDataSpecs,     null, '#7dd3fc'),
+      subNav === 'structures' && relSection("Member of Data Dicts",      detail.memberOfDataDicts,     null, '#7dd3fc'),
+      subNav === 'fields'     && relSection("Assigned Glossary Terms",   detail.assignedMeanings,      function(g) { onNavigateToGlossary && onNavigateToGlossary(g); }, '#86efac'),
+      subNav === 'fields'     && relSection("Part of Data Structures",   detail.partOfDataStructures,  function(g) { switchAndSelect('structures', g); }, '#a5b4fc'),
+      subNav === 'fields'     && relSection("Assigned Data Classes",     detail.assignedDataClasses,   null, '#7dd3fc'),
+      subNav === 'grains'     && relSection("Assigned Data Value Specs", detail.assignedDataValueSpecs, function(g) { switchAndSelect('specs', g); }, '#7dd3fc')
+    );
+  }
+
+  const curList = listStates[subNav];
+
+  return React.createElement("div", { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', gap: 4, padding: '8px 12px', borderBottom: '1px solid var(--border)', background: 'var(--surface)', flexShrink: 0 } },
+      SUB_NAVS.map(function(n) {
+        const st = listStates[n.key];
+        const active = subNav === n.key;
+        return React.createElement("button", {
+          key: n.key,
+          onClick: function() {
+            if (subNav === n.key) return;
+            setSubNav(n.key);
+            setSelGuid(null);
+            setDetail(null);
+            setDetailSt('idle');
+          },
+          style: { padding: '5px 14px', borderRadius: 5, border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: active ? 700 : 400, background: active ? 'rgba(125,211,252,.15)' : 'transparent', color: active ? n.color : 'var(--dim)', transition: 'all .15s' }
+        },
+          n.label,
+          st.st === 'ready' && st.items.length > 0 && React.createElement("span", { style: { marginLeft: 5, fontSize: 10, background: 'rgba(125,211,252,.1)', color: n.color, borderRadius: 10, padding: '1px 5px' } }, st.items.length)
+        );
+      })
+    ),
+    React.createElement("div", { style: { display: 'flex', flex: 1, overflow: 'hidden' } },
+      React.createElement("div", { style: { width: sideW, borderRight: '1px solid var(--border)', overflowY: 'auto', flexShrink: 0 } },
+        curList.st === 'loading'
+          ? React.createElement("div", { className: "center", style: { padding: 20 } }, React.createElement("div", { className: "spinner" }))
+          : curList.st === 'error'
+          ? React.createElement("div", { style: { padding: 12, color: '#f87171', fontSize: 13 } }, "Error: " + (curList.error || ''))
+          : curList.items.length === 0 && curList.st === 'ready'
+          ? React.createElement("div", { style: { padding: 12, color: 'var(--dim)', fontSize: 13 } }, "None found")
+          : curList.items.map(function(item) {
+              const active = item.guid === selGuid;
+              return React.createElement("div", {
+                key: item.guid,
+                onClick: function() { loadDetail(subNav, item.guid); },
+                style: { padding: '7px 12px', cursor: 'pointer', borderBottom: '1px solid var(--border)', background: active ? 'var(--hover)' : 'transparent', color: active ? 'var(--fg)' : 'var(--muted)' }
+              },
+                React.createElement("div", { style: { fontSize: 13, fontWeight: active ? 600 : 400, lineHeight: 1.3 } }, item.displayName || item.qualifiedName || item.guid),
+                item.description && React.createElement("div", { style: { fontSize: 11, color: 'var(--dim)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, item.description)
+              );
+            })
+      ),
+      React.createElement(ResizeDivider, { onMouseDown: onSideDivDown }),
+      React.createElement("div", { style: { flex: 1, overflow: 'hidden' } }, renderDetail())
+    )
+  );
+}
+
+function SolutionBlueprintDetail({ blueprint, onNavigateToComponent }) {
+  const [implState, setImplState] = useState('idle');
+  if (!blueprint) return null;
+  const fields = [
+    ['Qualified Name',     blueprint.qualifiedName],
+    ['Version',           blueprint.versionIdentifier],
+    ['Lifecycle Status',  blueprint.lifecycleStatus],
+    ['User Defined Status', blueprint.userDefinedStatus],
+    ['Status',            blueprint.status],
+  ].filter(([, v]) => v && String(v).trim());
+
+  return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+      React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, blueprint.displayName || blueprint.qualifiedName),
+      React.createElement("span", { className: "badge", style: { background: 'rgba(167,139,250,.1)', color: '#c4b5fd', border: '0.5px solid rgba(167,139,250,.3)' } }, blueprint.typeName || 'SolutionBlueprint')
+    ),
+    React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, blueprint.guid),
+    blueprint.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(blueprint.description)),
+    React.createElement(MermaidSection, { guid: blueprint.guid }),
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+      React.createElement("tbody", null,
+        fields.map(function([label, value]) {
+          return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
+            React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, label),
+            React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(value)))
+          );
+        })
+      )
+    ),
+    blueprint.components && blueprint.components.length > 0 && React.createElement("div", null,
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 8, color: 'var(--accent)' } }, "Solution Components (" + blueprint.components.length + ")"),
+      React.createElement("div", { style: { display: 'flex', flexDirection: 'column', gap: 4 } },
+        blueprint.components.map(function(c) {
+          return React.createElement("div", { key: c.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+            React.createElement("span", { style: { flex: 1 } }, c.displayName || c.qualifiedName),
+            c.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, c.typeName),
+            onNavigateToComponent && React.createElement("button", {
+              onClick: function() { onNavigateToComponent(c.guid); },
+              style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(167,139,250,.4)', background: 'rgba(167,139,250,.1)', color: '#c4b5fd', cursor: 'pointer', fontSize: 11 }
+            }, "View →")
+          );
+        })
+      )
+    )
+  );
+}
+
+function SolutionComponentDetail({ component, onNavigateToBlueprint, onNavigateToComponent }) {
+  const creds = React.useContext(CredContext);
+  const [implState, setImplState] = useState('idle');
+  const [implementations, setImplementations] = useState([]);
+
+  function loadImplementations() {
+    if (implState !== 'idle') return;
+    setImplState('loading');
+    fetch(credAppend('/api/solution/components/' + component.guid + '/implementations', creds))
+      .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(data => { setImplementations(data.implementations || []); setImplState('done'); })
+      .catch(() => setImplState('error'));
+  }
+
+  if (!component) return null;
+  const fields = [
+    ['Qualified Name',      component.qualifiedName],
+    ['Component Type',      component.componentType],
+    ['Version',            component.versionIdentifier],
+    ['Lifecycle Status',   component.lifecycleStatus],
+    ['User Defined Status', component.userDefinedStatus],
+    ['Status',             component.status],
+  ].filter(([, v]) => v && String(v).trim());
+
+  function relSection(title, items, onClick) {
+    if (!items || items.length === 0) return null;
+    return React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { fontWeight: 600, fontSize: 13, marginBottom: 6, color: 'var(--accent)' } }, title + " (" + items.length + ")"),
+      items.map(function(item) {
+        return React.createElement("div", { key: item.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, item.displayName || item.qualifiedName),
+          item.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' } }, item.typeName),
+          onClick && React.createElement("button", {
+            onClick: function() { onClick(item.guid); },
+            style: { padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(167,139,250,.4)', background: 'rgba(167,139,250,.1)', color: '#c4b5fd', cursor: 'pointer', fontSize: 11 }
+          }, "View →")
+        );
+      })
+    );
+  }
+
+  return React.createElement("div", { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4, flexWrap: 'wrap' } },
+      React.createElement("div", { style: { fontSize: 18, fontWeight: 700 } }, component.displayName || component.qualifiedName),
+      React.createElement("span", { className: "badge", style: { background: 'rgba(96,165,250,.1)', color: '#93c5fd', border: '0.5px solid rgba(96,165,250,.3)' } }, component.typeName || 'SolutionComponent')
+    ),
+    React.createElement("code", { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, component.guid),
+    component.description && React.createElement("div", { style: { fontSize: 13, marginBottom: 16 } }, renderMd(component.description)),
+    React.createElement(MermaidSection, { guid: component.guid }),
+    fields.length > 0 && React.createElement("table", { style: { width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 20 } },
+      React.createElement("tbody", null,
+        fields.map(function([label, value]) {
+          return React.createElement("tr", { key: label, style: { borderTop: '1px solid var(--border)' } },
+            React.createElement("td", { style: { padding: '6px 12px 6px 0', color: 'var(--dim)', whiteSpace: 'nowrap', width: 160, verticalAlign: 'top' } }, label),
+            React.createElement("td", { style: { padding: '6px 0' } }, renderMd(String(value)))
+          );
+        })
+      )
+    ),
+    relSection("Parent Blueprints", component.blueprints, onNavigateToBlueprint),
+    relSection("Parent Components", component.parentComponents, onNavigateToComponent),
+    relSection("Sub-components", component.subComponents, onNavigateToComponent),
+    relSection("Actors", component.actors, null),
+    relSection("Wired To", component.wiredTo, onNavigateToComponent),
+    relSection("Wired From", component.wiredFrom, onNavigateToComponent),
+    React.createElement("div", { style: { marginBottom: 16 } },
+      React.createElement("div", { style: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 } },
+        React.createElement("div", { style: { fontWeight: 600, fontSize: 13, color: 'var(--accent)' } }, "Implementations"),
+        implState === 'idle' && React.createElement("button", {
+          onClick: loadImplementations,
+          style: { padding: '2px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--hover)', cursor: 'pointer', fontSize: 11 }
+        }, "Load"),
+        implState === 'loading' && React.createElement("span", { style: { fontSize: 11, color: 'var(--dim)' } }, "Loading…"),
+        implState === 'error' && React.createElement("span", { style: { fontSize: 11, color: '#f87171' } }, "Failed to load"),
+      ),
+      implState === 'done' && implementations.length === 0 && React.createElement("div", { style: { fontSize: 13, color: 'var(--dim)' } }, "No implementations found"),
+      implState === 'done' && implementations.map(function(impl) {
+        return React.createElement("div", { key: impl.guid, style: { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '4px 0', borderTop: '1px solid var(--border)' } },
+          React.createElement("span", { style: { flex: 1 } }, impl.displayName || impl.qualifiedName),
+          impl.typeName && React.createElement("span", { className: "badge", style: { fontSize: 10, background: 'rgba(74,222,128,.1)', color: '#86efac', border: '0.5px solid rgba(74,222,128,.25)' } }, impl.typeName)
+        );
+      })
+    )
+  );
+}
+
+function SolutionArchitectView() {
+  const creds = React.useContext(CredContext);
+  const [sideW, onDivDown] = useResizable(260);
+  const [subNav, setSubNav] = useState('blueprints'); // 'blueprints' | 'components'
+
+  const [bpState, setBpState]   = useState('loading');
+  const [bpAttempt, setBpAttempt] = useState(0);
+  const [blueprints, setBlueprints] = useState([]);
+  const [bpError, setBpError]   = useState('');
+  const [selectedBp, setSelectedBp] = useState(null);
+  const [bpDetail, setBpDetail] = useState(null);
+  const [bpDetailState, setBpDetailState] = useState('idle');
+
+  const [compState, setCompState]   = useState('idle');
+  const [compAttempt, setCompAttempt] = useState(0);
+  const [components, setComponents] = useState([]);
+  const [compError, setCompError]   = useState('');
+  const [selectedComp, setSelectedComp] = useState(null);
+  const [compDetail, setCompDetail] = useState(null);
+  const [compDetailState, setCompDetailState] = useState('idle');
+
+  // Load blueprints
+  useEffect(function() {
+    setBpState('loading'); setBpError('');
+    fetch(credAppend('/api/solution/blueprints', creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setBlueprints(data.blueprints || []); setBpState('ready'); })
+      .catch(function(e) { setBpError(e.message); setBpState('error'); });
+  }, [bpAttempt]);
+
+  // Load components when sub-nav switches to components (lazy)
+  useEffect(function() {
+    if (subNav !== 'components' || compState !== 'idle') return;
+    setCompState('loading'); setCompError('');
+    fetch(credAppend('/api/solution/components', creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setComponents(data.components || []); setCompState('ready'); })
+      .catch(function(e) { setCompError(e.message); setCompState('error'); });
+  }, [subNav, compAttempt]);
+
+  // Fetch blueprint detail when selection changes
+  useEffect(function() {
+    if (!selectedBp) { setBpDetail(null); return; }
+    setBpDetailState('loading');
+    fetch(credAppend('/api/solution/blueprints/' + selectedBp, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setBpDetail(data); setBpDetailState('ready'); })
+      .catch(function() { setBpDetailState('error'); });
+  }, [selectedBp]);
+
+  // Fetch component detail when selection changes
+  useEffect(function() {
+    if (!selectedComp) { setCompDetail(null); return; }
+    setCompDetailState('loading');
+    fetch(credAppend('/api/solution/components/' + selectedComp, creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) { setCompDetail(data); setCompDetailState('ready'); })
+      .catch(function() { setCompDetailState('error'); });
+  }, [selectedComp]);
+
+  function onNavigateToBlueprint(guid) {
+    setSubNav('blueprints');
+    setSelectedBp(guid);
+  }
+
+  function onNavigateToComponent(guid) {
+    setSubNav('components');
+    if (compState === 'idle') setCompAttempt(function(a) { return a + 1; });
+    setSelectedComp(guid);
+  }
+
+  const sidebar = React.createElement("div", { style: { width: sideW, minWidth: sideW, display: 'flex', flexDirection: 'column', borderRight: '1px solid var(--border)', overflowY: 'auto', height: '100%' } },
+    // Sub-nav toggle
+    React.createElement("div", { style: { display: 'flex', borderBottom: '1px solid var(--border)', flexShrink: 0 } },
+      React.createElement("button", { onClick: function() { setSubNav('blueprints'); }, style: { flex: 1, padding: '8px 0', background: 'none', border: 'none', cursor: 'pointer', fontWeight: subNav === 'blueprints' ? 700 : 400, color: subNav === 'blueprints' ? 'var(--accent)' : 'var(--fg)', borderBottom: subNav === 'blueprints' ? '2px solid var(--accent)' : '2px solid transparent', fontSize: 13 } }, "Blueprints"),
+      React.createElement("button", { onClick: function() { setSubNav('components'); }, style: { flex: 1, padding: '8px 0', background: 'none', border: 'none', cursor: 'pointer', fontWeight: subNav === 'components' ? 700 : 400, color: subNav === 'components' ? 'var(--accent)' : 'var(--fg)', borderBottom: subNav === 'components' ? '2px solid var(--accent)' : '2px solid transparent', fontSize: 13 } }, "Components")
+    ),
+    // Blueprints list
+    subNav === 'blueprints' && React.createElement("div", { style: { overflowY: 'auto', flex: 1 } },
+      bpState === 'loading' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading blueprints…"),
+      bpState === 'error' && React.createElement("div", { style: { padding: 16 } },
+        React.createElement("div", { style: { color: '#f87171', fontSize: 13, marginBottom: 8 } }, "Error: " + bpError),
+        React.createElement("button", { className: "view-tab on", onClick: function() { setBpAttempt(function(a) { return a + 1; }); } }, "Retry")
+      ),
+      bpState === 'ready' && blueprints.length === 0 && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "No blueprints found"),
+      bpState === 'ready' && blueprints.map(function(bp) {
+        return React.createElement("div", {
+          key: bp.guid,
+          className: "tree-item" + (selectedBp === bp.guid ? " sel" : ""),
+          onClick: function() { setSelectedBp(bp.guid); },
+          title: bp.qualifiedName || bp.guid,
+        },
+          React.createElement("span", { className: "type-name" }, bp.displayName || bp.qualifiedName),
+          bp.lifecycleStatus && React.createElement("span", { className: "badge", style: { fontSize: 9, background: 'rgba(167,139,250,.1)', color: '#c4b5fd', border: '0.5px solid rgba(167,139,250,.3)', marginLeft: 4 } }, bp.lifecycleStatus)
+        );
+      })
+    ),
+    // Components list
+    subNav === 'components' && React.createElement("div", { style: { overflowY: 'auto', flex: 1 } },
+      compState === 'idle' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading components…"),
+      compState === 'loading' && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "Loading components…"),
+      compState === 'error' && React.createElement("div", { style: { padding: 16 } },
+        React.createElement("div", { style: { color: '#f87171', fontSize: 13, marginBottom: 8 } }, "Error: " + compError),
+        React.createElement("button", { className: "view-tab on", onClick: function() { setCompAttempt(function(a) { return a + 1; }); } }, "Retry")
+      ),
+      compState === 'ready' && components.length === 0 && React.createElement("div", { style: { padding: 16, color: 'var(--dim)', fontSize: 13 } }, "No components found"),
+      compState === 'ready' && components.map(function(c) {
+        return React.createElement("div", {
+          key: c.guid,
+          className: "tree-item" + (selectedComp === c.guid ? " sel" : ""),
+          onClick: function() { setSelectedComp(c.guid); },
+          title: c.qualifiedName || c.guid,
+        },
+          React.createElement("span", { className: "type-name" }, c.displayName || c.qualifiedName),
+          c.componentType && React.createElement("span", { className: "badge", style: { fontSize: 9, background: 'rgba(96,165,250,.1)', color: '#93c5fd', border: '0.5px solid rgba(96,165,250,.3)', marginLeft: 4 } }, c.componentType)
+        );
+      })
+    )
+  );
+
+  const mainPanel = React.createElement("div", { className: "main", style: { flex: 1, overflowY: 'auto' } },
+    subNav === 'blueprints' && React.createElement(React.Fragment, null,
+      !selectedBp && React.createElement("div", { className: "center" },
+        React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a blueprint from the sidebar")
+      ),
+      selectedBp && bpDetailState === 'loading' && React.createElement("div", { style: { padding: 24, color: 'var(--dim)' } }, "Loading…"),
+      selectedBp && bpDetailState === 'error' && React.createElement("div", { style: { padding: 24, color: '#f87171' } }, "Failed to load blueprint detail"),
+      selectedBp && bpDetailState === 'ready' && bpDetail && React.createElement(SolutionBlueprintDetail, { blueprint: bpDetail, onNavigateToComponent: onNavigateToComponent })
+    ),
+    subNav === 'components' && React.createElement(React.Fragment, null,
+      !selectedComp && React.createElement("div", { className: "center" },
+        React.createElement("span", { style: { color: 'var(--muted)' } }, "Select a component from the sidebar")
+      ),
+      selectedComp && compDetailState === 'loading' && React.createElement("div", { style: { padding: 24, color: 'var(--dim)' } }, "Loading…"),
+      selectedComp && compDetailState === 'error' && React.createElement("div", { style: { padding: 24, color: '#f87171' } }, "Failed to load component detail"),
+      selectedComp && compDetailState === 'ready' && compDetail && React.createElement(SolutionComponentDetail, {
+        component: compDetail,
+        onNavigateToBlueprint: onNavigateToBlueprint,
+        onNavigateToComponent: onNavigateToComponent
+      })
+    )
+  );
+
+  return React.createElement("div", { className: "body" },
+    sidebar,
+    React.createElement(ResizeDivider, { onMouseDown: onDivDown }),
+    mainPanel
+  );
+}
+
 function App() {
   const [creds, setCreds] = useState(function() {
     try {
@@ -3565,10 +4104,22 @@ function App() {
   const [view, setView]           = useState('types'); // 'types' | 'attrs'
   const [section, setSection]     = useState('splash'); // 'splash' | 'type-system' | 'reference-data' | 'digital-products' | 'glossary' | 'report-specs' | 'valid-values'
   const [glossaryNavGuid, setGlossaryNavGuid] = useState(null);
+  const [validValuesNavProp, setValidValuesNavProp] = useState(null);
+  const [dataDesignNavGuid, setDataDesignNavGuid] = useState(null);
 
   const onNavigateToGlossary = useCallback(function(guid) {
     setSection('glossary');
     setGlossaryNavGuid(guid);
+  }, []);
+
+  const onNavigateToValidValues = useCallback(function(propName) {
+    setValidValuesNavProp(propName);
+    setSection('valid-values');
+  }, []);
+
+  const onNavigateToDataSpec = useCallback(function(guid) {
+    setDataDesignNavGuid(guid);
+    setSection('data-design');
   }, []);
 
   const [typeSideW, onTypeDivDown] = useResizable(254);
@@ -3657,6 +4208,8 @@ function App() {
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('report-specs') }, "Report Specs"),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('valid-values') }, "Valid Values"),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('rest-apis') }, "REST APIs"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'solution-architect' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('solution-architect') }, "Solution Architect"),
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'data-design' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('data-design') }, "Data Design"),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
       section === 'type-system' && /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
       section === 'type-system' && view === 'types' && /*#__PURE__*/React.createElement("select", {
@@ -3690,11 +4243,15 @@ function App() {
       : section === 'reference-data'
       ? React.createElement(ReferenceDataView, null)
       : section === 'digital-products'
-      ? React.createElement(DigitalProductsView, { onNavigateToGlossary: onNavigateToGlossary })
+      ? React.createElement(DigitalProductsView, { onNavigateToGlossary: onNavigateToGlossary, onNavigateToDataSpec: onNavigateToDataSpec })
       : section === 'valid-values'
-      ? React.createElement(ValidValuesView, null)
+      ? React.createElement(ValidValuesView, { navProp: validValuesNavProp })
       : section === 'rest-apis'
       ? React.createElement(RestApiView, null)
+      : section === 'solution-architect'
+      ? React.createElement(SolutionArchitectView, null)
+      : section === 'data-design'
+      ? React.createElement(DataDesignView, { navSpecGuid: dataDesignNavGuid, onNavigateToGlossary: onNavigateToGlossary })
       : section !== 'type-system'
       ? /*#__PURE__*/React.createElement(PlaceholderView, { section: section })
       : view === 'attrs'
@@ -3703,7 +4260,7 @@ function App() {
           /*#__PURE__*/React.createElement(Sidebar, { selected: selected, onSelect: onSelect, data: data, width: typeSideW }),
           /*#__PURE__*/React.createElement(ResizeDivider, { onMouseDown: onTypeDivDown }),
           /*#__PURE__*/React.createElement("div", { className: "main" },
-            selected.kind === 'type' && (entities[selected.name] || allEntities[selected.name]) && /*#__PURE__*/React.createElement(TypeDetail, { name: selected.name, entities: allEntities, relationships: relationships, onSelect: onSelect }),
+            selected.kind === 'type' && (entities[selected.name] || allEntities[selected.name]) && /*#__PURE__*/React.createElement(TypeDetail, { name: selected.name, entities: allEntities, relationships: relationships, onSelect: onSelect, onNavigateProp: onNavigateToValidValues }),
             selected.kind === 'classif' && classifications[selected.name] && /*#__PURE__*/React.createElement(ClassifDetail, { name: selected.name, classifications: classifications }),
             selected.kind === 'rel' && relationships[selected.name] && /*#__PURE__*/React.createElement(RelDetail, { name: selected.name, relationships: relationships, onSelect: onSelect }),
             !selected.name && /*#__PURE__*/React.createElement("div", { className: "center" },

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/valid_values_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/valid_values_handler.py
@@ -7,7 +7,6 @@ Valid Metadata Values Explorer — FastAPI router.
 Endpoints:
   GET /api/valid-values/properties  → property names that have registered valid values
   GET /api/valid-values/lookup      → valid values for a specific Egeria property name
-  GET /api/valid-values/debug       → raw find_metadata_elements response (for diagnosis)
 """
 
 import os
@@ -125,42 +124,6 @@ def _names_from_raw(raw) -> set:
         if n:
             names.add(n)
     return names
-
-
-@router.get("/api/valid-values/debug", summary="Debug: raw find_metadata_elements response structure")
-def debug_valid_value_properties(
-    url:     Optional[str] = Query(None),
-    server:  Optional[str] = Query(None),
-    user_id: Optional[str] = Query(None),
-    user_pwd:Optional[str] = Query(None),
-):
-    """Return diagnostic information about the raw find_metadata_elements response."""
-    try:
-        mgr = _get_expert(url, server, user_id, user_pwd)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Connection failed: {exc}")
-
-    try:
-        raw = mgr.find_metadata_elements(_FIND_BODY)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"find_metadata_elements failed: {exc}")
-
-    first = None
-    if isinstance(raw, list) and raw:
-        first = raw[0]
-    elif isinstance(raw, dict):
-        elems = raw.get("elements") or raw.get("elementsAsStrings") or []
-        first = elems[0] if elems else None
-
-    return JSONResponse({
-        "raw_type":        type(raw).__name__,
-        "raw_length":      len(raw) if isinstance(raw, (list, str)) else None,
-        "raw_keys":        list(raw.keys()) if isinstance(raw, dict) else None,
-        "first_item_type": type(first).__name__ if first is not None else None,
-        "first_item_keys": list(first.keys()) if isinstance(first, dict) else None,
-        "first_item":      first,
-        "names_extracted": sorted(_names_from_raw(raw)),
-    })
 
 
 @router.get("/api/valid-values/properties", summary="List property names that have registered valid values")

--- a/templates/advanced/Actor Manager/Create_Governance_Role.md
+++ b/templates/advanced/Actor Manager/Create_Governance_Role.md
@@ -1,0 +1,450 @@
+___
+
+## Create Governance Role
+> Creates or updates a governance role — a role that may be performed by people.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Headcount
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The expected number of holders of this role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_IT_Profile_Role.md
+++ b/templates/advanced/Actor Manager/Create_IT_Profile_Role.md
@@ -1,0 +1,442 @@
+___
+
+## Create IT Profile Role
+> Creates or updates an IT profile role — a role that may be performed by IT profiles (engines, services, automated processes).
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Organization.md
+++ b/templates/advanced/Actor Manager/Create_Organization.md
@@ -1,0 +1,442 @@
+___
+
+## Create Organization
+> Creates or updates an organization — a special type of team that is the root of a hierarchy of teams, representing a collection of people and resources with a particular purpose (business, non-profit, governance department).
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Team Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of team (e.g. Department, Division, BusinessUnit). Open string until a controlled vocabulary is established.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Person.md
+++ b/templates/advanced/Actor Manager/Create_Person.md
@@ -1,0 +1,530 @@
+___
+
+## Create Person
+> Creates or updates a person — an individual who acts in one or more roles in the organization.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Courtesy Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A courtesy title prefix for the person (e.g. Mr, Ms, Dr, Prof).
+
+
+### Employee Number
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's organizational employee number or identifier.
+
+
+### Employee Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of employment relationship (e.g. Permanent, Contractor, Intern). Open string until a controlled vocabulary is established.
+
+
+### Full Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's full name as it should be displayed.
+
+
+### Given Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's given (first) names.
+
+
+### Initials
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's initials.
+
+
+### Job Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's job title (e.g. Senior Data Architect).
+
+
+### Preferred Language
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's preferred language for communication (e.g. en, en-US, fr).
+
+
+### Pronouns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's preferred pronouns.
+
+
+### Resident Country
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The country in which the person resides.
+
+
+### Surname
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's surname (family name).
+
+
+### Time Zone
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's time zone (e.g. America/New_York, Europe/London).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Person_Role.md
+++ b/templates/advanced/Actor Manager/Create_Person_Role.md
@@ -1,0 +1,450 @@
+___
+
+## Create Person Role
+> Creates or updates a person role — a role that may be performed by people.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Headcount
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The expected number of holders of this role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Perspective.md
+++ b/templates/advanced/Actor Manager/Create_Perspective.md
@@ -1,0 +1,434 @@
+___
+
+## Create Perspective
+> Creates or updates a perspective — a viewpoint or standpoint held by an actor.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Skill.md
+++ b/templates/advanced/Actor Manager/Create_Skill.md
@@ -1,0 +1,462 @@
+___
+
+## Create Skill
+> Creates or updates a skill — a capability or competency held by an actor.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Team.md
+++ b/templates/advanced/Actor Manager/Create_Team.md
@@ -1,0 +1,442 @@
+___
+
+## Create Team
+> Creates or updates a team — a group of people organized to support a specific goal or responsibility.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Team Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of team (e.g. Department, Division, BusinessUnit). Open string until a controlled vocabulary is established.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Create_Team_Role.md
+++ b/templates/advanced/Actor Manager/Create_Team_Role.md
@@ -1,0 +1,450 @@
+___
+
+## Create Team Role
+> Creates or updates a team role — a role that may be performed by teams.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Headcount
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The expected number of holders of this role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Assignment_Scope.md
+++ b/templates/advanced/Actor Manager/Link_Assignment_Scope.md
@@ -1,0 +1,110 @@
+___
+
+## Link Assignment Scope
+> Assigns an actor (or actor role) responsibility for a defined scope, where the scope is identified by any Referenceable using the AssignmentScope relationship.
+
+### Assigned Actor
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Actor (or ActorRole) being assigned a scope.
+
+
+### Assignment Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of assignment relating an actor to assignmentScoped referenceable.
+
+
+### Scope Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Referenceable that defines the scope of the assignment.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Associated_Skill_Set.md
+++ b/templates/advanced/Actor Manager/Link_Associated_Skill_Set.md
@@ -1,0 +1,132 @@
+___
+
+## Link Associated Skill Set
+> Links an actor to a skill set.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Actor Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the actor (role or person) associated with this agreement relationship.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### SkillSet Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Skillset to assign.
+
+>	**Alternative Labels**: SkillSet
+
+
+___

--- a/templates/advanced/Actor Manager/Link_IT_Profile_Role_Appointment.md
+++ b/templates/advanced/Actor Manager/Link_IT_Profile_Role_Appointment.md
@@ -1,0 +1,94 @@
+___
+
+## Link IT Profile Role Appointment
+> Appoints an IT profile to an IT profile role using ITProfileAppointment relationship.
+
+### IT Profile
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of an ITProfile.
+
+
+### IT Profile Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of an ITProfileRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Person_Role_Appointment.md
+++ b/templates/advanced/Actor Manager/Link_Person_Role_Appointment.md
@@ -1,0 +1,102 @@
+___
+
+## Link Person Role Appointment
+> Appoints a person to a person role with an expected time allocation percentage using PersonRoleAppointment relationship.
+
+### Expected Time Allocation Percent
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Expected percentage of the appointee's time to be allocated to this role appointment (0-100).
+
+
+### Person
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a Person.
+
+
+### Person Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a PersonRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Perspective_to_Question.md
+++ b/templates/advanced/Actor Manager/Link_Perspective_to_Question.md
@@ -1,0 +1,130 @@
+___
+
+## Link Perspective to Question
+> Links a Perspective to a Question via a ScopedBy relationship.
+
+### Perspective Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Perspective.
+
+
+### Question Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Question (a GlossaryTerm with IsQuestion classification).
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Team_Leader.md
+++ b/templates/advanced/Actor Manager/Link_Team_Leader.md
@@ -1,0 +1,96 @@
+___
+
+## Link Team Leader
+> Links a team to a TeamLeader role (a PersonRole subtype) that leads it using AssignmentScope relationship.
+>
+>	**Alternative Names**: Link Team Leadership
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Leader Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the TeamLeader role (a PersonRole subtype).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Team_Membership.md
+++ b/templates/advanced/Actor Manager/Link_Team_Membership.md
@@ -1,0 +1,94 @@
+___
+
+## Link Team Membership
+> Links a team to a TeamMember role (a PersonRole subtype) representing membership in the team using the AssignmentScope relationship.
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Member Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the TeamMember role (a PersonRole subtype).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Team_Role_Appointment.md
+++ b/templates/advanced/Actor Manager/Link_Team_Role_Appointment.md
@@ -1,0 +1,102 @@
+___
+
+## Link Team Role Appointment
+> Appoints a team to a team role with an expected time allocation percentage using TeamRoleAppointment relationship.
+
+### Expected Time Allocation Percent
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Expected percentage of the appointee's time to be allocated to this role appointment (0-100).
+
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a TeamRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Actor Manager/Link_Team_Structure.md
+++ b/templates/advanced/Actor Manager/Link_Team_Structure.md
@@ -1,0 +1,94 @@
+___
+
+## Link Team Structure
+> Links a parent (super) team to a child (sub) team in an organization's hierarchical team structure.
+
+### Sub Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the child (sub) team in a team hierarchy.
+
+
+### Super Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the parent (super) team in a team hierarchy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+___

--- a/templates/advanced/Collections/Add_Member_to_Collection.md
+++ b/templates/advanced/Collections/Add_Member_to_Collection.md
@@ -1,0 +1,160 @@
+___
+
+## Add Member to Collection
+> Add/Remove a member to/from a collection.
+>
+>	**Alternative Names**: Member; Member to Collection; Member to Folder; Member->Collection; Member from Collection; Member from Folder
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Collections/Attach_Collection_to_Resource.md
+++ b/templates/advanced/Collections/Attach_Collection_to_Resource.md
@@ -1,0 +1,156 @@
+___
+
+## Attach Collection to Resource
+> Connect an existing collection to an element using the ResourceList relationship.
+>
+>	**Alternative Names**: Collection to Resource; Collection from Resource
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Resource Use
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Describes how the resource is being used. From the ResourceList relationship (0019).
+
+>	**Valid Values**: Validate Resource,Hosted Service,Supporting Template,Called Service,Supporting Person,Member Template,Supporting Team,Derived Element Template,Generate Insight,Activity Folder,Inform Steward,Certify Resource,Provision Resource,Hosted Connector,Improve Metadata Element,Survey Resource,Hosted Governance Engine,Watch Metadata Element,Data Specification,Choose Path,Supporting Process,Configure Connector,Catalog Resource,Create Subscription,Uncatalog Resource,Related Information,Cancel Subscription
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Collection.md
+++ b/templates/advanced/Collections/Create_Collection.md
@@ -1,0 +1,470 @@
+___
+
+## Create Collection
+> Create or update a generic collection. While it can be used to create specific kinds of collections, you cannot set the collection-specific properties - so use the appropriate Dr.Egeria command to set all of the properties.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Collection_Folder.md
+++ b/templates/advanced/Collections/Create_Collection_Folder.md
@@ -1,0 +1,472 @@
+___
+
+## Create Collection Folder
+> Create a CollectionFolder - a collection used to organize subsets of metadata elements within a larger collection hierarchy.
+>
+>	**Alternative Names**: Folder; Folders
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Folio.md
+++ b/templates/advanced/Collections/Create_Folio.md
@@ -1,0 +1,472 @@
+___
+
+## Create Folio
+> Create a Folio - a  collection of your work.
+>
+>	**Alternative Names**: Folio Collection
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Home_Collection.md
+++ b/templates/advanced/Collections/Create_Home_Collection.md
@@ -1,0 +1,470 @@
+___
+
+## Create Home Collection
+> Create a home collection to store things like favorites.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Namespace.md
+++ b/templates/advanced/Collections/Create_Namespace.md
@@ -1,0 +1,470 @@
+___
+
+## Create Namespace
+> Create a Namespace collection - a collection of elements organized by namespace.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Question_Spec.md
+++ b/templates/advanced/Collections/Create_Question_Spec.md
@@ -1,0 +1,470 @@
+___
+
+## Create Question Spec
+> Creates or updates a CollectionFolder containing a question specification, identified by a qualified name beginning with QuestionSpec.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Recent_Access.md
+++ b/templates/advanced/Collections/Create_Recent_Access.md
@@ -1,0 +1,470 @@
+___
+
+## Create Recent Access
+> Create a RecentAccess collection - a collection of elements accessed recently by a user.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Reference_List.md
+++ b/templates/advanced/Collections/Create_Reference_List.md
@@ -1,0 +1,470 @@
+___
+
+## Create Reference List
+> Create a collection to hold lists of references.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Results_Set.md
+++ b/templates/advanced/Collections/Create_Results_Set.md
@@ -1,0 +1,470 @@
+___
+
+## Create Results Set
+> Create a ResultsSet collection - a collection of elements that are the results from a specific request or query.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Root_Collection.md
+++ b/templates/advanced/Collections/Create_Root_Collection.md
@@ -1,0 +1,472 @@
+___
+
+## Create Root Collection
+> Create a RootCollection - a master collection serving as the starting node for an independent collection hierarchy.
+>
+>	**Alternative Names**: Root Collection
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Security_Group.md
+++ b/templates/advanced/Collections/Create_Security_Group.md
@@ -1,0 +1,478 @@
+___
+
+## Create Security Group
+> A group (collection) of actors that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Security_List.md
+++ b/templates/advanced/Collections/Create_Security_List.md
@@ -1,0 +1,478 @@
+___
+
+## Create Security List
+> A group (collection) of identities that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Security_Role.md
+++ b/templates/advanced/Collections/Create_Security_Role.md
@@ -1,0 +1,478 @@
+___
+
+## Create Security Role
+> A group (collection) of roles that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Skill_Set.md
+++ b/templates/advanced/Collections/Create_Skill_Set.md
@@ -1,0 +1,470 @@
+___
+
+## Create Skill Set
+> Create a collection to hold a group of skills.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Subject_Area.md
+++ b/templates/advanced/Collections/Create_Subject_Area.md
@@ -1,0 +1,470 @@
+___
+
+## Create Subject Area
+> Create a SubjectArea - a  collection of material on the same topic.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Collections/Create_Work_Item_List.md
+++ b/templates/advanced/Collections/Create_Work_Item_List.md
@@ -1,0 +1,470 @@
+___
+
+## Create Work Item List
+> Create a WorkItemList collection - a collection organizing work items such as ToDos or Tasks.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Assign_Data_Value_Specification.md
+++ b/templates/advanced/Data Designer/Assign_Data_Value_Specification.md
@@ -1,0 +1,118 @@
+___
+
+## Assign Data Value Specification
+> Link a data value specification, DataClass, DataGrain,  to a referenceable element providing a definition.
+>
+>	**Alternative Names**: Link Data Value Specification; Attach Data Value Specification to Element
+
+### Data Value Specification
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Assignment Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Status of a value assignment.
+
+>	**Valid Values**: DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: DISCOVERED
+
+
+### Method
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A method for value assignment.
+
+
+### Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Threshold  for assignment.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Data Designer/Attach_Data_Description_to_Element.md
+++ b/templates/advanced/Data Designer/Attach_Data_Description_to_Element.md
@@ -1,0 +1,135 @@
+___
+
+## Attach Data Description to Element
+> Connect an existing data describing collection to an element using the DataDescription relationship (0580).
+
+>
+>	**Alternative Names**: Attach Data Description->Element
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Class.md
+++ b/templates/advanced/Data Designer/Create_Data_Class.md
@@ -1,0 +1,662 @@
+___
+
+## Create Data Class
+> Creates or updates a data class — a description of the values that may be stored in data fields. Supports composition via Containing Data Class and specialization via Specializes Data Class. Can be used to configure quality validators and data field classifiers.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Allow Duplicate Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the data class allows duplicate values in the data field.
+
+>	**Default Value**: true
+
+
+### Average Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A typical or average value for the data class, used in data quality assessments.
+
+
+### Containing Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that this data class is composed within (DataClassComposition relationship).
+
+
+### Data Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Regular expressions or patterns that describe the format of valid values for this data class.
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### Is Case Sensitive
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, values for this data class or field are case-sensitive.
+
+>	**Default Value**: false
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Sample Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Representative example values that illustrate the expected content of this data class or field.
+
+
+### Value List
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: An enumerated list of valid values for this data class.
+
+
+### Value Range From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The lower bound of the valid value range for this data class.
+
+
+### Value Range To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The upper bound of the valid value range for this data class.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Dictionary.md
+++ b/templates/advanced/Data Designer/Create_Data_Dictionary.md
@@ -1,0 +1,472 @@
+___
+
+## Create Data Dictionary
+> Creates or updates a data dictionary — an organized collection of defined data fields serving as a knowledge base of preferred data definitions. Implemented as a Collection with the DataDictionary classification.
+>
+>	**Alternative Names**: Data Dict
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Field.md
+++ b/templates/advanced/Data Designer/Create_Data_Field.md
@@ -1,0 +1,780 @@
+___
+
+## Create Data Field
+> Creates or updates a data field — a named, typed element within a data structure. Supports nesting via In Data Field and data class assignment.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### In Data Field
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data field that this element is nested within (NestedDataField relationship).
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of characters or digits allowed in the field.
+
+
+### Maximum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of times this field may appear in the containing data structure (-1 means unbounded).
+
+>	**Default Value**: 1
+
+
+### Minimum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of times this field must appear in the containing data structure.
+
+>	**Default Value**: 1
+
+
+### Minimum Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of characters or digits required in the field.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Ordered Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the values in this field are ordered (i.e. sequence matters).
+
+
+### Position
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The ordinal position of the data field within its containing data structure.
+
+>	**Default Value**: 0
+
+
+### Precision
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of significant digits after the decimal point for numeric fields.
+
+
+### Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The sort order for values in this field. Valid values from DataItemSortOrder enum: UNKNOWN, UNSORTED, ASCENDING, DESCENDING, OTHER.
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Allow Duplicate Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the data class allows duplicate values in the data field.
+
+>	**Default Value**: true
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### In Data Field
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data field that this element is nested within (NestedDataField relationship).
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of characters or digits allowed in the field.
+
+
+### Maximum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of times this field may appear in the containing data structure (-1 means unbounded).
+
+>	**Default Value**: 1
+
+
+### Minimum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of times this field must appear in the containing data structure.
+
+>	**Default Value**: 1
+
+
+### Minimum Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of characters or digits required in the field.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Ordered Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the values in this field are ordered (i.e. sequence matters).
+
+
+### Position
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The ordinal position of the data field within its containing data structure.
+
+>	**Default Value**: 0
+
+
+### Precision
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of significant digits after the decimal point for numeric fields.
+
+
+### Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The sort order for values in this field. Valid values from DataItemSortOrder enum: UNKNOWN, UNSORTED, ASCENDING, DESCENDING, OTHER.
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Grain.md
+++ b/templates/advanced/Data Designer/Create_Data_Grain.md
@@ -1,0 +1,592 @@
+___
+
+## Create Data Grain
+> Creates or updates a data grain — a defined granularity of data that can be associated with a data field or data lens.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Granularity Basis
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The basis on which the granularity is defined (e.g. time period, geographic region, customer segment). UML type: string — no enum defined in Egeria open types.
+
+
+### Grain Statement
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A human-readable statement describing the granularity of the data grain (e.g. 'one row per customer per day').
+
+
+### Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The time interval in milliseconds between data captures for time-based data grains.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Spec.md
+++ b/templates/advanced/Data Designer/Create_Data_Spec.md
@@ -1,0 +1,472 @@
+___
+
+## Create Data Spec
+> Creates or updates a data specification — a collection describing the data requirements for a project or initiative. Its members are typically data structures. Implemented as a Collection with the DataSpec classification.
+>
+>	**Alternative Names**: Data Specification
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Structure.md
+++ b/templates/advanced/Data Designer/Create_Data_Structure.md
@@ -1,0 +1,518 @@
+___
+
+## Create Data Structure
+> Creates or updates a data structure — a collection of data fields that defines the structure for a data source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### In Data Dictionary
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data dictionary that contains this data structure.
+
+
+### In Data Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data specification that contains this data structure.
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### In Data Dictionary
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data dictionary that contains this data structure.
+
+
+### In Data Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data specification that contains this data structure.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Data_Value_Specification.md
+++ b/templates/advanced/Data Designer/Create_Data_Value_Specification.md
@@ -1,0 +1,568 @@
+___
+
+## Create Data Value Specification
+> Creates or updates a data value classification which represents the characteristics of a data value. DataClass and DataGrain are subtypes.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Create_Report_Type.md
+++ b/templates/advanced/Data Designer/Create_Report_Type.md
@@ -1,0 +1,494 @@
+___
+
+## Create Report Type
+> A type of report that inherits from Data Spec (and Collection)
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Last Modifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Who made the last modification.
+
+
+### Last Modified Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element  was last modified.
+
+
+### Created Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element  was created.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Data Designer/Link_Certification_Type_to_Data_Structure.md
+++ b/templates/advanced/Data Designer/Link_Certification_Type_to_Data_Structure.md
@@ -1,0 +1,130 @@
+___
+
+## Link Certification Type to Data Structure
+> Link a data structure to a certification type. In defining a certification type,  this assigns the data structure to this type of certification.
+
+### Data Structure
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data structure name. Preferably a qualified name.
+
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Data Designer/Link_Data_Class_Composition.md
+++ b/templates/advanced/Data Designer/Link_Data_Class_Composition.md
@@ -1,0 +1,130 @@
+___
+
+## Link Data Class Composition
+> Link a child data class to a parent data class. 
+
+### Data Class Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Data Designer/Link_Data_Field.md
+++ b/templates/advanced/Data Designer/Link_Data_Field.md
@@ -1,0 +1,146 @@
+___
+
+## Link Data Field
+> Links or unlinks two data fields via the LinkedDataField relationship, with an optional relationship type name to describe the nature of the association (e.g. ForeignKey, DerivedFrom).
+
+### Linked Data Field 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first data field in a LinkedDataField peer relationship.
+
+
+### Linked Data Field 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second data field in a LinkedDataField peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Link Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the relationship used in a LinkedDataField connection.
+
+
+### Link Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the relationship used in a LinkedDataField connection.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Data Designer/Link_Data_Field_to_Data_Structure.md
+++ b/templates/advanced/Data Designer/Link_Data_Field_to_Data_Structure.md
@@ -1,0 +1,132 @@
+___
+
+## Link Data Field to Data Structure
+> Links a data field to a data structure via the MemberDataField relationship.
+>
+>	**Alternative Names**: Link Data Field to Structure; Link Field to Structure
+
+### Data Field
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data field  name. Preferably a qualified name.
+
+
+### Data Structure
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data structure name. Preferably a qualified name.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Data Designer/Link_Data_Value_Composition.md
+++ b/templates/advanced/Data Designer/Link_Data_Value_Composition.md
@@ -1,0 +1,130 @@
+___
+
+## Link Data Value Composition
+> Link a data value specification, DataClass, DataGrain,  to a referenceable element providing a definition.
+
+### Data Value Specification
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Data Value Specification Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_Agreement.md
+++ b/templates/advanced/Digital Product Manager/Create_Agreement.md
@@ -1,0 +1,478 @@
+___
+
+## Create Agreement
+> A kind of collection that represents an Agreement. This is for generic agreements. Specific kinds of agreements have their own commands.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_CSV_File.md
+++ b/templates/advanced/Digital Product Manager/Create_CSV_File.md
@@ -1,0 +1,502 @@
+___
+
+## Create CSV File
+> Create a CSV File asset.
+>
+>	**Alternative Names**: Create CSV
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### File Encoding
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Encoding of the file.
+
+>	**Default Value**: UTF-8
+
+
+### File Extension
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Typically CSV.
+
+>	**Default Value**: csv
+
+
+### File Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Path to the file including file name. File system name is pre-pended if set.
+
+>	**Alternative Labels**: File Path Name
+
+
+### File System Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Optional  file system name to be prepended in front of the path name.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_Data_Sharing_Agreement.md
+++ b/templates/advanced/Digital Product Manager/Create_Data_Sharing_Agreement.md
@@ -1,0 +1,478 @@
+___
+
+## Create Data Sharing Agreement
+> Create a new collection with the DataSharingAgreement classification.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_Digital_Product.md
+++ b/templates/advanced/Digital Product Manager/Create_Digital_Product.md
@@ -1,0 +1,544 @@
+___
+
+## Create Digital Product
+> A Digital Product represents artifacts that can be subscribed to and consumed by users.
+>
+>	**Alternative Names**: Data Product
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Current Version
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The current version identifier of the digital product.
+
+
+### Introduction Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of product introduction in ISO 8601 format.
+
+
+### Maturity
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Product maturity - user defined.
+
+
+### Next Version Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the next version of the digital product is expected, in ISO 8601 format.
+
+
+### Product Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The human-readable name of the digital product.
+
+
+### Product Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Lifecycle status of the digital product.
+
+
+### Product Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of digital product (e.g., Periodic Delta, On Demand, Snapshot).
+
+
+### Service Life
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The estimated operational lifetime of the digital product.
+
+
+### Withdrawal Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of planned product withdrawal in ISO 8601 format.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_Digital_Product_Catalog.md
+++ b/templates/advanced/Digital Product Manager/Create_Digital_Product_Catalog.md
@@ -1,0 +1,470 @@
+___
+
+## Create Digital Product Catalog
+> Create a Digital Product Catalog - a root collection that organizes digital products into a browsable catalog.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Create_Digital_Subscription.md
+++ b/templates/advanced/Digital Product Manager/Create_Digital_Subscription.md
@@ -1,0 +1,496 @@
+___
+
+## Create Digital Subscription
+> A type of agreement for a digital subscription.
+>
+>	**Alternative Names**: Create Product Subscription
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Subscription Level
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Level or tier of the subscription (e.g., basic, premium, enterprise).
+
+
+### Support Level
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Level of support provided with the subscription (e.g., community, business hours, 24/7).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Digital Product Manager/Link_Agreement_Actor.md
+++ b/templates/advanced/Digital Product Manager/Link_Agreement_Actor.md
@@ -1,0 +1,140 @@
+___
+
+## Link Agreement Actor
+> Link an actor (role or person) to an Agreement, defining their role and responsibilities within it.
+>
+>	**Alternative Names**: Agreement to Actor; Agreement from Actor
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Actor Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the actor (role or person) associated with this agreement relationship.
+
+
+### Actors
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Actors or Solution Roles related to this element.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Digital Product Manager/Link_Agreement_Item.md
+++ b/templates/advanced/Digital Product Manager/Link_Agreement_Item.md
@@ -1,0 +1,204 @@
+___
+
+## Link Agreement Item
+> Attach or detach an agreement to an element referenced in its definition. Agreement item can be any referenceable element.
+>
+>	**Alternative Names**: Agreement from Item; Agreement to Item
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Item Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the referenceable item to add to an agreement. Using qualified names is recommended.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Agreement End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the agreement expires or was terminated, in ISO 8601 format.
+
+
+### Agreement Item Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified agreement item identifier.
+
+
+### Agreement Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the agreement becomes effective, in ISO 8601 format.
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Usage Measurements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing usage measurements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Digital Product Manager/Link_Contract.md
+++ b/templates/advanced/Digital Product Manager/Link_Contract.md
@@ -1,0 +1,164 @@
+___
+
+## Link Contract
+> Attach or detach an agreement to a related document with the ContractLink relationship
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Contract Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified contract identifier.
+
+
+### Contract Liaison
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The liaison for a contract.
+
+
+### Contract Liaison Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property to use for the contract liaison.
+
+
+### Contract Liaison Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The liason for a contract.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Digital Product Manager/Link_Digital_Subscriber.md
+++ b/templates/advanced/Digital Product Manager/Link_Digital_Subscriber.md
@@ -1,0 +1,136 @@
+___
+
+## Link Digital Subscriber
+> Attach or detach a subscriber to a subscription. Subscriber can be any type of element.
+>
+>	**Alternative Names**: Subscriber to Subscription; Subscribers; Subscribers from Subscription
+
+### Subscriber Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Referenceable acting as subscriber in a DigitalSubscriber relationship.
+
+>	**Alternative Labels**: Subscriber; Subscriber ID
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Subscription Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the DigitalSubscription being subscribed to.
+
+>	**Alternative Labels**: Subscription;Subscription ID
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Digital Product Manager/Link_Product_Dependency.md
+++ b/templates/advanced/Digital Product Manager/Link_Product_Dependency.md
@@ -1,0 +1,148 @@
+___
+
+## Link Product Dependency
+> Link digital product dependency between two digital products.
+>
+>	**Alternative Names**: Digital Product - Digital Product; Digital Product to Digital Product; Digital Products
+
+### Digital Product 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first Digital Product in a DigitalProductDependency relationship.
+
+
+### Digital Product 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second Digital Product in a DigitalProductDependency relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Dependency Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Description of the dependency between two digital products.
+
+
+### Dependency Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Description of the dependency between two digital products.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/External Reference/Create_Cited_Document.md
+++ b/templates/advanced/External Reference/Create_Cited_Document.md
@@ -1,0 +1,618 @@
+___
+
+## Create Cited Document
+> Create or update a Cited Document - an external reference to a published document with full bibliographic metadata.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Edition
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The edition being cited.
+
+
+### First Publication Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of first publication in ISO 8601 format (e.g. 2025-01-31).
+
+
+### Number of Pages
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of pages in the document.
+
+
+### Page Range
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The range of pages cited.
+
+
+### Publication City
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: City of publication.
+
+
+### Publication Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Publication date in ISO 8601 format (e.g. 2025-02-23).
+
+
+### Publication Numbers
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Identification numbers of the publication (ISBN, ISSN, DOI, etc.).
+
+
+### Publication Series
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The series this publication is part of.
+
+>	**Alternative Labels**: Series
+
+
+### Publication Series Volume
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The volume in the series that contains the citation.
+
+
+### Publication Year
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Year of publication.
+
+
+### Publisher
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the publisher.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Create_External_Data_Source.md
+++ b/templates/advanced/External Reference/Create_External_Data_Source.md
@@ -1,0 +1,528 @@
+___
+
+## Create External Data Source
+> Create or update an External Data Source - an external reference that refers to an external data source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Create_External_Model_Source.md
+++ b/templates/advanced/External Reference/Create_External_Model_Source.md
@@ -1,0 +1,528 @@
+___
+
+## Create External Model Source
+> Create or update an External Model Source - an external reference that refers to an external analytical or AI model source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Create_External_Reference.md
+++ b/templates/advanced/External Reference/Create_External_Reference.md
@@ -1,0 +1,528 @@
+___
+
+## Create External Reference
+> Create or update an External Reference - a Referenceable that describes an external source of information.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Create_External_Source_Code.md
+++ b/templates/advanced/External Reference/Create_External_Source_Code.md
@@ -1,0 +1,528 @@
+___
+
+## Create External Source Code
+> Create or update an External Source Code reference - an external reference that refers to software source code. If the component created from this source code is catalogued, it is linked to the ExternalSourceCode using the ExternalReferenceLink relationship.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Create_Related_Media.md
+++ b/templates/advanced/External Reference/Create_Related_Media.md
@@ -1,0 +1,566 @@
+___
+
+## Create Related Media
+> Create or update Related Media - an external reference to media such as images, audio, video or documents.
+>
+>	**Alternative Names**: Media
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Default Media Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How the media is being used by default.
+
+>	**Valid Values**: ICON,THUMBNAIL,ILLUSTRATION,USAGE_GUIDANCE,OTHER
+
+
+### Default Media Usage Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the default media usage when not using a standard valid value.
+
+
+### Media Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Type of media (e.g. image, audio, video, document).
+
+>	**Valid Values**: IMAGE,AUDIO,DOCUMENT,VIDEO,OTHER
+
+
+### Media Type Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the media type when not using a standard valid value.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/External Reference/Link_Cited_Document.md
+++ b/templates/advanced/External Reference/Link_Cited_Document.md
@@ -1,0 +1,66 @@
+___
+
+## Link Cited Document
+> Link a cited document to a referenceable via the CitedDocumentLink relationship.
+>
+>	**Alternative Names**: Link Referenceable->Cited Document; Link Cited Document
+
+### Cited Document
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The cited document to link to.
+
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### Pages
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The specific pages referenced in the cited document.
+
+
+### Reference Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identifier of the cited document in the link context.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/External Reference/Link_External_Reference.md
+++ b/templates/advanced/External Reference/Link_External_Reference.md
@@ -1,0 +1,134 @@
+___
+
+## Link External Reference
+> Link an external reference to a referenceable.
+>
+>	**Alternative Names**: Referenceable->External Reference; External Reference; External Data Source; External Model Source
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### External Reference
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The external reference to link to.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/External Reference/Link_Media_Reference.md
+++ b/templates/advanced/External Reference/Link_Media_Reference.md
@@ -1,0 +1,76 @@
+___
+
+## Link Media Reference
+> Link a related media reference to a referenceable via the MediaReferenceLink relationship.
+>
+>	**Alternative Names**: Referenceable->Media Reference; Media Reference
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### Media Reference
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The related media reference to link to.
+
+
+### Media Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identifier of the media being referenced.
+
+
+### Media Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How the media is being used in this specific link.
+
+>	**Valid Values**: ICON,THUMBNAIL,ILLUSTRATION,USAGE_GUIDANCE,OTHER
+
+
+### Media Usage Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the media usage when not using a standard valid value.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Feedback/Attach_Comment.md
+++ b/templates/advanced/Feedback/Attach_Comment.md
@@ -1,0 +1,114 @@
+___
+
+## Attach Comment
+> Attach a comment to a referenceable element via the AttachedComment relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Feedback/Attach_Like.md
+++ b/templates/advanced/Feedback/Attach_Like.md
@@ -1,0 +1,130 @@
+___
+
+## Attach Like
+> Attach a like to a referenceable element via the AttachedLike relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Emoji
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An emoji associated with a Like.
+
+
+### Liked Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being liked.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Feedback/Attach_Rating.md
+++ b/templates/advanced/Feedback/Attach_Rating.md
@@ -1,0 +1,140 @@
+___
+
+## Attach Rating
+> Attach a star rating to a referenceable element via the AttachedRating relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Reviewed Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being rated.
+
+
+### Review
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Text review accompanying a star rating.
+
+
+### Stars
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Star rating for an element.
+
+>	**Valid Values**: NO_RECOMMENDATION,ONE_STAR,TWO_STARS,THREE_STARS,FOUR_STARS,FIVE_STARS
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Feedback/Attach_Tag.md
+++ b/templates/advanced/Feedback/Attach_Tag.md
@@ -1,0 +1,130 @@
+___
+
+## Attach Tag
+> Attach an informal tag to a referenceable element via the AttachedTag relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Informal Tag
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The informal tag being attached.
+
+
+### Tagged Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being tagged.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Feedback/Create_Blog_Entry.md
+++ b/templates/advanced/Feedback/Create_Blog_Entry.md
@@ -1,0 +1,244 @@
+___
+
+## Create Blog Entry
+> Add a blog entry.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Identifier of an external source that is associated with this element.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of an external element that is associated with this element.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Comment.md
+++ b/templates/advanced/Feedback/Create_Comment.md
@@ -1,0 +1,456 @@
+___
+
+## Create Comment
+> Creates a comment on a metadata element.
+>
+>	**Alternative Names**: Add Comment
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Commented On Element
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being commented on.
+
+>	**Alternative Labels**: Associated Element
+
+
+### Comment Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The type of comment.
+
+>	**Valid Values**: STANDARD_COMMENT,QUESTION,ANSWER,SUGGESTION,USAGE_EXPERIENCE,REQUIREMENT,OTHER
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Informal_Tag.md
+++ b/templates/advanced/Feedback/Create_Informal_Tag.md
@@ -1,0 +1,434 @@
+___
+
+## Create Informal Tag
+> Creates an informal tag — a user-defined label that can be attached to any referenceable element.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Journal_Activity.md
+++ b/templates/advanced/Feedback/Create_Journal_Activity.md
@@ -1,0 +1,244 @@
+___
+
+## Create Journal Activity
+> Journal about your actiity.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Identifier of an external source that is associated with this element.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of an external element that is associated with this element.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Like.md
+++ b/templates/advanced/Feedback/Create_Like.md
@@ -1,0 +1,268 @@
+___
+
+## Create Like
+> Creates a like (with optional emoji) on a metadata element.
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Log_Activity.md
+++ b/templates/advanced/Feedback/Create_Log_Activity.md
@@ -1,0 +1,244 @@
+___
+
+## Create Log Activity
+> Log my activity.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Identifier of an external source that is associated with this element.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of an external element that is associated with this element.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Create_Rating.md
+++ b/templates/advanced/Feedback/Create_Rating.md
@@ -1,0 +1,286 @@
+___
+
+## Create Rating
+> Creates a star rating on a metadata element.
+
+### Stars
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Star rating for an element.
+
+>	**Valid Values**: NO_RECOMMENDATION,ONE_STAR,TWO_STARS,THREE_STARS,FOUR_STARS,FIVE_STARS
+
+
+### Review
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Text review accompanying a star rating.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Feedback/Link_Accept_Answer.md
+++ b/templates/advanced/Feedback/Link_Accept_Answer.md
@@ -1,0 +1,130 @@
+___
+
+## Link Accept Answer
+> Link a question comment to the comment that answers it via the AcceptedAnswer relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Accepted Answer Comment
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The question comment that has been answered.
+
+
+### Answering Comment
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The comment accepted as an answer.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Glossary/Classify_Glossary_as_Canonical.md
+++ b/templates/advanced/Glossary/Classify_Glossary_as_Canonical.md
@@ -1,0 +1,278 @@
+___
+
+## Classify Glossary as Canonical
+> Classify a glossary as a Canonical
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Classify_Glossary_as_Taxonomy.md
+++ b/templates/advanced/Glossary/Classify_Glossary_as_Taxonomy.md
@@ -1,0 +1,278 @@
+___
+
+## Classify Glossary as Taxonomy
+> Classify a glossary as a Taxonomy
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Classify_Term_as_Question.md
+++ b/templates/advanced/Glossary/Classify_Term_as_Question.md
@@ -1,0 +1,278 @@
+___
+
+## Classify Term as Question
+> Classify a glossary term as a Question
+
+### Term Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of a term.
+
+>	**Alternative Labels**: Term; Term Name
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Create_Glossary.md
+++ b/templates/advanced/Glossary/Create_Glossary.md
@@ -1,0 +1,526 @@
+___
+
+## Create Glossary
+> Creates or updates a glossary — a collection of related terms for a specific domain or purpose.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Language
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The primary language of the glossary. Note that multilingual descriptions are supported.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Canonical Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope associated with a canonical glossary. Only relevant if the glossary is classified as cononical.
+
+
+### Is Canonical
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify a glossary to declare that it has no two GlossaryTerm definitions with the same name.  This means there is only one definition for each term.  Typically, the terms are also of a similar level of granularity and are limited to a specific scope of use. Canonical vocabularies are used to semantically classify assets in an unambiguous way. A canonical vocabulary can have a Canonical Scope attribute.
+
+>	**Alternative Labels**: Canonical
+
+>	**Default Value**: False
+
+
+### Is Taxonomy
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary to indicate that it can be used as a taxonomy.  This means each term is attached to one, and only one folder and the folders are organized as a hierarchy with a single root folder. A taxonomy can have an Organizing Principle.
+
+>	**Alternative Labels**: Taxonomy
+
+>	**Default Value**: False
+
+
+### Organizing Principle
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid for taxonomies. Principle by wihch the taxonomy is organized.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Create_Glossary_Term.md
+++ b/templates/advanced/Glossary/Create_Glossary_Term.md
@@ -1,0 +1,594 @@
+___
+
+## Create Glossary Term
+> Creates or updates a glossary term — a concept, phrase, or word defined within a glossary.
+>
+>	**Alternative Names**: Term
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Abbreviation
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An abbreviation for the glossary term.
+
+
+### Example
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An example of how the glossary term is used.
+
+>	**Alternative Labels**: Examples
+
+
+### Folders
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Existing folder collections that you'd like to make the term a member of.
+
+>	**Alternative Labels**: Folders; Collection Folders
+
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Context Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid for terms classified as describing context.
+
+
+### Context Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid for terms classified as describing context.
+
+
+### Is Abstract Concept
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes an abstract concept.
+
+>	**Default Value**: False
+
+
+### Is Activity Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes an activity. An activity description classification can have an Term Activity Type.
+
+>	**Default Value**: False
+
+
+### Is Context
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes a context.
+
+>	**Default Value**: False
+
+
+### Is Data Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes a data valuet.
+
+>	**Default Value**: False
+
+
+### Term Activity Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Only valid for terms classified as describing context.
+
+>	**Valid Values**: OPERATION,ACTION,TASK,PROCESS,PROJECT,OTHER
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Create_Question.md
+++ b/templates/advanced/Glossary/Create_Question.md
@@ -1,0 +1,592 @@
+___
+
+## Create Question
+> Create a GlossaryTerm classified as a Question (IsQuestion) in a single API call.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Abbreviation
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An abbreviation for the glossary term.
+
+
+### Example
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An example of how the glossary term is used.
+
+>	**Alternative Labels**: Examples
+
+
+### Folders
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Existing folder collections that you'd like to make the term a member of.
+
+>	**Alternative Labels**: Folders; Collection Folders
+
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Context Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid for terms classified as describing context.
+
+
+### Context Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid for terms classified as describing context.
+
+
+### Is Abstract Concept
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes an abstract concept.
+
+>	**Default Value**: False
+
+
+### Is Activity Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes an activity. An activity description classification can have an Term Activity Type.
+
+>	**Default Value**: False
+
+
+### Is Context
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes a context.
+
+>	**Default Value**: False
+
+
+### Is Data Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classify the glossary term to indicate that it describes a data valuet.
+
+>	**Default Value**: False
+
+
+### Term Activity Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Only valid for terms classified as describing context.
+
+>	**Valid Values**: OPERATION,ACTION,TASK,PROCESS,PROJECT,OTHER
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Glossary/Link_Term-Term_Relationship.md
+++ b/templates/advanced/Glossary/Link_Term-Term_Relationship.md
@@ -1,0 +1,86 @@
+___
+
+## Link Term-Term Relationship
+> Links or unlinks two glossary terms via a typed semantic relationship (e.g. Synonym, Antonym, PreferredTerm, TranslationOf).
+>
+>	**Alternative Names**: Term-Term Relationship; Term to Term Relationship
+
+### Relationship Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Enum
+
+>	**Description**: The type of relationship connecting the two terms. E.g. Synonym, Antonym, PreferredTerm, ReplacedByTerm, TranslationOf, etc.
+
+>	**Valid Values**: RelatedTerm,Synonym,Antonym,PreferredTerm,ReplacementTerm,Translation,ISA,ValidValue,ISARelationship,TermHASARelationship,TYPED BY,TermTYPEDBYRelationship,TYPE OF,TermISATYPEOFRelationship
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Term Relationship Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the term-term relationship.
+
+>	**Valid Values**: DRAFT,ACTIVE,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Glossary/Link_Term_as_Context.md
+++ b/templates/advanced/Glossary/Link_Term_as_Context.md
@@ -1,0 +1,106 @@
+___
+
+## Link Term as Context
+> Relates a glossary term as context to a referenceable.
+>
+>	**Alternative Names**: Used in Context; Term as Context
+
+### Relationship Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Enum
+
+>	**Description**: The type of relationship connecting the two terms. E.g. Synonym, Antonym, PreferredTerm, ReplacedByTerm, TranslationOf, etc.
+
+>	**Valid Values**: RelatedTerm,Synonym,Antonym,PreferredTerm,ReplacementTerm,Translation,ISA,ValidValue,ISARelationship,TermHASARelationship,TYPED BY,TermTYPEDBYRelationship,TYPE OF,TermISATYPEOFRelationship
+
+
+### Term 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the first term to connect.
+
+>	**Alternative Labels**: Term; Term Name
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Term Relationship Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the term-term relationship.
+
+>	**Valid Values**: DRAFT,ACTIVE,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Glossary/Set_Glossary_as_Taxonomy.md
+++ b/templates/advanced/Glossary/Set_Glossary_as_Taxonomy.md
@@ -1,0 +1,278 @@
+___
+
+## Set Glossary as Taxonomy
+> Classify a glossary as a Taxonomy
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of the digital product. There is a list of valid values that this conforms to.
+
+>	**Default Value**: ACTIVE
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Generally True. 
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: True
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor identity for the collection. Typically a qualified name but if display name is unique then it could be used (not recommended)
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Unique name of the parent element.
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The kind of the relationship to the parent element.
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the parent at end1 of the relationship?
+
+>	**Default Value**: True
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If True, only those attributes specified in the update will be updated; If False, any attributes not provided during the update will be set to None.
+
+>	**Alternative Labels**: Merge
+
+>	**Default Value**: True
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional user defined values organized as name value pairs in a dictionary.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Business_Imperative.md
+++ b/templates/advanced/Governance Officer/Create_Business_Imperative.md
@@ -1,0 +1,530 @@
+___
+
+## Create Business Imperative
+> The BusinessImperative entity defines a business goal that is critical to the success of the organization.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Certification_Type.md
+++ b/templates/advanced/Governance Officer/Create_Certification_Type.md
@@ -1,0 +1,576 @@
+___
+
+## Create Certification Type
+> A type of certification.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Data_Lens.md
+++ b/templates/advanced/Governance Officer/Create_Data_Lens.md
@@ -1,0 +1,616 @@
+___
+
+## Create Data Lens
+> A DataLens defines a geographic, temporal, and element scope for data collection and analysis.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Max Height
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum height of the vertical scope.
+
+
+### Data Collection End Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: End time for the data collection period.
+
+
+### Data Collection Start Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Start time for the data collection period.
+
+
+### Max Latitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum latitude of the geographic scope.
+
+
+### Max Longitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum longitude of the geographic scope.
+
+
+### Min Height
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum height of the vertical scope.
+
+
+### Min Latitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum latitude of the geographic scope.
+
+
+### Min Longitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum longitude of the geographic scope.
+
+
+### Scope Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Map of element identifiers defining the scope of the data lens.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Data_Processing_Purpose.md
+++ b/templates/advanced/Governance Officer/Create_Data_Processing_Purpose.md
@@ -1,0 +1,540 @@
+___
+
+## Create Data Processing Purpose
+> Privacy regulations such as  (GDPR) require data subjects to agree the processing that is permitted on their data.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Action.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Action.md
@@ -1,0 +1,540 @@
+___
+
+## Create Governance Action
+> An executable action, or sequence of actions to support a governance requirement.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Approach.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Approach.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Approach
+> The GovernanceApproach entity defines a policy that describes a method that should be used for a particular activity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Control.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Control.md
@@ -1,0 +1,540 @@
+___
+
+## Create Governance Control
+> A governance control describes how a particular governance policy should be implemented. There are many types of controls.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Definition.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Definition.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Definition
+> Create a general governance definition.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Driver.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Driver.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Driver
+> A motivating topic leading to governance work.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Metric.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Metric.md
@@ -1,0 +1,556 @@
+___
+
+## Create Governance Metric
+> A governance metric describes measurements that support governance requirements.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Measurement
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A measurement for a governance metric.
+
+
+### Target
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Target values for a measurement.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Obligation.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Obligation.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Obligation
+> The GovernanceObligation entity defines a policy that describes a requirement that must be met.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Policy.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Policy.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Policy
+> Policies  created in response to governance drivers. There are several types of policies.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Principle.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Principle.md
@@ -1,0 +1,530 @@
+___
+
+## Create Governance Principle
+> The GovernancePrinciple entity defines a policy that describes an end state that the organization aims to achieve.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Procedure.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Procedure.md
@@ -1,0 +1,540 @@
+___
+
+## Create Governance Procedure
+> A manual procedure that is performed under certain circumstances.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Responsibility.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Responsibility.md
@@ -1,0 +1,540 @@
+___
+
+## Create Governance Responsibility
+> A responsibility assigned to an actor or team. It could be a requirement to take a certain action in specific circumstances or to make decisions or give approvals for actions.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Rule.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Rule.md
@@ -1,0 +1,540 @@
+___
+
+## Create Governance Rule
+> An executable rule that can be deployed at particular points in the operations.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Strategy.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Strategy.md
@@ -1,0 +1,538 @@
+___
+
+## Create Governance Strategy
+> The strategy used in the development of the governance domains activities. How the governance domain supports the business strategy.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Business Imperatives
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Defines the list of business imperatives the strategy supports.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Governance_Zone.md
+++ b/templates/advanced/Governance Officer/Create_Governance_Zone.md
@@ -1,0 +1,548 @@
+___
+
+## Create Governance Zone
+> A collection of assets that are used or processed in a specific way. Policies and controls can be attached to zones using the GovernedBy relationship.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The criteria for membership in a governance zone.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_License_Type.md
+++ b/templates/advanced/Governance Officer/Create_License_Type.md
@@ -1,0 +1,576 @@
+___
+
+## Create License Type
+> A type of license.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Methodology.md
+++ b/templates/advanced/Governance Officer/Create_Methodology.md
@@ -1,0 +1,540 @@
+___
+
+## Create Methodology
+> A Methodology describes a specific approach or framework for governance processes.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Naming_Standard_Rule.md
+++ b/templates/advanced/Governance Officer/Create_Naming_Standard_Rule.md
@@ -1,0 +1,548 @@
+___
+
+## Create Naming Standard Rule
+> A standard for naming specific kinds of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Notification_Type.md
+++ b/templates/advanced/Governance Officer/Create_Notification_Type.md
@@ -1,0 +1,598 @@
+___
+
+## Create Notification Type
+> A NotificationType defines a type of notification that can be sent as a governance control.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Multiple Notifications Permitted
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Whether multiple notifications are permitted for this notification type.
+
+>	**Default Value**: True
+
+
+### Next Scheduled Notification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The date of the next scheduled notification.
+
+
+### Notification Count
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of notifications sent so far.
+
+
+### Notification Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The interval between scheduled notifications in milliseconds.
+
+
+### Minimum Notification Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum interval between notifications in milliseconds.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Regulation.md
+++ b/templates/advanced/Governance Officer/Create_Regulation.md
@@ -1,0 +1,546 @@
+___
+
+## Create Regulation
+> Defines a relevant legal regulation that the business operation must comply with. Often regulations are divided into regulation articles.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Regulation Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the regulation - often, an authority.
+
+
+### Regulators
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of regulators.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Regulation_Article.md
+++ b/templates/advanced/Governance Officer/Create_Regulation_Article.md
@@ -1,0 +1,530 @@
+___
+
+## Create Regulation Article
+> A RegulationArticle entity is an article in a regulation. Dividing a regulation  simplifies planning and execution.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Security_Access_Control.md
+++ b/templates/advanced/Governance Officer/Create_Security_Access_Control.md
@@ -1,0 +1,540 @@
+___
+
+## Create Security Access Control
+> A technical control that defines the access control lists that an actor must belong to be entitled to perform a specific action.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Service_Level_Objective.md
+++ b/templates/advanced/Governance Officer/Create_Service_Level_Objective.md
@@ -1,0 +1,542 @@
+___
+
+## Create Service Level Objective
+> Defines the performance, availability and quality levels expected by the element attached.
+>
+>	**Alternative Names**: Service Level Objectives
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Terms_and_Conditions.md
+++ b/templates/advanced/Governance Officer/Create_Terms_and_Conditions.md
@@ -1,0 +1,578 @@
+___
+
+## Create Terms and Conditions
+> A defined set of terms and conditions.
+>
+>	**Alternative Names**: T&C; Terms & Conditions
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Create_Threat.md
+++ b/templates/advanced/Governance Officer/Create_Threat.md
@@ -1,0 +1,532 @@
+___
+
+## Create Threat
+> The Threat entity describes a particular threat to the organization
+>
+>	**Alternative Names**: Threat Definition
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Governance Officer/Detach_Regulator.md
+++ b/templates/advanced/Governance Officer/Detach_Regulator.md
@@ -1,0 +1,130 @@
+___
+
+## Detach Regulator
+> Detaches a regulator (usually an organization) from a regulation.
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Regulator
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulator (usually an organization) to link to the regulation.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Agreement_Terms_and_Conditions.md
+++ b/templates/advanced/Governance Officer/Link_Agreement_Terms_and_Conditions.md
@@ -1,0 +1,158 @@
+___
+
+## Link Agreement Terms and Conditions
+> Links an agreement to terms and conditions definition with implementation details.
+>
+>	**Alternative Names**: Agreement T&C; Agreement Terms & Conditions
+
+### Terms & Conditions Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A reference to a TermsAndConditions element - may also be a subtype.
+
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Associated_List.md
+++ b/templates/advanced/Governance Officer/Link_Associated_List.md
@@ -1,0 +1,138 @@
+___
+
+## Link Associated List
+> Establishes that a Security Access Control applies to this Security List, Group or Role.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Access Control
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The security access control endpoint in an AssociatedSecurityGroup relationship.
+
+
+### Operation Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the operation controled by the SecurityAccessControl.
+
+
+### Security List
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The security group endpoint in an AssociatedSecurityGroup relationship.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Certification.md
+++ b/templates/advanced/Governance Officer/Link_Certification.md
@@ -1,0 +1,272 @@
+___
+
+## Link Certification
+> Links a certification type to a referenceable element, adding details about the certification.
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Certificate GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Unique identifier of the certificate.
+
+
+### Certified By
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the person or organization that issued the certification.
+
+
+### Certified By Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the certifier element (used with Certified By Type Name).
+
+
+### Certified By Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element that issued the certification (used with Certified By Property Name to identify the certifier).
+
+
+### Conditions
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Conditions for certifications or licenses.
+
+
+### Custodian
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Custodian of the license or certification.
+
+
+### Custodian Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the custodian element (used with Custodian Type Name).
+
+
+### Custodian Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element acting as custodian (used with Custodian Property Name to identify the custodian).
+
+
+### End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification expires.
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Recipient
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The receiver of the certification.
+
+
+### Recipient Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the certification recipient element (used with Recipient Type Name).
+
+
+### Recipient Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element receiving the certification (used with Recipient Property Name).
+
+
+### Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification takes effect.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governance_Controls.md
+++ b/templates/advanced/Governance Officer/Link_Governance_Controls.md
@@ -1,0 +1,130 @@
+___
+
+## Link Governance Controls
+> Link peer governance controls with the GovernanceControlLink relationship. Controls types are: GovernanceRule, GovernanceProcess, GovernanceResponsibility, GovernanceProcedure, SecurityAccessControl, SecurityGroup.
+
+### Governance Control 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernanceControl entity in the peer relationship.
+
+
+### Governance Control 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernanceControl entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governance_Drivers.md
+++ b/templates/advanced/Governance Officer/Link_Governance_Drivers.md
@@ -1,0 +1,130 @@
+___
+
+## Link Governance Drivers
+> Link peer governance drivers with the GovernanceDriverLink relationship. Drivers are: GovernanceStrategy, BusinessImperitive, Regulation, RegulationArticle, Threat.
+
+### Governance Driver 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernanceDriver entity in the peer relationship.
+
+
+### Governance Driver 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernanceDriver entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governance_Mechanism.md
+++ b/templates/advanced/Governance Officer/Link_Governance_Mechanism.md
@@ -1,0 +1,138 @@
+___
+
+## Link Governance Mechanism
+> Link a governance policy to a governance control that supports it. The GovernanceMechanism relationship is used.
+
+### Mechanism
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The GovernanceControl that implements the governance mechanism.
+
+
+### Policy
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The governance policy endpoint in a GovernanceResponse or GovernanceMechanism relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The rationale for using this control to  support this policy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governance_Policies.md
+++ b/templates/advanced/Governance Officer/Link_Governance_Policies.md
@@ -1,0 +1,130 @@
+___
+
+## Link Governance Policies
+> Link peer governance policies with the GovernancePolicyLink relationship. Policies types are: GovernancePrinciple, GovernanceObligation, GovernanceApproach.
+
+### Governance Policy 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernancePolicy entity in the peer relationship.
+
+
+### Governance Policy 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernancePolicy entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governance_Response.md
+++ b/templates/advanced/Governance Officer/Link_Governance_Response.md
@@ -1,0 +1,138 @@
+___
+
+## Link Governance Response
+> Links Policies as a response to governance Drivers.
+
+### Driver
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The GovernanceDriver that initiates the governance response.
+
+
+### Policy
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The governance policy endpoint in a GovernanceResponse or GovernanceMechanism relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The rationale for using this control to  support this policy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Governed_By.md
+++ b/templates/advanced/Governance Officer/Link_Governed_By.md
@@ -1,0 +1,132 @@
+___
+
+## Link Governed By
+> A referenceable element can be governed by one or more governance definitions.
+
+### Governance Definition
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The definition governing the referenceable.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_License.md
+++ b/templates/advanced/Governance Officer/Link_License.md
@@ -1,0 +1,272 @@
+___
+
+## Link License
+> Links a license type to a referenceable element, adding details about the license.
+
+### License Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Conditions
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Conditions for certifications or licenses.
+
+
+### Custodian
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Custodian of the license or certification.
+
+
+### Custodian Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the custodian element (used with Custodian Type Name).
+
+
+### Custodian Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element acting as custodian (used with Custodian Property Name to identify the custodian).
+
+
+### End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification expires.
+
+
+### License GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Unique identifier of the license.
+
+
+### Licensed By
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the person or organization that granted the license.
+
+
+### Licensed By Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the licensor element (used with Licensed By Type Name).
+
+
+### Licensed By Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element that granted the license (used with Licensed By Property Name).
+
+
+### Licensee
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The licensee.
+
+
+### Licensee Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the licensee element (used with Licensee Type Name).
+
+
+### Licensee Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element receiving the license (used with Licensee Property Name).
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification takes effect.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Monitored_Resource.md
+++ b/templates/advanced/Governance Officer/Link_Monitored_Resource.md
@@ -1,0 +1,130 @@
+___
+
+## Link Monitored Resource
+> Links a Notification Type to a Referenceable that it monitors.
+
+### Monitored Resource
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The monitored referenceable endpoint in a MonitoredResource relationship.
+
+
+### Notification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The NotificationType entity to link the subscriber to or for a monitored resource.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Notification_Subscriber.md
+++ b/templates/advanced/Governance Officer/Link_Notification_Subscriber.md
@@ -1,0 +1,158 @@
+___
+
+## Link Notification Subscriber
+> Links a Referenceable as a subscriber to a NotificationType, defining the subscription parameters.
+
+### Notification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The NotificationType entity to link the subscriber to or for a monitored resource.
+
+
+### Subscriber
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Referenceable entity subscribing to the notification type.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Last Notification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The date of the last notification sent to this subscriber.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Activity Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of an activity - one of an enumerated set of values.
+
+>	**Valid Values**: REQUESTED,APPROVED,WAITING,ACTIVATING,IN_PROGRESS,PAUSED,COMPLETED,INVALID,IGNORED,FAILED,CANCELLED,ABANDONED,OTHER
+
+>	**Default Value**: REQUESTED
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Regulation_Certification_Type.md
+++ b/templates/advanced/Governance Officer/Link_Regulation_Certification_Type.md
@@ -1,0 +1,130 @@
+___
+
+## Link Regulation Certification Type
+> A certification type addressing a specific regulation.
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Regulation_to_Regulator.md
+++ b/templates/advanced/Governance Officer/Link_Regulation_to_Regulator.md
@@ -1,0 +1,140 @@
+___
+
+## Link Regulation to Regulator
+> Use the Regulator relationship to link a regulation to a regulator organization.
+
+### Governance Definition
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The definition governing the referenceable.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Regulator.md
+++ b/templates/advanced/Governance Officer/Link_Regulator.md
@@ -1,0 +1,162 @@
+___
+
+## Link Regulator
+> Links a regulator (usually an organization) to a regulation using the Regulator relationship.
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Regulator
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulator (usually an organization) to link to the regulation.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+___

--- a/templates/advanced/Governance Officer/Link_Zone_Hierarchy.md
+++ b/templates/advanced/Governance Officer/Link_Zone_Hierarchy.md
@@ -1,0 +1,130 @@
+___
+
+## Link Zone Hierarchy
+> Links child governance zones to parent governance zone.
+
+### Parent Zone
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent GovernanceZone in the zone hierarchy.
+
+
+### Child Zone
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The child GovernanceZone in the zone hierarchy.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Projects/Create_Campaign.md
+++ b/templates/advanced/Projects/Create_Campaign.md
@@ -1,0 +1,602 @@
+___
+
+## Create Campaign
+> Creates or updates a campaign — a collection of related projects working towards a common goal. Sets the Campaign classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Projects/Create_Personal_Project.md
+++ b/templates/advanced/Projects/Create_Personal_Project.md
@@ -1,0 +1,602 @@
+___
+
+## Create Personal Project
+> Creates or updates a personal project — an informal project created by a single person to organize part of their work. Sets the PersonalProject classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Projects/Create_Project.md
+++ b/templates/advanced/Projects/Create_Project.md
@@ -1,0 +1,602 @@
+___
+
+## Create Project
+> Creates or updates a project. Projects organize a specific activity, controlling resources and costs to achieve defined goals.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Projects/Create_Study_Project.md
+++ b/templates/advanced/Projects/Create_Study_Project.md
@@ -1,0 +1,602 @@
+___
+
+## Create Study Project
+> Creates or updates a study project — a focused analysis of a topic, person, object or situation. Sets the StudyProject classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Projects/Create_Task.md
+++ b/templates/advanced/Projects/Create_Task.md
@@ -1,0 +1,602 @@
+___
+
+## Create Task
+> Creates or updates a task — a small piece of work typically assigned to a single person. Sets the Task classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Projects/Link_Project_Dependency.md
+++ b/templates/advanced/Projects/Link_Project_Dependency.md
@@ -1,0 +1,130 @@
+___
+
+## Link Project Dependency
+> Links or unlinks a project and a project it depends on via the ProjectDependency relationship.
+
+### Child Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the child project.
+
+
+### Parent Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the parent project.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Projects/Link_Project_Hierarchy.md
+++ b/templates/advanced/Projects/Link_Project_Hierarchy.md
@@ -1,0 +1,130 @@
+___
+
+## Link Project Hierarchy
+> Links or unlinks a parent project and a child project via the ProjectHierarchy relationship.
+
+### Child Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the child project.
+
+
+### Parent Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the parent project.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Report/Report.md
+++ b/templates/advanced/Report/Report.md
@@ -1,0 +1,210 @@
+___
+
+## Report
+> Runs a named pyegeria report spec (FormatSet) via hey_egeria run_report. Returns formatted output from the Egeria repository — not an element creation command.
+
+### Report Spec
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the report spec (FormatSet) to run, e.g. 'Digital-Products', 'Collections', 'My-User-MD'. This is the primary identifier for the report — equivalent to --report in the CLI.
+
+>	**Default Value**: Referenceable
+
+
+### Search String
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An optional search string to filter results by.
+
+>	**Default Value**: *
+
+
+### Output Format
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Optional specification of output format for the query.
+
+>	**Valid Values**: LIST,FORM,REPORT,MERMAID,DICT,MD,TABLE,JSON
+
+>	**Default Value**: JSON
+
+
+### Starts With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the beginning of  a field.
+
+>	**Default Value**: True
+
+
+### Ends With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the end of  a field.
+
+>	**Default Value**: False
+
+
+### Ignore Case
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, ignore the difference between upper and lower characters when matching the search string.
+
+>	**Default Value**: False
+
+
+### Metadata Element Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Optionally filter results by the type of metadata element.
+
+
+### Metadata Element Subtype Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Filter results by the list of metadata elements. If none are provided, then no status filtering will be performed.
+
+
+### Page Size
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of elements returned per page.
+
+>	**Default Value**: 0
+
+
+### Start From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: When paging through results, the starting point of the results to return.
+
+>	**Default Value**: 0
+
+
+### Limit Result by Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: One of the status values from a list of valid values.
+
+>	**Valid Values**: UNKNOWN,DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,APPROVED_CONCEPT,UNDER_DEVELOPMENT,DEVELOPMENT_COMPLETE,APPROVED_FOR_DEPLOYMENT,STANDBY,ACTIVE,FAILED,DISABLED,COMPLETE,DEPRECATED,OTHER,DELETED
+
+>	**Default Value**: ['ACTIVE']
+
+
+### Skip Relationships
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Allow listed relationships to be skipped in the output returned.
+
+
+### Include Only Relationships
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include information only about specified relationships.
+
+
+### Skip Classified Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Skip elements with the any of the specified classifications.
+
+
+### Include Only Classified Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include only elements with the specified classifications.
+
+
+### Governance Zone Filter
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include only elements in one of the specified governance zones.
+
+
+### Graph Query Depth
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The depth of the hierarchy to return. Default is 5. Specifying 0 returns only the top level attributes.
+
+>	**Default Value**: 1
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### AsOfTime
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to view the state of the repository.
+
+
+### Output Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How to order the results. The sort order can be selected from a list of valid value.
+
+>	**Valid Values**: ANY,CREATION_DATE_RECENT,CREATION_DATA_OLDEST,LAST_UPDATE_RECENT,LAST_UPDATE_OLDEST,PROPERTY_ASCENDING,PROPERTY_DESCENDING
+
+
+### Order Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property to use for sorting if the sort_order_property is PROPERTY_ASCENDING or PROPERTY_DESCENDING
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+___

--- a/templates/advanced/Report/View Report.md
+++ b/templates/advanced/Report/View Report.md
@@ -1,0 +1,210 @@
+___
+
+## View Report
+> Runs a named pyegeria report spec (FormatSet) via hey_egeria run_report. Returns formatted output from the Egeria repository — not an element creation command.
+
+### Report Spec
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the report spec (FormatSet) to run, e.g. 'Digital-Products', 'Collections', 'My-User-MD'. This is the primary identifier for the report — equivalent to --report in the CLI.
+
+>	**Default Value**: Referenceable
+
+
+### Search String
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An optional search string to filter results by.
+
+>	**Default Value**: *
+
+
+### Output Format
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Optional specification of output format for the query.
+
+>	**Valid Values**: LIST,FORM,REPORT,MERMAID,DICT,MD,TABLE,JSON
+
+>	**Default Value**: JSON
+
+
+### Starts With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the beginning of  a field.
+
+>	**Default Value**: True
+
+
+### Ends With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the end of  a field.
+
+>	**Default Value**: False
+
+
+### Ignore Case
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, ignore the difference between upper and lower characters when matching the search string.
+
+>	**Default Value**: False
+
+
+### Metadata Element Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Optionally filter results by the type of metadata element.
+
+
+### Metadata Element Subtype Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Filter results by the list of metadata elements. If none are provided, then no status filtering will be performed.
+
+
+### Page Size
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of elements returned per page.
+
+>	**Default Value**: 0
+
+
+### Start From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: When paging through results, the starting point of the results to return.
+
+>	**Default Value**: 0
+
+
+### Limit Result by Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: One of the status values from a list of valid values.
+
+>	**Valid Values**: UNKNOWN,DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,APPROVED_CONCEPT,UNDER_DEVELOPMENT,DEVELOPMENT_COMPLETE,APPROVED_FOR_DEPLOYMENT,STANDBY,ACTIVE,FAILED,DISABLED,COMPLETE,DEPRECATED,OTHER,DELETED
+
+>	**Default Value**: ['ACTIVE']
+
+
+### Skip Relationships
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Allow listed relationships to be skipped in the output returned.
+
+
+### Include Only Relationships
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include information only about specified relationships.
+
+
+### Skip Classified Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Skip elements with the any of the specified classifications.
+
+
+### Include Only Classified Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include only elements with the specified classifications.
+
+
+### Governance Zone Filter
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Include only elements in one of the specified governance zones.
+
+
+### Graph Query Depth
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The depth of the hierarchy to return. Default is 5. Specifying 0 returns only the top level attributes.
+
+>	**Default Value**: 1
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### AsOfTime
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to view the state of the repository.
+
+
+### Output Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How to order the results. The sort order can be selected from a list of valid value.
+
+>	**Valid Values**: ANY,CREATION_DATE_RECENT,CREATION_DATA_OLDEST,LAST_UPDATE_RECENT,LAST_UPDATE_OLDEST,PROPERTY_ASCENDING,PROPERTY_DESCENDING
+
+
+### Order Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property to use for sorting if the sort_order_property is PROPERTY_ASCENDING or PROPERTY_DESCENDING
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+___

--- a/templates/advanced/Solution Architect/Create_Information_Supply_Chain.md
+++ b/templates/advanced/Solution Architect/Create_Information_Supply_Chain.md
@@ -1,0 +1,522 @@
+___
+
+## Create Information Supply Chain
+> Creates or updates an information supply chain — a description of the flow of a particular type of data across a digital landscape.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### In Information Supply Chain
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Supply chains that this supply chain is a segment of.
+
+
+### Integration Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The integration style of the information supply chain (e.g. how data flows between segments).
+
+
+### Nested Information Supply Chains
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of supply chains that compose this supply chain.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Estimated Volumetrics
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Estimated data volumes for the information supply chain, as a map of metric name to value (e.g. records per day).
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Solution Architect/Create_Solution_Blueprint.md
+++ b/templates/advanced/Solution Architect/Create_Solution_Blueprint.md
@@ -1,0 +1,488 @@
+___
+
+## Create Solution Blueprint
+> Creates or updates a solution blueprint — a description of the architecture of a digital service in terms of solution components.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Role List
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of actor roles to assign to a blueprint or other collection.
+
+>	**Alternative Labels**: Actor Role List
+
+
+### Solution Components
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution components that make up this blueprint.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Solution Architect/Create_Solution_Component.md
+++ b/templates/advanced/Solution Architect/Create_Solution_Component.md
@@ -1,0 +1,526 @@
+___
+
+## Create Solution Component
+> Creates or updates a reusable solution component — a building block of a solution blueprint or information supply chain.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actors
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Actors or Solution Roles related to this element.
+
+
+### In Information Supply Chain
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Supply chains that this supply chain is a segment of.
+
+
+### In Solution Blueprints
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution blueprints that contain this component.
+
+
+### In Solution Components
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution components that include this one.
+
+
+### Planned Deployed Implementation Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The planned implementation type for deployment.
+
+
+### Solution Component Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of solution component.
+
+
+### Solution SubComponents
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution sub-components of this component. In current approach the parent does not specify sub-components; components specify their parents instead.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### Canonical Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The canonical name for this design model element (from DesignModelElement, 0565).
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Solution Architect/Create_Solution_Role.md
+++ b/templates/advanced/Solution Architect/Create_Solution_Role.md
@@ -1,0 +1,508 @@
+___
+
+## Create Solution Role
+> Creates or updates a solution role — a collection of responsibilities associated with a solution component.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Role Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Role Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the solution role.
+
+
+### Role Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of the solution role. Currently must be GovernanceRole.
+
+>	**Default Value**: GovernanceRole
+
+
+### Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the solution role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Legal
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Copyright and/or license information for the element or associated resource.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the anchoring element.
+
+
+### Anchor Scope ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Anchor scope to restrict search.
+
+>	**Alternative Labels**: Anchor Scope
+
+
+### Glossary Term
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Term that provides meaning to this field.
+
+>	**Alternative Labels**: Term
+
+
+### Is Own Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the element is its own anchor or is anchored to a different element.
+
+>	**Alternative Labels**: Own Anchor
+
+>	**Default Value**: true
+
+
+### Merge Update
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the update should be a merge or replace.
+
+>	**Alternative Labels**: isMergeUpdate
+
+>	**Default Value**: true
+
+
+### Parent at End1
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: A flag indicating if the parent is at end1 of the relationship
+
+>	**Default Value**: true
+
+
+### Parent ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Name of the parent
+
+>	**Alternative Labels**: Parent;
+
+
+### Parent Relationship Attributes
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of relationship attributes to establish the parent relationship.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Parent Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of parent relationship.
+
+
+### Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Repository or element header status for an element.
+
+>	**Default Value**: ACTIVE
+
+
+### Zone Membership
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Zones scope visibility of elements to different users.
+
+
+### Additional Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional Properties  allow arbitrary properties not defined in the type definitions to be added to any referenceable element.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Class Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a class word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Confidence Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidenceLevel enum: UNCLASSIFIED=0, AD_HOC=1, TRANSACTIONAL=2, AUTHORITATIVE=3, DERIVED=4, OBSOLETE=5, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,AD_HOC,TRANSACTIONAL,AUTHORITATIVE,DERIVED,OBSOLETE,OTHER
+
+
+### Confidentiality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses ConfidentialityLevel enum: UNCLASSIFIED=0, INTERNAL=1, CONFIDENTIAL=2, SENSITIVE=3, RESTRICTED=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,INTERNAL,CONFIDENTIAL,SENSITIVE,RESTRICTED,OTHER
+
+
+### Criticality Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, level_identifier: int}. level_identifier uses CriticalityLevel enum: UNCLASSIFIED=0, MARGINAL=1, IMPORTANT=2, CRITICAL=3, CATASTROPHIC=4, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,MARGINAL,IMPORTANT,CRITICAL,CATASTROPHIC,OTHER
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identier
+
+>	**Alternative Labels**: ID
+
+
+### Impact Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, severity_identifier: int}. severity_identifier uses ImpactSeverity enum: UNCLASSIFIED=0, LOW=1, MEDIUM=2, HIGH=3, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,LOW,MEDIUM,HIGH,OTHER
+
+
+### Modifier Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a modifier in a naming standard.
+
+>	**Default Value**: False
+
+
+### Policy Management Point
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Combined classification from 0435. Applied to Referenceable. Structure: {point_type: str, name: str, description: str}. point_type is one of: PolicyAdministrationPoint, PolicyDecisionPoint, PolicyEnforcementPoint, PolicyInformationPoint, PolicyRetrievalPoint. A Referenceable may have multiple policy management point classifications simultaneously.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Prime Word Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Classification from 0438. Applied to Referenceable. Marker classification (no attributes) indicating the element is a prime word in a naming standard.
+
+>	**Default Value**: False
+
+
+### Retention Classification
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Classification from 0422. Structure: {status_identifier: int, confidence: int, steward: str, steward_type_name: str, steward_property_name: str, source: str, notes: str, basis_identifier: int, associated_guid: str, archive_after: date, delete_after: date}. basis_identifier uses RetentionBasis enum: UNCLASSIFIED=0, TEMPORARY=1, PROJECT_LIFETIME=2, TEAM_LIFETIME=3, CONTRACT_LIFETIME=4, REGULATED_LIFETIME=5, TIMEBOXED_LIFETIME=6, OTHER=99.
+
+>	**Valid Values**: UNCLASSIFIED,TEMPORARY,PROJECT_LIFETIME,TEAM_LIFETIME,CONTRACT_LIFETIME,REGULATED_LIFETIME,TIMEBOXED_LIFETIME,OTHER
+
+
+### Security Tags
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Optional security tags for security processing.
+
+
+### User Defined Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user defined content status = only valid if content status is OTHER.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Only valid if  Status is set to OTHER. User defined & managed status values.
+
+
+### Classifications
+>	**Input Required**: false
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Optionally specify the initial classifications for a collection. Multiple classifications can be specified. 
+
+>	**Alternative Labels**: classification
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Anchor Scope Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Optional qualified name of an anchor scope.
+
+
+### Supplementary Properties
+>	**Input Required**: False
+
+>	**Attribute Type**: Named DICT
+
+>	**Description**: Provide supplementary information to the element using the structure of a glossary term
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Actor_to_Blueprint.md
+++ b/templates/advanced/Solution Architect/Link_Actor_to_Blueprint.md
@@ -1,0 +1,156 @@
+___
+
+## Link Actor to Blueprint
+> Link an actor to a Blueprint.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Solution Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The role that an actor or component plays in the context of a relationship (e.g. in SolutionBlueprintComposition or SolutionComponentActor).
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Blueprint_Child.md
+++ b/templates/advanced/Solution Architect/Link_Blueprint_Child.md
@@ -1,0 +1,156 @@
+___
+
+## Link Blueprint Child
+> Links or unlinks an blueprint child segment to an parent blueprint using CollectionMembership.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Blueprint Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Component_to_Actor.md
+++ b/templates/advanced/Solution Architect/Link_Component_to_Actor.md
@@ -1,0 +1,130 @@
+___
+
+## Link Component to Actor
+> Links a solution component to an actor role via the SolutionComponentActor relationship.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Solution Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The role that an actor or component plays in the context of a relationship (e.g. in SolutionBlueprintComposition or SolutionComponentActor).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Information_Supply_Chain_Child.md
+++ b/templates/advanced/Solution Architect/Link_Information_Supply_Chain_Child.md
@@ -1,0 +1,156 @@
+___
+
+## Link Information Supply Chain Child
+> Links or unlinks an information supply chain child segment to an Information Supply Chain using CollectionMembership.
+
+### ISC Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A Referenceable that is a logical child of the information supply chain segment.
+
+
+### ISC Parent
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A Referenceable that is a logical source or destination for the information supply chain segment.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Information_Supply_Chain_Peers.md
+++ b/templates/advanced/Solution Architect/Link_Information_Supply_Chain_Peers.md
@@ -1,0 +1,132 @@
+___
+
+## Link Information Supply Chain Peers
+> Links or unlinks two information supply chain segments.
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Element2 Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of a second element being referenced.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Solution_Component_to_Blueprint.md
+++ b/templates/advanced/Solution Architect/Link_Solution_Component_to_Blueprint.md
@@ -1,0 +1,156 @@
+___
+
+## Link Solution Component to Blueprint
+> Link a component to a blueprint.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Membership Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Name of the type of membership.
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Confidence
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: A percent confidence in the proposed adding of the member.
+
+
+### Expression
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An expression describing a membership, relationship or classification.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the information.
+
+
+### Steward
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The identifier of the steward responsible for the element.
+
+
+### Steward Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Property name used to identify the type of the steward.
+
+
+### Steward Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type name of the steward element.
+
+
+### User Defined Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined status value. Only valid when the primary status is set to OTHER.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An ISO-8601 string representing the time to use for evaluating effectivity of the elements related to this one.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element becomes effective (visible).
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string in ISO-8601 format that defines the when an element is no longer effective (visible).
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Solution_Components.md
+++ b/templates/advanced/Solution Architect/Link_Solution_Components.md
@@ -1,0 +1,138 @@
+___
+
+## Link Solution Components
+> Links or unlinks two solution compoents.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Component2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second solution component in a peer linking relationship (SolutionLinkingWire).
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+### ISC Qualified Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The qualified names of the information supply chains that this wire implements. From SolutionLinkingWire (0735).
+
+
+___

--- a/templates/advanced/Solution Architect/Link_Solution_Design.md
+++ b/templates/advanced/Solution Architect/Link_Solution_Design.md
@@ -1,0 +1,134 @@
+___
+
+## Link Solution Design
+> Link a solution blueprint to a referenceable element.
+>
+>	**Alternative Names**: Blueprint to Element
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/advanced/Solution Architect/Link_SubComponent.md
+++ b/templates/advanced/Solution Architect/Link_SubComponent.md
@@ -1,0 +1,130 @@
+___
+
+## Link SubComponent
+> Links a child compoent to a parent component.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Component Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The child solution component to link.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Effective From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The beginning of when an element is viewable.
+
+
+### Effective Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The time at which an element must be effective in order to be returned by the request.
+
+
+### Effective To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The ending time at which an element is visible.
+
+
+### External Source GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: The unique identifier of an external source.
+
+
+### External Source Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of an external source
+
+
+### For Duplicate Processing
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support duplicate processing.
+
+
+### For Lineage
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Flag indicating if the request is to support lineage.
+
+
+### Request ID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user provided or system generated request id for a conversation.
+
+
+### Anchor Scope IDs
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of IDs that are anchor scopes for this element.
+
+
+### Make Anchor
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Is the element at end2 an anchor to end1?
+
+>	**Default Value**: false
+
+
+___

--- a/templates/basic/Actor Manager/Create_IT_Profile_Role.md
+++ b/templates/basic/Actor Manager/Create_IT_Profile_Role.md
@@ -1,0 +1,96 @@
+___
+
+## Create IT Profile Role
+> Creates or updates an IT profile role — a role that may be performed by IT profiles (engines, services, automated processes).
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Create_Organization.md
+++ b/templates/basic/Actor Manager/Create_Organization.md
@@ -1,0 +1,96 @@
+___
+
+## Create Organization
+> Creates or updates an organization — a special type of team that is the root of a hierarchy of teams, representing a collection of people and resources with a particular purpose (business, non-profit, governance department).
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Team Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of team (e.g. Department, Division, BusinessUnit). Open string until a controlled vocabulary is established.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Create_Person.md
+++ b/templates/basic/Actor Manager/Create_Person.md
@@ -1,0 +1,184 @@
+___
+
+## Create Person
+> Creates or updates a person — an individual who acts in one or more roles in the organization.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Courtesy Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A courtesy title prefix for the person (e.g. Mr, Ms, Dr, Prof).
+
+
+### Employee Number
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's organizational employee number or identifier.
+
+
+### Employee Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of employment relationship (e.g. Permanent, Contractor, Intern). Open string until a controlled vocabulary is established.
+
+
+### Full Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's full name as it should be displayed.
+
+
+### Given Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's given (first) names.
+
+
+### Initials
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's initials.
+
+
+### Job Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's job title (e.g. Senior Data Architect).
+
+
+### Preferred Language
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's preferred language for communication (e.g. en, en-US, fr).
+
+
+### Pronouns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's preferred pronouns.
+
+
+### Resident Country
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The country in which the person resides.
+
+
+### Surname
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's surname (family name).
+
+
+### Time Zone
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The person's time zone (e.g. America/New_York, Europe/London).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Create_Person_Role.md
+++ b/templates/basic/Actor Manager/Create_Person_Role.md
@@ -1,0 +1,104 @@
+___
+
+## Create Person Role
+> Creates or updates a person role — a role that may be performed by people.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Headcount
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The expected number of holders of this role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Create_Team.md
+++ b/templates/basic/Actor Manager/Create_Team.md
@@ -1,0 +1,96 @@
+___
+
+## Create Team
+> Creates or updates a team — a group of people organized to support a specific goal or responsibility.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Team Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of team (e.g. Department, Division, BusinessUnit). Open string until a controlled vocabulary is established.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Create_Team_Role.md
+++ b/templates/basic/Actor Manager/Create_Team_Role.md
@@ -1,0 +1,104 @@
+___
+
+## Create Team Role
+> Creates or updates a team role — a role that may be performed by teams.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Headcount
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The expected number of holders of this role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Actor Manager/Link_Assignment_Scope.md
+++ b/templates/basic/Actor Manager/Link_Assignment_Scope.md
@@ -1,0 +1,46 @@
+___
+
+## Link Assignment Scope
+> Assigns an actor (or actor role) responsibility for a defined scope, where the scope is identified by any Referenceable using the AssignmentScope relationship.
+
+### Assigned Actor
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Actor (or ActorRole) being assigned a scope.
+
+
+### Assignment Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The type of assignment relating an actor to assignmentScoped referenceable.
+
+
+### Scope Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the Referenceable that defines the scope of the assignment.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Actor Manager/Link_IT_Profile_Role_Appointment.md
+++ b/templates/basic/Actor Manager/Link_IT_Profile_Role_Appointment.md
@@ -1,0 +1,30 @@
+___
+
+## Link IT Profile Role Appointment
+> Appoints an IT profile to an IT profile role using ITProfileAppointment relationship.
+
+### IT Profile
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of an ITProfile.
+
+
+### IT Profile Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of an ITProfileRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Actor Manager/Link_Person_Role_Appointment.md
+++ b/templates/basic/Actor Manager/Link_Person_Role_Appointment.md
@@ -1,0 +1,38 @@
+___
+
+## Link Person Role Appointment
+> Appoints a person to a person role with an expected time allocation percentage using PersonRoleAppointment relationship.
+
+### Expected Time Allocation Percent
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Expected percentage of the appointee's time to be allocated to this role appointment (0-100).
+
+
+### Person
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a Person.
+
+
+### Person Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a PersonRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Actor Manager/Link_Team_Leader.md
+++ b/templates/basic/Actor Manager/Link_Team_Leader.md
@@ -1,0 +1,32 @@
+___
+
+## Link Team Leader
+> Links a team to a TeamLeader role (a PersonRole subtype) that leads it using AssignmentScope relationship.
+>
+>	**Alternative Names**: Link Team Leadership
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Leader Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the TeamLeader role (a PersonRole subtype).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Actor Manager/Link_Team_Membership.md
+++ b/templates/basic/Actor Manager/Link_Team_Membership.md
@@ -1,0 +1,32 @@
+___
+
+## Link Team Membership
+> Links a team to a TeamMember role (a PersonRole subtype) representing membership in the team using the AssignmentScope relationship.
+>
+>	**Alternative Names**: Link Team Member
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Member Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the TeamMember role (a PersonRole subtype).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Actor Manager/Link_Team_Role_Appointment.md
+++ b/templates/basic/Actor Manager/Link_Team_Role_Appointment.md
@@ -1,0 +1,38 @@
+___
+
+## Link Team Role Appointment
+> Appoints a team to a team role with an expected time allocation percentage using TeamRoleAppointment relationship.
+
+### Expected Time Allocation Percent
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Expected percentage of the appointee's time to be allocated to this role appointment (0-100).
+
+
+### Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the team.
+
+
+### Team Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of a TeamRole.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Actor Manager/Link_Team_Structure.md
+++ b/templates/basic/Actor Manager/Link_Team_Structure.md
@@ -1,0 +1,30 @@
+___
+
+## Link Team Structure
+> Links a parent (super) team to a child (sub) team in an organization's hierarchical team structure.
+
+### Sub Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the child (sub) team in a team hierarchy.
+
+
+### Super Team
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Qualified name of the parent (super) team in a team hierarchy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+___

--- a/templates/basic/Collections/Add_Member_to_Collection.md
+++ b/templates/basic/Collections/Add_Member_to_Collection.md
@@ -1,0 +1,54 @@
+___
+
+## Add Member to Collection
+> Add/Remove a member to/from a collection.
+>
+>	**Alternative Names**: Member; Member to Collection; Member to Folder; Member->Collection; Member from Collection; Member from Folder
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+___

--- a/templates/basic/Collections/Attach_Collection_to_Resource.md
+++ b/templates/basic/Collections/Attach_Collection_to_Resource.md
@@ -1,0 +1,70 @@
+___
+
+## Attach Collection to Resource
+> Connect an existing collection to an element using the ResourceList relationship.
+>
+>	**Alternative Names**: Collection to Resource; Collection from Resource
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Resource Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the supporting resource in a ResourceList relationship.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Resource Use
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Describes how the resource is being used. From the ResourceList relationship (0019).
+
+>	**Valid Values**: Validate Resource,Hosted Service,Supporting Template,Called Service,Supporting Person,Member Template,Supporting Team,Derived Element Template,Generate Insight,Activity Folder,Inform Steward,Certify Resource,Provision Resource,Hosted Connector,Improve Metadata Element,Survey Resource,Hosted Governance Engine,Watch Metadata Element,Data Specification,Choose Path,Supporting Process,Configure Connector,Catalog Resource,Create Subscription,Uncatalog Resource,Related Information,Cancel Subscription
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+___

--- a/templates/basic/Collections/Create_Collection.md
+++ b/templates/basic/Collections/Create_Collection.md
@@ -1,0 +1,116 @@
+___
+
+## Create Collection
+> Create or update a generic collection. While it can be used to create specific kinds of collections, you cannot set the collection-specific properties - so use the appropriate Dr.Egeria command to set all of the properties.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Collection_Folder.md
+++ b/templates/basic/Collections/Create_Collection_Folder.md
@@ -1,0 +1,118 @@
+___
+
+## Create Collection Folder
+> Create a CollectionFolder - a collection used to organize subsets of metadata elements within a larger collection hierarchy.
+>
+>	**Alternative Names**: Folder; Folders
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Folio.md
+++ b/templates/basic/Collections/Create_Folio.md
@@ -1,0 +1,118 @@
+___
+
+## Create Folio
+> Create a Folio - a  collection of your work.
+>
+>	**Alternative Names**: Folio Collection
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Home_Collection.md
+++ b/templates/basic/Collections/Create_Home_Collection.md
@@ -1,0 +1,116 @@
+___
+
+## Create Home Collection
+> Create a home collection to store things like favorites.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Namespace.md
+++ b/templates/basic/Collections/Create_Namespace.md
@@ -1,0 +1,116 @@
+___
+
+## Create Namespace
+> Create a Namespace collection - a collection of elements organized by namespace.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Recent_Access.md
+++ b/templates/basic/Collections/Create_Recent_Access.md
@@ -1,0 +1,116 @@
+___
+
+## Create Recent Access
+> Create a RecentAccess collection - a collection of elements accessed recently by a user.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Results_Set.md
+++ b/templates/basic/Collections/Create_Results_Set.md
@@ -1,0 +1,116 @@
+___
+
+## Create Results Set
+> Create a ResultsSet collection - a collection of elements that are the results from a specific request or query.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Root_Collection.md
+++ b/templates/basic/Collections/Create_Root_Collection.md
@@ -1,0 +1,118 @@
+___
+
+## Create Root Collection
+> Create a RootCollection - a master collection serving as the starting node for an independent collection hierarchy.
+>
+>	**Alternative Names**: Root Collection
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Security_Group.md
+++ b/templates/basic/Collections/Create_Security_Group.md
@@ -1,0 +1,124 @@
+___
+
+## Create Security Group
+> A group (collection) of actors that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Security_List.md
+++ b/templates/basic/Collections/Create_Security_List.md
@@ -1,0 +1,124 @@
+___
+
+## Create Security List
+> A group (collection) of identities that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Security_Role.md
+++ b/templates/basic/Collections/Create_Security_Role.md
@@ -1,0 +1,124 @@
+___
+
+## Create Security Role
+> A group (collection) of roles that need to be given the same access to a specific set of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Distinguished Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Distinguished name for security group.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Subject_Area.md
+++ b/templates/basic/Collections/Create_Subject_Area.md
@@ -1,0 +1,116 @@
+___
+
+## Create Subject Area
+> Create a SubjectArea - a  collection of material on the same topic.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Collections/Create_Work_Item_List.md
+++ b/templates/basic/Collections/Create_Work_Item_List.md
@@ -1,0 +1,116 @@
+___
+
+## Create Work Item List
+> Create a WorkItemList collection - a collection organizing work items such as ToDos or Tasks.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Assign_Data_Value_Specification.md
+++ b/templates/basic/Data Designer/Assign_Data_Value_Specification.md
@@ -1,0 +1,54 @@
+___
+
+## Assign Data Value Specification
+> Link a data value specification, DataClass, DataGrain,  to a referenceable element providing a definition.
+>
+>	**Alternative Names**: Link Data Value Specification; Attach Data Value Specification to Element
+
+### Data Value Specification
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Assignment Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Status of a value assignment.
+
+>	**Valid Values**: DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: DISCOVERED
+
+
+### Method
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A method for value assignment.
+
+
+### Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: Threshold  for assignment.
+
+
+___

--- a/templates/basic/Data Designer/Attach_Data_Description_to_Element.md
+++ b/templates/basic/Data Designer/Attach_Data_Description_to_Element.md
@@ -1,0 +1,53 @@
+___
+
+## Attach Data Description to Element
+> Connect an existing data describing collection to an element using the DataDescription relationship (0580).
+
+>
+>	**Alternative Names**: Attach Data Description->Element
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Collection Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the collection.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Class.md
+++ b/templates/basic/Data Designer/Create_Data_Class.md
@@ -1,0 +1,308 @@
+___
+
+## Create Data Class
+> Creates or updates a data class — a description of the values that may be stored in data fields. Supports composition via Containing Data Class and specialization via Specializes Data Class. Can be used to configure quality validators and data field classifiers.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Allow Duplicate Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the data class allows duplicate values in the data field.
+
+>	**Default Value**: true
+
+
+### Average Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A typical or average value for the data class, used in data quality assessments.
+
+
+### Containing Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that this data class is composed within (DataClassComposition relationship).
+
+
+### Data Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Regular expressions or patterns that describe the format of valid values for this data class.
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### Is Case Sensitive
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, values for this data class or field are case-sensitive.
+
+>	**Default Value**: false
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Sample Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Representative example values that illustrate the expected content of this data class or field.
+
+
+### Value List
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: An enumerated list of valid values for this data class.
+
+
+### Value Range From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The lower bound of the valid value range for this data class.
+
+
+### Value Range To
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The upper bound of the valid value range for this data class.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Dictionary.md
+++ b/templates/basic/Data Designer/Create_Data_Dictionary.md
@@ -1,0 +1,118 @@
+___
+
+## Create Data Dictionary
+> Creates or updates a data dictionary — an organized collection of defined data fields serving as a knowledge base of preferred data definitions. Implemented as a Collection with the DataDictionary classification.
+>
+>	**Alternative Names**: Data Dict
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Field.md
+++ b/templates/basic/Data Designer/Create_Data_Field.md
@@ -1,0 +1,426 @@
+___
+
+## Create Data Field
+> Creates or updates a data field — a named, typed element within a data structure. Supports nesting via In Data Field and data class assignment.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### In Data Field
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data field that this element is nested within (NestedDataField relationship).
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of characters or digits allowed in the field.
+
+
+### Maximum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of times this field may appear in the containing data structure (-1 means unbounded).
+
+>	**Default Value**: 1
+
+
+### Minimum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of times this field must appear in the containing data structure.
+
+>	**Default Value**: 1
+
+
+### Minimum Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of characters or digits required in the field.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Ordered Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the values in this field are ordered (i.e. sequence matters).
+
+
+### Position
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The ordinal position of the data field within its containing data structure.
+
+>	**Default Value**: 0
+
+
+### Precision
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of significant digits after the decimal point for numeric fields.
+
+
+### Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The sort order for values in this field. Valid values from DataItemSortOrder enum: UNKNOWN, UNSORTED, ASCENDING, DESCENDING, OTHER.
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Allow Duplicate Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the data class allows duplicate values in the data field.
+
+>	**Default Value**: true
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### Default Value
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The default value assigned to this field or data class when no value is supplied.
+
+
+### In Data Field
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data field that this element is nested within (NestedDataField relationship).
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Is Nullable
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the field may hold null values.
+
+>	**Default Value**: true
+
+
+### Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of characters or digits allowed in the field.
+
+
+### Maximum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The maximum number of times this field may appear in the containing data structure (-1 means unbounded).
+
+>	**Default Value**: 1
+
+
+### Minimum Cardinality
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of times this field must appear in the containing data structure.
+
+>	**Default Value**: 1
+
+
+### Minimum Length
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum number of characters or digits required in the field.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Ordered Values
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, the values in this field are ordered (i.e. sequence matters).
+
+
+### Position
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The ordinal position of the data field within its containing data structure.
+
+>	**Default Value**: 0
+
+
+### Precision
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of significant digits after the decimal point for numeric fields.
+
+
+### Sort Order
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The sort order for values in this field. Valid values from DataItemSortOrder enum: UNKNOWN, UNSORTED, ASCENDING, DESCENDING, OTHER.
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Grain.md
+++ b/templates/basic/Data Designer/Create_Data_Grain.md
@@ -1,0 +1,238 @@
+___
+
+## Create Data Grain
+> Creates or updates a data grain — a defined granularity of data that can be associated with a data field or data lens.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Granularity Basis
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The basis on which the granularity is defined (e.g. time period, geographic region, customer segment). UML type: string — no enum defined in Egeria open types.
+
+
+### Grain Statement
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A human-readable statement describing the granularity of the data grain (e.g. 'one row per customer per day').
+
+
+### Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The time interval in milliseconds between data captures for time-based data grains.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Spec.md
+++ b/templates/basic/Data Designer/Create_Data_Spec.md
@@ -1,0 +1,118 @@
+___
+
+## Create Data Spec
+> Creates or updates a data specification — a collection describing the data requirements for a project or initiative. Its members are typically data structures. Implemented as a Collection with the DataSpec classification.
+>
+>	**Alternative Names**: Data Specification
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Structure.md
+++ b/templates/basic/Data Designer/Create_Data_Structure.md
@@ -1,0 +1,164 @@
+___
+
+## Create Data Structure
+> Creates or updates a data structure — a collection of data fields that defines the structure for a data source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### In Data Dictionary
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data dictionary that contains this data structure.
+
+
+### In Data Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data specification that contains this data structure.
+
+
+### In Data Structure
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data structure that contains this data field (MemberDataField relationship).
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### In Data Dictionary
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data dictionary that contains this data structure.
+
+
+### In Data Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data specification that contains this data structure.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Data_Value_Specification.md
+++ b/templates/basic/Data Designer/Create_Data_Value_Specification.md
@@ -1,0 +1,214 @@
+___
+
+## Create Data Value Specification
+> Creates or updates a data value classification which represents the characteristics of a data value. DataClass and DataGrain are subtypes.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Absolute Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The absolute margin of error for numeric values in this data value specification (in the same units as the value).
+
+
+### Data Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The data type of the field or value specification (e.g. string, int, date, boolean).
+
+>	**Valid Values**: string,int,long,date,boolean,char,byte,float,double,biginteger,bigdecimal,array<string>,array<int>,map<string,string>,map<string,boolean>,map<string,int>,map<string,long>,map<string,double>,map<string,date>,map<string,object>,short,map<string,array<string>>,other
+
+>	**Default Value**: string
+
+
+### In Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification that this element is a sub-specification of (DataValueHierarchy relationship).
+
+>	**Alternative Labels**: In Data Class; In Data Grain
+
+
+### Match Property Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The names of the properties used when matching values against this data value specification.
+
+
+### Match Threshold
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The confidence threshold (0-100) required for a value to be considered a match for this data value specification.
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Namespace Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The namespace path that qualifies the element's name within a larger naming hierarchy.
+
+
+### Relative Uncertainty
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: The relative margin of error for values in this data value specification, expressed as a percentage (0-100).
+
+
+### Specializes Data Value Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent data value specification that this one specializes or refines.
+
+
+### Specification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A formal or technical specification string that describes the valid values or format for this data value specification.
+
+
+### Specification Details
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Additional key-value details that extend the formal specification for this data value specification.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Units
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The unit of measure for numeric values in this field or specification (e.g. metres, kg, USD).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Create_Report_Type.md
+++ b/templates/basic/Data Designer/Create_Report_Type.md
@@ -1,0 +1,116 @@
+___
+
+## Create Report Type
+> A type of report that inherits from Data Spec (and Collection)
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Data Designer/Link_Certification_Type_to_Data_Structure.md
+++ b/templates/basic/Data Designer/Link_Certification_Type_to_Data_Structure.md
@@ -1,0 +1,48 @@
+___
+
+## Link Certification Type to Data Structure
+> Link a data structure to a certification type. In defining a certification type,  this assigns the data structure to this type of certification.
+
+### Data Structure
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data structure name. Preferably a qualified name.
+
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Data Designer/Link_Data_Class_Composition.md
+++ b/templates/basic/Data Designer/Link_Data_Class_Composition.md
@@ -1,0 +1,48 @@
+___
+
+## Link Data Class Composition
+> Link a child data class to a parent data class. 
+
+### Data Class Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Data Class
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data class that specifies the valid values or patterns for this data field (DataValueDefinition relationship).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Data Designer/Link_Data_Field.md
+++ b/templates/basic/Data Designer/Link_Data_Field.md
@@ -1,0 +1,64 @@
+___
+
+## Link Data Field
+> Links or unlinks two data fields via the LinkedDataField relationship, with an optional relationship type name to describe the nature of the association (e.g. ForeignKey, DerivedFrom).
+
+### Linked Data Field 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first data field in a LinkedDataField peer relationship.
+
+
+### Linked Data Field 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second data field in a LinkedDataField peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Link Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the relationship used in a LinkedDataField connection.
+
+
+### Link Relationship Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the relationship used in a LinkedDataField connection.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Data Designer/Link_Data_Field_to_Data_Structure.md
+++ b/templates/basic/Data Designer/Link_Data_Field_to_Data_Structure.md
@@ -1,0 +1,50 @@
+___
+
+## Link Data Field to Data Structure
+> Links a data field to a data structure via the MemberDataField relationship.
+>
+>	**Alternative Names**: Link Data Field to Structure; Link Field to Structure
+
+### Data Field
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data field  name. Preferably a qualified name.
+
+
+### Data Structure
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A data structure name. Preferably a qualified name.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Data Designer/Link_Data_Value_Composition.md
+++ b/templates/basic/Data Designer/Link_Data_Value_Composition.md
@@ -1,0 +1,48 @@
+___
+
+## Link Data Value Composition
+> Link a data value specification, DataClass, DataGrain,  to a referenceable element providing a definition.
+
+### Data Value Specification
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Data Value Specification Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The data value specification to use in a relationship. Preferable to use a qualified name.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_Agreement.md
+++ b/templates/basic/Digital Product Manager/Create_Agreement.md
@@ -1,0 +1,124 @@
+___
+
+## Create Agreement
+> A kind of collection that represents an Agreement. This is for generic agreements. Specific kinds of agreements have their own commands.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_CSV_File.md
+++ b/templates/basic/Digital Product Manager/Create_CSV_File.md
@@ -1,0 +1,148 @@
+___
+
+## Create CSV File
+> Create a CSV File asset.
+>
+>	**Alternative Names**: Create CSV
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+### File Encoding
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Encoding of the file.
+
+>	**Default Value**: UTF-8
+
+
+### File Extension
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Typically CSV.
+
+>	**Default Value**: csv
+
+
+### File Path
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Path to the file including file name. File system name is pre-pended if set.
+
+>	**Alternative Labels**: File Path Name
+
+
+### File System Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Optional  file system name to be prepended in front of the path name.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_Data_Sharing_Agreement.md
+++ b/templates/basic/Digital Product Manager/Create_Data_Sharing_Agreement.md
@@ -1,0 +1,124 @@
+___
+
+## Create Data Sharing Agreement
+> Create a new collection with the DataSharingAgreement classification.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_Digital_Product.md
+++ b/templates/basic/Digital Product Manager/Create_Digital_Product.md
@@ -1,0 +1,190 @@
+___
+
+## Create Digital Product
+> A Digital Product represents artifacts that can be subscribed to and consumed by users.
+>
+>	**Alternative Names**: Data Product
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Current Version
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The current version identifier of the digital product.
+
+
+### Introduction Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of product introduction in ISO 8601 format.
+
+
+### Maturity
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Product maturity - user defined.
+
+
+### Next Version Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the next version of the digital product is expected, in ISO 8601 format.
+
+
+### Product Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The human-readable name of the digital product.
+
+
+### Product Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Lifecycle status of the digital product.
+
+
+### Product Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of digital product (e.g., Periodic Delta, On Demand, Snapshot).
+
+
+### Service Life
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The estimated operational lifetime of the digital product.
+
+
+### Withdrawal Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of planned product withdrawal in ISO 8601 format.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_Digital_Product_Catalog.md
+++ b/templates/basic/Digital Product Manager/Create_Digital_Product_Catalog.md
@@ -1,0 +1,116 @@
+___
+
+## Create Digital Product Catalog
+> Create a Digital Product Catalog - a root collection that organizes digital products into a browsable catalog.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Digital Product Manager/Create_Digital_Subscription.md
+++ b/templates/basic/Digital Product Manager/Create_Digital_Subscription.md
@@ -1,0 +1,142 @@
+___
+
+## Create Digital Subscription
+> A type of agreement for a digital subscription.
+>
+>	**Alternative Names**: Create Product Subscription
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Agreement Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of agreement (e.g., service level agreement, licensing agreement, data sharing agreement).
+
+
+### Subscription Level
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Level or tier of the subscription (e.g., basic, premium, enterprise).
+
+
+### Support Level
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Level of support provided with the subscription (e.g., community, business hours, 24/7).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Digital Product Manager/Link_Agreement_Actor.md
+++ b/templates/basic/Digital Product Manager/Link_Agreement_Actor.md
@@ -1,0 +1,58 @@
+___
+
+## Link Agreement Actor
+> Link an actor (role or person) to an Agreement, defining their role and responsibilities within it.
+>
+>	**Alternative Names**: Agreement to Actor; Agreement from Actor
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Actor Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the actor (role or person) associated with this agreement relationship.
+
+
+### Actors
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Actors or Solution Roles related to this element.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Digital Product Manager/Link_Agreement_Item.md
+++ b/templates/basic/Digital Product Manager/Link_Agreement_Item.md
@@ -1,0 +1,122 @@
+___
+
+## Link Agreement Item
+> Attach or detach an agreement to an element referenced in its definition. Agreement item can be any referenceable element.
+>
+>	**Alternative Names**: Agreement from Item; Agreement to Item
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Item Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the referenceable item to add to an agreement. Using qualified names is recommended.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Agreement End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the agreement expires or was terminated, in ISO 8601 format.
+
+
+### Agreement Item Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified agreement item identifier.
+
+
+### Agreement Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date when the agreement becomes effective, in ISO 8601 format.
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Usage Measurements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing usage measurements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/basic/Digital Product Manager/Link_Contract.md
+++ b/templates/basic/Digital Product Manager/Link_Contract.md
@@ -1,0 +1,82 @@
+___
+
+## Link Contract
+> Attach or detach an agreement to a related document with the ContractLink relationship
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Contract Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified contract identifier.
+
+
+### Contract Liaison
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The liaison for a contract.
+
+
+### Contract Liaison Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property to use for the contract liaison.
+
+
+### Contract Liaison Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The liason for a contract.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Digital Product Manager/Link_Digital_Subscriber.md
+++ b/templates/basic/Digital Product Manager/Link_Digital_Subscriber.md
@@ -1,0 +1,54 @@
+___
+
+## Link Digital Subscriber
+> Attach or detach a subscriber to a subscription. Subscriber can be any type of element.
+>
+>	**Alternative Names**: Subscriber to Subscription; Subscribers; Subscribers from Subscription
+
+### Subscriber Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Referenceable acting as subscriber in a DigitalSubscriber relationship.
+
+>	**Alternative Labels**: Subscriber; Subscriber ID
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Subscription Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the DigitalSubscription being subscribed to.
+
+>	**Alternative Labels**: Subscription;Subscription ID
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Digital Product Manager/Link_Product_Dependency.md
+++ b/templates/basic/Digital Product Manager/Link_Product_Dependency.md
@@ -1,0 +1,66 @@
+___
+
+## Link Product Dependency
+> Link digital product dependency between two digital products.
+>
+>	**Alternative Names**: Digital Product - Digital Product; Digital Product to Digital Product; Digital Products
+
+### Digital Product 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first Digital Product in a DigitalProductDependency relationship.
+
+
+### Digital Product 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second Digital Product in a DigitalProductDependency relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Dependency Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Description of the dependency between two digital products.
+
+
+### Dependency Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Description of the dependency between two digital products.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/External Reference/Create_Cited_Document.md
+++ b/templates/basic/External Reference/Create_Cited_Document.md
@@ -1,0 +1,264 @@
+___
+
+## Create Cited Document
+> Create or update a Cited Document - an external reference to a published document with full bibliographic metadata.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Edition
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The edition being cited.
+
+
+### First Publication Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date of first publication in ISO 8601 format (e.g. 2025-01-31).
+
+
+### Number of Pages
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of pages in the document.
+
+
+### Page Range
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The range of pages cited.
+
+
+### Publication City
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: City of publication.
+
+
+### Publication Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Publication date in ISO 8601 format (e.g. 2025-02-23).
+
+
+### Publication Numbers
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Identification numbers of the publication (ISBN, ISSN, DOI, etc.).
+
+
+### Publication Series
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The series this publication is part of.
+
+>	**Alternative Labels**: Series
+
+
+### Publication Series Volume
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The volume in the series that contains the citation.
+
+
+### Publication Year
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Year of publication.
+
+
+### Publisher
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the publisher.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Create_External_Data_Source.md
+++ b/templates/basic/External Reference/Create_External_Data_Source.md
@@ -1,0 +1,174 @@
+___
+
+## Create External Data Source
+> Create or update an External Data Source - an external reference that refers to an external data source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Create_External_Model_Source.md
+++ b/templates/basic/External Reference/Create_External_Model_Source.md
@@ -1,0 +1,174 @@
+___
+
+## Create External Model Source
+> Create or update an External Model Source - an external reference that refers to an external analytical or AI model source.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Create_External_Reference.md
+++ b/templates/basic/External Reference/Create_External_Reference.md
@@ -1,0 +1,174 @@
+___
+
+## Create External Reference
+> Create or update an External Reference - a Referenceable that describes an external source of information.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Create_External_Source_Code.md
+++ b/templates/basic/External Reference/Create_External_Source_Code.md
@@ -1,0 +1,174 @@
+___
+
+## Create External Source Code
+> Create or update an External Source Code reference - an external reference that refers to software source code. If the component created from this source code is catalogued, it is linked to the ExternalSourceCode using the ExternalReferenceLink relationship.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Create_Related_Media.md
+++ b/templates/basic/External Reference/Create_Related_Media.md
@@ -1,0 +1,212 @@
+___
+
+## Create Related Media
+> Create or update Related Media - an external reference to media such as images, audio, video or documents.
+>
+>	**Alternative Names**: Media
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Attribution
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Attribution string to describe the external reference.
+
+
+### Copyright
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The copyright associated with the external reference.
+
+
+### License
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The license associated with the external reference.
+
+
+### Organization
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Organization owning the external reference.
+
+
+### Reference Abstract
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Abstract for the remote reference.
+
+>	**Alternative Labels**: Abstract
+
+
+### Reference Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the external reference.
+
+>	**Alternative Labels**: Title
+
+
+### Sources
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A map of source strings (e.g. URL, DOI, ISBN).
+
+>	**Alternative Labels**: Reference Sources
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Default Media Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How the media is being used by default.
+
+>	**Valid Values**: ICON,THUMBNAIL,ILLUSTRATION,USAGE_GUIDANCE,OTHER
+
+
+### Default Media Usage Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the default media usage when not using a standard valid value.
+
+
+### Media Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Type of media (e.g. image, audio, video, document).
+
+>	**Valid Values**: IMAGE,AUDIO,DOCUMENT,VIDEO,OTHER
+
+
+### Media Type Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the media type when not using a standard valid value.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/External Reference/Link_Cited_Document.md
+++ b/templates/basic/External Reference/Link_Cited_Document.md
@@ -1,0 +1,42 @@
+___
+
+## Link Cited Document
+> Link a cited document to a referenceable via the DocumentCitationLink relationship.
+>
+>	**Alternative Names**: Link Referenceable->Cited Document; Link Cited Document
+
+### Cited Document
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The cited document to link to.
+
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### Pages
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The specific pages referenced in the cited document.
+
+
+### Reference Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identifier of the cited document in the link context.
+
+
+___

--- a/templates/basic/External Reference/Link_External_Reference.md
+++ b/templates/basic/External Reference/Link_External_Reference.md
@@ -1,0 +1,52 @@
+___
+
+## Link External Reference
+> Link an external reference to a referenceable.
+>
+>	**Alternative Names**: Referenceable->External Reference; External Reference; External Data Source; External Model Source
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### External Reference
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The external reference to link to.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/External Reference/Link_Media_Reference.md
+++ b/templates/basic/External Reference/Link_Media_Reference.md
@@ -1,0 +1,52 @@
+___
+
+## Link Media Reference
+> Link a related media reference to a referenceable via the MediaReferenceLink relationship.
+>
+>	**Alternative Names**: Referenceable->Media Reference; Media Reference
+
+### Element Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A referenceable to link to the external reference.
+
+>	**Alternative Labels**: Referenceable
+
+
+### Media Reference
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The related media reference to link to.
+
+
+### Media Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An identifier of the media being referenced.
+
+
+### Media Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: How the media is being used in this specific link.
+
+>	**Valid Values**: ICON,THUMBNAIL,ILLUSTRATION,USAGE_GUIDANCE,OTHER
+
+
+### Media Usage Other Id
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An id associated with the media usage when not using a standard valid value.
+
+
+___

--- a/templates/basic/Feedback/Attach_Comment.md
+++ b/templates/basic/Feedback/Attach_Comment.md
@@ -1,0 +1,32 @@
+___
+
+## Attach Comment
+> Attach a comment to a referenceable element via the AttachedComment relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Feedback/Attach_Like.md
+++ b/templates/basic/Feedback/Attach_Like.md
@@ -1,0 +1,48 @@
+___
+
+## Attach Like
+> Attach a like to a referenceable element via the AttachedLike relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Emoji
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An emoji associated with a Like.
+
+
+### Liked Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being liked.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Feedback/Attach_Rating.md
+++ b/templates/basic/Feedback/Attach_Rating.md
@@ -1,0 +1,58 @@
+___
+
+## Attach Rating
+> Attach a star rating to a referenceable element via the AttachedRating relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Reviewed Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being rated.
+
+
+### Review
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Text review accompanying a star rating.
+
+
+### Stars
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Star rating for an element.
+
+>	**Valid Values**: NO_RECOMMENDATION,ONE_STAR,TWO_STARS,THREE_STARS,FOUR_STARS,FIVE_STARS
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Feedback/Attach_Tag.md
+++ b/templates/basic/Feedback/Attach_Tag.md
@@ -1,0 +1,48 @@
+___
+
+## Attach Tag
+> Attach an informal tag to a referenceable element via the AttachedTag relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Informal Tag
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The informal tag being attached.
+
+
+### Tagged Element
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being tagged.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Feedback/Create_Blog_Entry.md
+++ b/templates/basic/Feedback/Create_Blog_Entry.md
@@ -1,0 +1,80 @@
+___
+
+## Create Blog Entry
+> Add a blog entry.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Feedback/Create_Comment.md
+++ b/templates/basic/Feedback/Create_Comment.md
@@ -1,0 +1,110 @@
+___
+
+## Create Comment
+> Creates a comment on a metadata element.
+>
+>	**Alternative Names**: Add Comment
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Commented On Element
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The element being commented on.
+
+>	**Alternative Labels**: Associated Element
+
+
+### Comment Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The type of comment.
+
+>	**Valid Values**: STANDARD_COMMENT,QUESTION,ANSWER,SUGGESTION,USAGE_EXPERIENCE,REQUIREMENT,OTHER
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Feedback/Create_Informal_Tag.md
+++ b/templates/basic/Feedback/Create_Informal_Tag.md
@@ -1,0 +1,88 @@
+___
+
+## Create Informal Tag
+> Creates an informal tag — a user-defined label that can be attached to any referenceable element.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+___

--- a/templates/basic/Feedback/Create_Journal_Activity.md
+++ b/templates/basic/Feedback/Create_Journal_Activity.md
@@ -1,0 +1,80 @@
+___
+
+## Create Journal Activity
+> Journal about your actiity.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Feedback/Create_Like.md
+++ b/templates/basic/Feedback/Create_Like.md
@@ -1,0 +1,80 @@
+___
+
+## Create Like
+> Creates a like (with optional emoji) on a metadata element.
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Feedback/Create_Log_Activity.md
+++ b/templates/basic/Feedback/Create_Log_Activity.md
@@ -1,0 +1,80 @@
+___
+
+## Create Log Activity
+> Log my activity.
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: 
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Feedback/Create_Rating.md
+++ b/templates/basic/Feedback/Create_Rating.md
@@ -1,0 +1,98 @@
+___
+
+## Create Rating
+> Creates a star rating on a metadata element.
+
+### Stars
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Star rating for an element.
+
+>	**Valid Values**: NO_RECOMMENDATION,ONE_STAR,TWO_STARS,THREE_STARS,FOUR_STARS,FIVE_STARS
+
+
+### Review
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Text review accompanying a star rating.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Feedback/Link_Accept_Answer.md
+++ b/templates/basic/Feedback/Link_Accept_Answer.md
@@ -1,0 +1,48 @@
+___
+
+## Link Accept Answer
+> Link a question comment to the comment that answers it via the AcceptedAnswer relationship.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Accepted Answer Comment
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The question comment that has been answered.
+
+
+### Answering Comment
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The comment accepted as an answer.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Glossary/Create_Glossary.md
+++ b/templates/basic/Glossary/Create_Glossary.md
@@ -1,0 +1,132 @@
+___
+
+## Create Glossary
+> Creates or updates a glossary — a collection of related terms for a specific domain or purpose.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Language
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The primary language of the glossary. Note that multilingual descriptions are supported.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Glossary/Create_Glossary_Term.md
+++ b/templates/basic/Glossary/Create_Glossary_Term.md
@@ -1,0 +1,174 @@
+___
+
+## Create Glossary Term
+> Creates or updates a glossary term — a concept, phrase, or word defined within a glossary.
+>
+>	**Alternative Names**: Term
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Abbreviation
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An abbreviation for the glossary term.
+
+
+### Example
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An example of how the glossary term is used.
+
+>	**Alternative Labels**: Examples
+
+
+### Folders
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Existing folder collections that you'd like to make the term a member of.
+
+>	**Alternative Labels**: Folders; Collection Folders
+
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Aliases
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Alternative names for this  field, used in different systems or contexts.
+
+>	**Alternative Labels**: Alias
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Glossary/Link_Term-Term_Relationship.md
+++ b/templates/basic/Glossary/Link_Term-Term_Relationship.md
@@ -1,0 +1,18 @@
+___
+
+## Link Term-Term Relationship
+> Links or unlinks two glossary terms via a typed semantic relationship (e.g. Synonym, Antonym, PreferredTerm, TranslationOf).
+>
+>	**Alternative Names**: Term-Term Relationship; Term to Term Relationship
+
+### Relationship Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Enum
+
+>	**Description**: The type of relationship connecting the two terms. E.g. Synonym, Antonym, PreferredTerm, ReplacedByTerm, TranslationOf, etc.
+
+>	**Valid Values**: RelatedTerm,Synonym,Antonym,PreferredTerm,ReplacementTerm,Translation,ISA,ValidValue,ISARelationship,TermHASARelationship,TYPED BY,TermTYPEDBYRelationship,TYPE OF,TermISATYPEOFRelationship
+
+
+___

--- a/templates/basic/Glossary/Link_Term_as_Context.md
+++ b/templates/basic/Glossary/Link_Term_as_Context.md
@@ -1,0 +1,38 @@
+___
+
+## Link Term as Context
+> Relates a glossary term as context to a referenceable.
+>
+>	**Alternative Names**: Used in Context; Term as Context
+
+### Relationship Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Enum
+
+>	**Description**: The type of relationship connecting the two terms. E.g. Synonym, Antonym, PreferredTerm, ReplacedByTerm, TranslationOf, etc.
+
+>	**Valid Values**: RelatedTerm,Synonym,Antonym,PreferredTerm,ReplacementTerm,Translation,ISA,ValidValue,ISARelationship,TermHASARelationship,TYPED BY,TermTYPEDBYRelationship,TYPE OF,TermISATYPEOFRelationship
+
+
+### Term 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the first term to connect.
+
+>	**Alternative Labels**: Term; Term Name
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+___

--- a/templates/basic/Glossary/Set_Glossary_as_Taxonomy.md
+++ b/templates/basic/Glossary/Set_Glossary_as_Taxonomy.md
@@ -1,0 +1,90 @@
+___
+
+## Set Glossary as Taxonomy
+> Classify a glossary as a Taxonomy
+
+### Glossary Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Zero or more existing glossaries that this term is a member of.
+
+>	**Alternative Labels**: Glossary; Glossaries; In Glossaries; In Glossary; Glossary Names
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user specified category name that can be used for example, to define product types or agreement types.
+
+>	**Alternative Labels**: Category Name
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: A unique qualified name for the element. Generated using the qualified name pattern  if not user specified.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Published product version identifier.
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: role identifier
+
+>	**Alternative Labels**: ID
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A system generated unique identifier.
+
+>	**Alternative Labels**: Guid; guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Link to supporting information
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Keywords to facilitate finding the element
+
+
+___

--- a/templates/basic/Governance Officer/Create_Business_Imperative.md
+++ b/templates/basic/Governance Officer/Create_Business_Imperative.md
@@ -1,0 +1,176 @@
+___
+
+## Create Business Imperative
+> The BusinessImperative entity defines a business goal that is critical to the success of the organization.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Certification_Type.md
+++ b/templates/basic/Governance Officer/Create_Certification_Type.md
@@ -1,0 +1,222 @@
+___
+
+## Create Certification Type
+> A type of certification.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Data_Lens.md
+++ b/templates/basic/Governance Officer/Create_Data_Lens.md
@@ -1,0 +1,262 @@
+___
+
+## Create Data Lens
+> A DataLens defines a geographic, temporal, and element scope for data collection and analysis.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Max Height
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum height of the vertical scope.
+
+
+### Data Collection End Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: End time for the data collection period.
+
+
+### Data Collection Start Time
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Start time for the data collection period.
+
+
+### Max Latitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum latitude of the geographic scope.
+
+
+### Max Longitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Maximum longitude of the geographic scope.
+
+
+### Min Height
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum height of the vertical scope.
+
+
+### Min Latitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum latitude of the geographic scope.
+
+
+### Min Longitude
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Float
+
+>	**Description**: Minimum longitude of the geographic scope.
+
+
+### Scope Elements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: Map of element identifiers defining the scope of the data lens.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Data_Processing_Purpose.md
+++ b/templates/basic/Governance Officer/Create_Data_Processing_Purpose.md
@@ -1,0 +1,186 @@
+___
+
+## Create Data Processing Purpose
+> Privacy regulations such as  (GDPR) require data subjects to agree the processing that is permitted on their data.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Action.md
+++ b/templates/basic/Governance Officer/Create_Governance_Action.md
@@ -1,0 +1,186 @@
+___
+
+## Create Governance Action
+> An executable action, or sequence of actions to support a governance requirement.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Approach.md
+++ b/templates/basic/Governance Officer/Create_Governance_Approach.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Approach
+> The GovernanceApproach entity defines a policy that describes a method that should be used for a particular activity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Control.md
+++ b/templates/basic/Governance Officer/Create_Governance_Control.md
@@ -1,0 +1,186 @@
+___
+
+## Create Governance Control
+> A governance control describes how a particular governance policy should be implemented. There are many types of controls.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Definition.md
+++ b/templates/basic/Governance Officer/Create_Governance_Definition.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Definition
+> Create a general governance definition.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Driver.md
+++ b/templates/basic/Governance Officer/Create_Governance_Driver.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Driver
+> A motivating topic leading to governance work.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Metric.md
+++ b/templates/basic/Governance Officer/Create_Governance_Metric.md
@@ -1,0 +1,202 @@
+___
+
+## Create Governance Metric
+> A governance metric describes measurements that support governance requirements.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Measurement
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A measurement for a governance metric.
+
+
+### Target
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Target values for a measurement.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Obligation.md
+++ b/templates/basic/Governance Officer/Create_Governance_Obligation.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Obligation
+> The GovernanceObligation entity defines a policy that describes a requirement that must be met.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Policy.md
+++ b/templates/basic/Governance Officer/Create_Governance_Policy.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Policy
+> Policies  created in response to governance drivers. There are several types of policies.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Principle.md
+++ b/templates/basic/Governance Officer/Create_Governance_Principle.md
@@ -1,0 +1,176 @@
+___
+
+## Create Governance Principle
+> The GovernancePrinciple entity defines a policy that describes an end state that the organization aims to achieve.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Procedure.md
+++ b/templates/basic/Governance Officer/Create_Governance_Procedure.md
@@ -1,0 +1,186 @@
+___
+
+## Create Governance Procedure
+> A manual procedure that is performed under certain circumstances.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Responsibility.md
+++ b/templates/basic/Governance Officer/Create_Governance_Responsibility.md
@@ -1,0 +1,186 @@
+___
+
+## Create Governance Responsibility
+> A responsibility assigned to an actor or team. It could be a requirement to take a certain action in specific circumstances or to make decisions or give approvals for actions.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Rule.md
+++ b/templates/basic/Governance Officer/Create_Governance_Rule.md
@@ -1,0 +1,186 @@
+___
+
+## Create Governance Rule
+> An executable rule that can be deployed at particular points in the operations.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Strategy.md
+++ b/templates/basic/Governance Officer/Create_Governance_Strategy.md
@@ -1,0 +1,184 @@
+___
+
+## Create Governance Strategy
+> The strategy used in the development of the governance domains activities. How the governance domain supports the business strategy.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Business Imperatives
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Defines the list of business imperatives the strategy supports.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Governance_Zone.md
+++ b/templates/basic/Governance Officer/Create_Governance_Zone.md
@@ -1,0 +1,194 @@
+___
+
+## Create Governance Zone
+> A collection of assets that are used or processed in a specific way. Policies and controls can be attached to zones using the GovernedBy relationship.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The criteria for membership in a governance zone.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_License_Type.md
+++ b/templates/basic/Governance Officer/Create_License_Type.md
@@ -1,0 +1,222 @@
+___
+
+## Create License Type
+> A type of license.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Methodology.md
+++ b/templates/basic/Governance Officer/Create_Methodology.md
@@ -1,0 +1,186 @@
+___
+
+## Create Methodology
+> A Methodology describes a specific approach or framework for governance processes.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Naming_Standard_Rule.md
+++ b/templates/basic/Governance Officer/Create_Naming_Standard_Rule.md
@@ -1,0 +1,194 @@
+___
+
+## Create Naming Standard Rule
+> A standard for naming specific kinds of resources.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Name Patterns
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Name patterns for naming standard rules.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Notification_Type.md
+++ b/templates/basic/Governance Officer/Create_Notification_Type.md
@@ -1,0 +1,244 @@
+___
+
+## Create Notification Type
+> A NotificationType defines a type of notification that can be sent as a governance control.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Multiple Notifications Permitted
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: Whether multiple notifications are permitted for this notification type.
+
+>	**Default Value**: True
+
+
+### Next Scheduled Notification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The date of the next scheduled notification.
+
+
+### Notification Count
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of notifications sent so far.
+
+
+### Notification Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The interval between scheduled notifications in milliseconds.
+
+
+### Minimum Notification Interval
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The minimum interval between notifications in milliseconds.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Regulation.md
+++ b/templates/basic/Governance Officer/Create_Regulation.md
@@ -1,0 +1,192 @@
+___
+
+## Create Regulation
+> Defines a relevant legal regulation that the business operation must comply with. Often regulations are divided into regulation articles.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Regulation Source
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The source of the regulation - often, an authority.
+
+
+### Regulators
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of regulators.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Regulation_Article.md
+++ b/templates/basic/Governance Officer/Create_Regulation_Article.md
@@ -1,0 +1,176 @@
+___
+
+## Create Regulation Article
+> A RegulationArticle entity is an article in a regulation. Dividing a regulation  simplifies planning and execution.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Security_Access_Control.md
+++ b/templates/basic/Governance Officer/Create_Security_Access_Control.md
@@ -1,0 +1,186 @@
+___
+
+## Create Security Access Control
+> A technical control that defines the access control lists that an actor must belong to be entitled to perform a specific action.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Service_Level_Objective.md
+++ b/templates/basic/Governance Officer/Create_Service_Level_Objective.md
@@ -1,0 +1,188 @@
+___
+
+## Create Service Level Objective
+> Defines the performance, availability and quality levels expected by the element attached.
+>
+>	**Alternative Names**: Service Level Objectives
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Terms_and_Conditions.md
+++ b/templates/basic/Governance Officer/Create_Terms_and_Conditions.md
@@ -1,0 +1,224 @@
+___
+
+## Create Terms and Conditions
+> A defined set of terms and conditions.
+>
+>	**Alternative Names**: T&C; Terms & Conditions
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Implementation Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Describes how this governance control is implemented.
+
+>	**Alternative Labels**: Implementation
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Create_Threat.md
+++ b/templates/basic/Governance Officer/Create_Threat.md
@@ -1,0 +1,178 @@
+___
+
+## Create Threat
+> The Threat entity describes a particular threat to the organization
+>
+>	**Alternative Names**: Threat Definition
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Implications
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of implications.
+
+
+### Importance
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Importance of the definition.
+
+
+### Outcomes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: List of desired outcomes.
+
+
+### Results
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of expected results.
+
+
+### Summary
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A short summary of the element's meaning or purpose.
+
+
+### Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The usage guidance for this element — how it is intended to be used in context.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Governance Officer/Detach_Regulator.md
+++ b/templates/basic/Governance Officer/Detach_Regulator.md
@@ -1,0 +1,48 @@
+___
+
+## Detach Regulator
+> Detaches a regulator (usually an organization) from a regulation.
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Regulator
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulator (usually an organization) to link to the regulation.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Agreement_Terms_and_Conditions.md
+++ b/templates/basic/Governance Officer/Link_Agreement_Terms_and_Conditions.md
@@ -1,0 +1,52 @@
+___
+
+## Link Agreement Terms and Conditions
+> Links an agreement to terms and conditions definition with implementation details.
+>
+>	**Alternative Names**: Agreement T&C; Agreement Terms & Conditions
+
+### Terms & Conditions Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A reference to a TermsAndConditions element - may also be a subtype.
+
+
+### Agreement Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the agreement to add an item to. Using qualified names is recommended.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Associated_List.md
+++ b/templates/basic/Governance Officer/Link_Associated_List.md
@@ -1,0 +1,56 @@
+___
+
+## Link Associated List
+> Establishes that a Security Access Control applies to this Security List, Group or Role.
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Access Control
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The security access control endpoint in an AssociatedSecurityGroup relationship.
+
+
+### Operation Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the operation controled by the SecurityAccessControl.
+
+
+### Security List
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The security group endpoint in an AssociatedSecurityGroup relationship.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Certification.md
+++ b/templates/basic/Governance Officer/Link_Certification.md
@@ -1,0 +1,190 @@
+___
+
+## Link Certification
+> Links a certification type to a referenceable element, adding details about the certification.
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Certificate GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Unique identifier of the certificate.
+
+
+### Certified By
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the person or organization that issued the certification.
+
+
+### Certified By Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the certifier element (used with Certified By Type Name).
+
+
+### Certified By Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element that issued the certification (used with Certified By Property Name to identify the certifier).
+
+
+### Conditions
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Conditions for certifications or licenses.
+
+
+### Custodian
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Custodian of the license or certification.
+
+
+### Custodian Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the custodian element (used with Custodian Type Name).
+
+
+### Custodian Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element acting as custodian (used with Custodian Property Name to identify the custodian).
+
+
+### End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification expires.
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Recipient
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The receiver of the certification.
+
+
+### Recipient Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the certification recipient element (used with Recipient Type Name).
+
+
+### Recipient Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element receiving the certification (used with Recipient Property Name).
+
+
+### Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification takes effect.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governance_Controls.md
+++ b/templates/basic/Governance Officer/Link_Governance_Controls.md
@@ -1,0 +1,48 @@
+___
+
+## Link Governance Controls
+> Link peer governance controls with the GovernanceControlLink relationship. Controls types are: GovernanceRule, GovernanceProcess, GovernanceResponsibility, GovernanceProcedure, SecurityAccessControl, SecurityGroup.
+
+### Governance Control 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernanceControl entity in the peer relationship.
+
+
+### Governance Control 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernanceControl entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governance_Drivers.md
+++ b/templates/basic/Governance Officer/Link_Governance_Drivers.md
@@ -1,0 +1,48 @@
+___
+
+## Link Governance Drivers
+> Link peer governance drivers with the GovernanceDriverLink relationship. Drivers are: GovernanceStrategy, BusinessImperitive, Regulation, RegulationArticle, Threat.
+
+### Governance Driver 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernanceDriver entity in the peer relationship.
+
+
+### Governance Driver 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernanceDriver entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governance_Mechanism.md
+++ b/templates/basic/Governance Officer/Link_Governance_Mechanism.md
@@ -1,0 +1,56 @@
+___
+
+## Link Governance Mechanism
+> Link a governance policy to a governance control that supports it. The GovernanceMechanism relationship is used.
+
+### Mechanism
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The GovernanceControl that implements the governance mechanism.
+
+
+### Policy
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The governance policy endpoint in a GovernanceResponse or GovernanceMechanism relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The rationale for using this control to  support this policy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governance_Policies.md
+++ b/templates/basic/Governance Officer/Link_Governance_Policies.md
@@ -1,0 +1,48 @@
+___
+
+## Link Governance Policies
+> Link peer governance policies with the GovernancePolicyLink relationship. Policies types are: GovernancePrinciple, GovernanceObligation, GovernanceApproach.
+
+### Governance Policy 1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: First GovernancePolicy entity in the peer relationship.
+
+
+### Governance Policy 2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: Second GovernancePolicy entity in the peer relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governance_Response.md
+++ b/templates/basic/Governance Officer/Link_Governance_Response.md
@@ -1,0 +1,56 @@
+___
+
+## Link Governance Response
+> Links Policies as a response to governance Drivers.
+
+### Driver
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The GovernanceDriver that initiates the governance response.
+
+
+### Policy
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The governance policy endpoint in a GovernanceResponse or GovernanceMechanism relationship.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The rationale for using this control to  support this policy.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Governed_By.md
+++ b/templates/basic/Governance Officer/Link_Governed_By.md
@@ -1,0 +1,50 @@
+___
+
+## Link Governed By
+> A referenceable element can be governed by one or more governance definitions.
+
+### Governance Definition
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The definition governing the referenceable.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_License.md
+++ b/templates/basic/Governance Officer/Link_License.md
@@ -1,0 +1,190 @@
+___
+
+## Link License
+> Links a license type to a referenceable element, adding details about the license.
+
+### License Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Conditions
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Conditions for certifications or licenses.
+
+
+### Custodian
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Custodian of the license or certification.
+
+
+### Custodian Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the custodian element (used with Custodian Type Name).
+
+
+### Custodian Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element acting as custodian (used with Custodian Property Name to identify the custodian).
+
+
+### End Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification expires.
+
+
+### License GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Unique identifier of the license.
+
+
+### Licensed By
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the person or organization that granted the license.
+
+
+### Licensed By Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the licensor element (used with Licensed By Type Name).
+
+
+### Licensed By Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element that granted the license (used with Licensed By Property Name).
+
+
+### Licensee
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The licensee.
+
+
+### Licensee Property Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The property name used to identify the licensee element (used with Licensee Type Name).
+
+
+### Licensee Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The open metadata type name of the element receiving the license (used with Licensee Property Name).
+
+
+### Obligations
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing obligations.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Date at which the license or certification takes effect.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Entitlements
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing entitlements.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+### Restrictions
+>	**Input Required**: False
+
+>	**Attribute Type**: Dictionary
+
+>	**Description**: A dictionary of property:value pairs describing restrictions.
+
+>	| Parameter Name | Parameter Value |
+>	|---|---|
+>	| example_key | example_value |
+
+
+___

--- a/templates/basic/Governance Officer/Link_Monitored_Resource.md
+++ b/templates/basic/Governance Officer/Link_Monitored_Resource.md
@@ -1,0 +1,48 @@
+___
+
+## Link Monitored Resource
+> Links a Notification Type to a Referenceable that it monitors.
+
+### Monitored Resource
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The monitored referenceable endpoint in a MonitoredResource relationship.
+
+
+### Notification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The NotificationType entity to link the subscriber to or for a monitored resource.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Notification_Subscriber.md
+++ b/templates/basic/Governance Officer/Link_Notification_Subscriber.md
@@ -1,0 +1,68 @@
+___
+
+## Link Notification Subscriber
+> Links a Referenceable as a subscriber to a NotificationType, defining the subscription parameters.
+
+### Notification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The NotificationType entity to link the subscriber to or for a monitored resource.
+
+
+### Subscriber
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Referenceable entity subscribing to the notification type.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Last Notification
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The date of the last notification sent to this subscriber.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Activity Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of an activity - one of an enumerated set of values.
+
+>	**Valid Values**: REQUESTED,APPROVED,WAITING,ACTIVATING,IN_PROGRESS,PAUSED,COMPLETED,INVALID,IGNORED,FAILED,CANCELLED,ABANDONED,OTHER
+
+>	**Default Value**: REQUESTED
+
+
+___

--- a/templates/basic/Governance Officer/Link_Regulation_Certification_Type.md
+++ b/templates/basic/Governance Officer/Link_Regulation_Certification_Type.md
@@ -1,0 +1,48 @@
+___
+
+## Link Regulation Certification Type
+> A certification type addressing a specific regulation.
+
+### Certification Type
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The license type being used for the license.
+
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Regulation_to_Regulator.md
+++ b/templates/basic/Governance Officer/Link_Regulation_to_Regulator.md
@@ -1,0 +1,58 @@
+___
+
+## Link Regulation to Regulator
+> Use the Regulator relationship to link a regulation to a regulator organization.
+
+### Governance Definition
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The definition governing the referenceable.
+
+
+### Referenceable
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The object being licensed or certified.
+
+>	**Alternative Labels**: element
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Regulator.md
+++ b/templates/basic/Governance Officer/Link_Regulator.md
@@ -1,0 +1,64 @@
+___
+
+## Link Regulator
+> Links a regulator (usually an organization) to a regulation using the Regulator relationship.
+
+### Regulation
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulation entity to link to the certification type.
+
+
+### Regulator
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The Regulator (usually an organization) to link to the regulation.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+___

--- a/templates/basic/Governance Officer/Link_Zone_Hierarchy.md
+++ b/templates/basic/Governance Officer/Link_Zone_Hierarchy.md
@@ -1,0 +1,48 @@
+___
+
+## Link Zone Hierarchy
+> Links child governance zones to parent governance zone.
+
+### Parent Zone
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The parent GovernanceZone in the zone hierarchy.
+
+
+### Child Zone
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The child GovernanceZone in the zone hierarchy.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Projects/Create_Campaign.md
+++ b/templates/basic/Projects/Create_Campaign.md
@@ -1,0 +1,248 @@
+___
+
+## Create Campaign
+> Creates or updates a campaign — a collection of related projects working towards a common goal. Sets the Campaign classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Projects/Create_Personal_Project.md
+++ b/templates/basic/Projects/Create_Personal_Project.md
@@ -1,0 +1,248 @@
+___
+
+## Create Personal Project
+> Creates or updates a personal project — an informal project created by a single person to organize part of their work. Sets the PersonalProject classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Projects/Create_Project.md
+++ b/templates/basic/Projects/Create_Project.md
@@ -1,0 +1,248 @@
+___
+
+## Create Project
+> Creates or updates a project. Projects organize a specific activity, controlling resources and costs to achieve defined goals.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Projects/Create_Study_Project.md
+++ b/templates/basic/Projects/Create_Study_Project.md
@@ -1,0 +1,248 @@
+___
+
+## Create Study Project
+> Creates or updates a study project — a focused analysis of a topic, person, object or situation. Sets the StudyProject classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Projects/Create_Task.md
+++ b/templates/basic/Projects/Create_Task.md
@@ -1,0 +1,248 @@
+___
+
+## Create Task
+> Creates or updates a task — a small piece of work typically assigned to a single person. Sets the Task classification on the Project entity.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actual Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project completed as an ISO 8601 string.
+
+
+### Actual Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The actual date the project started as an ISO 8601 string.
+
+
+### Mission
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The project mission statement.
+
+
+### Planned Completion Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project end date as an ISO 8601 string.
+
+
+### Planned Start Date
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Planned project start date as an ISO 8601 string.
+
+
+### Priority
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: An integer priority for the project.
+
+
+### Project Approach
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The methodology or approach used to achieve the project's goals (ProjectClassification attribute).
+
+
+### Project Health
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the health of the project.
+
+
+### Project Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the project.
+
+
+### Project Management Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The management style for the project (ProjectClassification attribute). For example, experimental vs. formal product development.
+
+
+### Project Phase
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string describing the current phase of the project.
+
+
+### Project Results Usage
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: How the results of the project are intended to be used (ProjectClassification attribute). For example: inform future projects, test a theory, develop a product.
+
+
+### Project Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The scope of the project — what is in and out of scope.
+
+
+### Project Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A string representing the current status of the project.
+
+
+### Project Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: A string classifying the project. Supported values are Campaign, Task, PersonalProject and StudyProject.
+
+>	**Valid Values**: Project,Campaign,Task,PersonalProject,StudyProject,Experiment
+
+>	**Default Value**: Project
+
+
+### Success Criteria
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of criteria used to evaluate the success of the project.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Projects/Link_Project_Dependency.md
+++ b/templates/basic/Projects/Link_Project_Dependency.md
@@ -1,0 +1,48 @@
+___
+
+## Link Project Dependency
+> Links or unlinks a project and a project it depends on via the ProjectDependency relationship.
+
+### Child Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the child project.
+
+
+### Parent Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the parent project.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Projects/Link_Project_Hierarchy.md
+++ b/templates/basic/Projects/Link_Project_Hierarchy.md
@@ -1,0 +1,48 @@
+___
+
+## Link Project Hierarchy
+> Links or unlinks a parent project and a child project via the ProjectHierarchy relationship.
+
+### Child Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the child project.
+
+
+### Parent Project
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The name of the parent project.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Report/View_Report.md
+++ b/templates/basic/Report/View_Report.md
@@ -1,0 +1,104 @@
+___
+
+## View Report
+> Runs a named pyegeria report spec (FormatSet) via hey_egeria run_report. Returns formatted output from the Egeria repository — not an element creation command.
+
+### Report Spec
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The name of the report spec (FormatSet) to run, e.g. 'Digital-Products', 'Collections', 'My-User-MD'. This is the primary identifier for the report — equivalent to --report in the CLI.
+
+>	**Default Value**: Referenceable
+
+
+### Search String
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: An optional search string to filter results by.
+
+>	**Default Value**: *
+
+
+### Output Format
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: Optional specification of output format for the query.
+
+>	**Valid Values**: LIST,FORM,REPORT,MERMAID,DICT,MD,TABLE,JSON
+
+>	**Default Value**: JSON
+
+
+### Starts With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the beginning of  a field.
+
+>	**Default Value**: True
+
+
+### Ends With
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, look for matches with the search string starting from the end of  a field.
+
+>	**Default Value**: False
+
+
+### Ignore Case
+>	**Input Required**: False
+
+>	**Attribute Type**: Bool
+
+>	**Description**: If true, ignore the difference between upper and lower characters when matching the search string.
+
+>	**Default Value**: False
+
+
+### Metadata Element Type Name
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Optionally filter results by the type of metadata element.
+
+
+### Metadata Element Subtype Names
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: Filter results by the list of metadata elements. If none are provided, then no status filtering will be performed.
+
+
+### Page Size
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: The number of elements returned per page.
+
+>	**Default Value**: 0
+
+
+### Start From
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple Int
+
+>	**Description**: When paging through results, the starting point of the results to return.
+
+>	**Default Value**: 0
+
+
+___

--- a/templates/basic/Solution Architect/Create_Information_Supply_Chain.md
+++ b/templates/basic/Solution Architect/Create_Information_Supply_Chain.md
@@ -1,0 +1,156 @@
+___
+
+## Create Information Supply Chain
+> Creates or updates an information supply chain — a description of the flow of a particular type of data across a digital landscape.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### In Information Supply Chain
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Supply chains that this supply chain is a segment of.
+
+
+### Integration Style
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The integration style of the information supply chain (e.g. how data flows between segments).
+
+
+### Nested Information Supply Chains
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of supply chains that compose this supply chain.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Purposes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of purposes for this project (array&lt;string&gt;). Note: distinct from Collection.purpose (string, singular) which is a separate attribute on Collection Base.
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Solution Architect/Create_Solution_Blueprint.md
+++ b/templates/basic/Solution Architect/Create_Solution_Blueprint.md
@@ -1,0 +1,134 @@
+___
+
+## Create Solution Blueprint
+> Creates or updates a solution blueprint — a description of the architecture of a digital service in terms of solution components.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Role List
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: A list of actor roles to assign to a blueprint or other collection.
+
+>	**Alternative Labels**: Actor Role List
+
+
+### Solution Components
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution components that make up this blueprint.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Purpose
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The purpose of this collection — a short description of why it exists or what it is used for.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Solution Architect/Create_Solution_Component.md
+++ b/templates/basic/Solution Architect/Create_Solution_Component.md
@@ -1,0 +1,164 @@
+___
+
+## Create Solution Component
+> Creates or updates a reusable solution component — a building block of a solution blueprint or information supply chain.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Actors
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Actors or Solution Roles related to this element.
+
+
+### In Information Supply Chain
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Supply chains that this supply chain is a segment of.
+
+
+### In Solution Blueprints
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution blueprints that contain this component.
+
+
+### In Solution Components
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution components that include this one.
+
+
+### Planned Deployed Implementation Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The planned implementation type for deployment.
+
+
+### Solution Component Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of solution component.
+
+
+### Solution SubComponents
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name List
+
+>	**Description**: Solution sub-components of this component. In current approach the parent does not specify sub-components; components specify their parents instead.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Solution Architect/Create_Solution_Role.md
+++ b/templates/basic/Solution Architect/Create_Solution_Role.md
@@ -1,0 +1,154 @@
+___
+
+## Create Solution Role
+> Creates or updates a solution role — a collection of responsibilities associated with a solution component.
+
+### Display Name
+>	**Input Required**: True
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The common name of an element.
+
+>	**Alternative Labels**: "Term Name"
+
+
+### Role Domain Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Enum
+
+>	**Description**: String representing the governance domain. All domains is ALL
+
+>	**Valid Values**: ALL,DATA,PRIVACY,SECURITY,IT_INFRASTRUCTURE,SOFTWARE_DEVELOPMENT,CORPORATE,ASSET_MANAGEMENT,OTHER
+
+>	**Default Value**: ALL
+
+
+### Role Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-assigned identifier for the solution role.
+
+
+### Role Type
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Type of the solution role. Currently must be GovernanceRole.
+
+>	**Default Value**: GovernanceRole
+
+
+### Title
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Title of the solution role.
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Category
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A user-defined category for the element, used to group related elements for display or search purposes.
+
+>	**Alternative Labels**: Category Name
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+### Qualified Name
+>	**Input Required**: False
+
+>	**Attribute Type**: QN
+
+>	**Description**: The unique, text name of an element.
+
+
+### Content Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The lifecycle status of an element.
+
+>	**Valid Values**: DRAFT,PREPARED,PROPOSED,APPROVED,REJECTED,ACTIVE,DEPRECATED,OTHER
+
+>	**Default Value**: ACTIVE
+
+
+### Scope
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Scope of the definition or element.
+
+
+### Search Keywords
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: A list of search keywords.
+
+
+### GUID
+>	**Input Required**: False
+
+>	**Attribute Type**: GUID
+
+>	**Description**: A unique identifier - typically of an element in this context.
+
+>	**Alternative Labels**: guid; Guid
+
+
+### URL
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: URL for further information.
+
+
+### Version Identifier
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: The version of the element
+
+>	**Alternative Labels**: Version
+
+>	**Default Value**: 1.0
+
+
+### Authors
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple List
+
+>	**Description**: The authors.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Actor_to_Blueprint.md
+++ b/templates/basic/Solution Architect/Link_Actor_to_Blueprint.md
@@ -1,0 +1,50 @@
+___
+
+## Link Actor to Blueprint
+> Link an actor to a Blueprint.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+### Solution Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The role that an actor or component plays in the context of a relationship (e.g. in SolutionBlueprintComposition or SolutionComponentActor).
+
+
+___

--- a/templates/basic/Solution Architect/Link_Blueprint_Child.md
+++ b/templates/basic/Solution Architect/Link_Blueprint_Child.md
@@ -1,0 +1,50 @@
+___
+
+## Link Blueprint Child
+> Links or unlinks an blueprint child segment to an parent blueprint using CollectionMembership.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Blueprint Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Component_to_Actor.md
+++ b/templates/basic/Solution Architect/Link_Component_to_Actor.md
@@ -1,0 +1,48 @@
+___
+
+## Link Component to Actor
+> Links a solution component to an actor role via the SolutionComponentActor relationship.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Solution Role
+>	**Input Required**: False
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The role that an actor or component plays in the context of a relationship (e.g. in SolutionBlueprintComposition or SolutionComponentActor).
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Information_Supply_Chain_Child.md
+++ b/templates/basic/Solution Architect/Link_Information_Supply_Chain_Child.md
@@ -1,0 +1,50 @@
+___
+
+## Link Information Supply Chain Child
+> Links or unlinks an information supply chain child segment to an Information Supply Chain using CollectionMembership.
+
+### ISC Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A Referenceable that is a logical child of the information supply chain segment.
+
+
+### ISC Parent
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A Referenceable that is a logical source or destination for the information supply chain segment.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Information_Supply_Chain_Peers.md
+++ b/templates/basic/Solution Architect/Link_Information_Supply_Chain_Peers.md
@@ -1,0 +1,50 @@
+___
+
+## Link Information Supply Chain Peers
+> Links or unlinks two information supply chain segments.
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Element2 Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of a second element being referenced.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Solution_Component_to_Blueprint.md
+++ b/templates/basic/Solution Architect/Link_Solution_Component_to_Blueprint.md
@@ -1,0 +1,50 @@
+___
+
+## Link Solution Component to Blueprint
+> Link a component to a blueprint.
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Membership Rationale
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Rationale for membership.
+
+
+### Membership Status
+>	**Input Required**: False
+
+>	**Attribute Type**: Valid Value
+
+>	**Description**: The status of adding a member to a collection.
+
+>	**Valid Values**: UNKNOWN,DISCOVERED,PROPOSED,IMPORTED,VALIDATED,DEPRECATED,OBSOLETE,OTHER
+
+>	**Default Value**: PROPOSED
+
+
+### Notes
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: Notes and observations about the element.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Solution_Components.md
+++ b/templates/basic/Solution Architect/Link_Solution_Components.md
@@ -1,0 +1,48 @@
+___
+
+## Link Solution Components
+> Links or unlinks two solution compoents.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Component2
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The second solution component in a peer linking relationship (SolutionLinkingWire).
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Solution Architect/Link_Solution_Design.md
+++ b/templates/basic/Solution Architect/Link_Solution_Design.md
@@ -1,0 +1,52 @@
+___
+
+## Link Solution Design
+> Link a solution blueprint to a referenceable element.
+>
+>	**Alternative Names**: Blueprint to Element
+
+### Blueprint
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: A named solution blueprint.
+
+
+### Element Id
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The unique identifier (qualified name or GUID) of the element being referenced.
+
+>	**Alternative Labels**: Element Name; Member Id
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___

--- a/templates/basic/Solution Architect/Link_SubComponent.md
+++ b/templates/basic/Solution Architect/Link_SubComponent.md
@@ -1,0 +1,48 @@
+___
+
+## Link SubComponent
+> Links a child compoent to a parent component.
+
+### Component1
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The first solution component to link.
+
+
+### Component Child
+>	**Input Required**: True
+
+>	**Attribute Type**: Reference Name
+
+>	**Description**: The child solution component to link.
+
+
+### Label
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A label used to identify or categorise a relationship link.
+
+>	**Alternative Labels**: Wire Label
+
+
+### Journal Entry
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A text entry into a journal.
+
+
+### Description
+>	**Input Required**: False
+
+>	**Attribute Type**: Simple
+
+>	**Description**: A description.
+
+
+___


### PR DESCRIPTION
  Phase 3 (Data Design): new data_design_handler.py with endpoints for
  DataSpecs (Collection subtype via CollectionManager), DataStructures,
  DataFields, and DataGrains (DataValueSpecification subtype). DataSpec
  detail shows contained DataStructures and parent collections with
  cross-navigation. All list endpoints use graph_query_depth=0 to avoid
  timeouts. DataDesignView added to type-explorer.html with 4-sub-nav
  and wired onNavigateToDataSpec from Digital Products tab.

  Phase 1 (Solution Architect): solution_architect_handler.py with
  blueprint and component endpoints; SolutionArchitectView with
  blueprint/component cross-navigation and Mermaid context diagrams.

  Also adds templates/basic and templates/advanced command template
  files across all Egeria manager families.