### PR TITLE
Quickstart demo: Resend email, SSL enabled, .gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ compose-configs/other-egeria-deployments/coco-labs-compose/coco-labs-runtimes-da
 /exchange-quickstart/Obsidian/**
 /exchange-quickstart/Sustainability Samples/**
 /exchange-quickstart/treasury-dts-history/**
+/exchange/treasury-dts-history/**
 
 /exchange-quickstart/distribution-hub/dr-egeria-outbox/DataDrivenLDN/**
 /exchange-quickstart/loading-bay/dr-egeria-inbox/Automated Delivery of Internal Products/**
@@ -188,12 +189,20 @@ compose-configs/other-egeria-deployments/coco-labs-compose/coco-labs-runtimes-da
 /runtime-volumes/quickstart-platform-data/data/
 /runtime-volumes/freshstart-platform-data/data/
 
+# Legacy / alternative platform-data directories (XTDB runtime database files)
+runtime-volumes/egeria-platform-data/
+egeria-platform-data/
+
+# Runtime Kafka and PostgreSQL data (not for version control)
+runtime-volumes/shared-infra-hardened-kafka/
+runtime-volumes/egeria-pg/
+
 compose-configs/egeria-quickstart/.env
 compose-configs/egeria-freshstart/.env
 compose-configs/shared-infra/.env
 
 /exchange/**
-/runtime-volumes/freshstart-platform-data/secrets/*.omsecrets
+/runtime-volumes/freshstart-platform-data/secrets/
 
 # Obsidian local workspace state
 **/.obsidian/workspace.json

--- a/compose-configs/egeria-quickstart/Dockerfile-apache-web
+++ b/compose-configs/egeria-quickstart/Dockerfile-apache-web
@@ -1,17 +1,21 @@
+FROM python:3.12-slim-bookworm AS python-base
+
 FROM httpd:2.4-bookworm
+
+# Copy Python from the python-base image
+COPY --from=python-base /usr/local/ /usr/local/
 
 # For settng up FastAPI
 COPY ./sites-available/fastapi-proxy.conf /usr/local/apache2/conf/extra/fastapi-proxy.conf
 
-# Install Python runtime for optional CGI tooling.
+# Install necessary libraries for Python and Apache
 # Use HTTPS apt sources to avoid environments that block outbound HTTP.
 RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/*.sources && \
     apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    python3 \
-    python3-pip \
-    python3-venv && \
-    rm -rf /var/lib/apt/lists/*
+    libsqlite3-0 \
+    libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Enable the necessary Apache modules for reverse proxying
 # These are often enabled by default, but explicitly enabling ensures it.

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-mode.md
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-mode.md
@@ -311,6 +311,11 @@ Before making a deployment public:
 
 ## Troubleshooting
 
+**"SSLCertificateFile: file '/etc/ssl/egeria/server.crt' does not exist or is empty"** — This occurs when you have enabled SSL in the compose yaml but the `runtime-volumes/certs` directory is empty or missing the expected files. Either provide your own certificates in that directory or use the helper script to generate self-signed ones:
+```bash
+./generate-certs.sh
+```
+
 **"Authentication required" on /egeria-explorer** — `DEMO_MODE` is true and the session cookie is missing or expired. Visit `/login` to sign in.
 
 **Email verification link not arriving** — SMTP is not configured (`SMTP_HOST` blank). Log into the admin panel and enable the user's account manually: use the Users tab, find the user, and check their status. Alternatively, promote the account to admin (which also sets `verified=true`).

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
@@ -38,12 +38,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 from jose import JWTError, jwt
 from loguru import logger
+import httpx
 import bcrypt as _bcrypt
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from demo_config import (
     JWT_ALGORITHM, JWT_EXPIRY_ADMIN_SEC, JWT_EXPIRY_USER_SEC, JWT_SECRET,
+    RESEND_API_KEY, RESEND_FROM,
     SITE_URL, SMTP_FROM, SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_SSL, SMTP_USER,
 )
 from demo_db import Config, Event, User, get_db, get_config, log_event, set_config
@@ -114,8 +116,35 @@ def require_admin(request: Request, db: Session = Depends(get_db)) -> User:
 # ── SMTP ───────────────────────────────────────────────────────────────────────
 
 def _send_email(to: str, subject: str, html: str, text: str = "") -> None:
+    # ── Try Resend first ──────────────────────────────────────────────────────
+    if RESEND_API_KEY:
+        try:
+            resp = httpx.post(
+                "https://api.resend.com/emails",
+                headers={
+                    "Authorization": f"Bearer {RESEND_API_KEY.strip()}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "from": RESEND_FROM or SMTP_FROM,
+                    "to": to,
+                    "subject": subject,
+                    "html": html,
+                    "text": text or html,
+                },
+                timeout=10.0,
+            )
+            if resp.status_code != 200:
+                logger.error(f"Resend returned {resp.status_code}: {resp.text}")
+            resp.raise_for_status()
+            logger.info(f"Email sent via Resend to {to!r}: {subject}")
+            return
+        except Exception as exc:
+            logger.error(f"Resend failed, falling back to SMTP if available: {exc}")
+
+    # ── Fallback to SMTP ──────────────────────────────────────────────────────
     if not SMTP_HOST:
-        logger.warning(f"SMTP not configured — skipped email to {to!r}: {subject}")
+        logger.warning(f"Email skipped — neither Resend nor SMTP configured for {to!r}")
         return
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_config.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_config.py
@@ -37,6 +37,11 @@ SMTP_USER:     str  = os.environ.get("SMTP_USER",     "") or _bootstrap_email
 SMTP_PASSWORD: str  = os.environ.get("SMTP_PASSWORD", "") or _bootstrap_password
 SMTP_FROM:     str  = os.environ.get("SMTP_FROM",     "") or SMTP_USER
 
+# ── Resend ─────────────────────────────────────────────────────────────────────
+
+RESEND_API_KEY: str = os.environ.get("RESEND_API_KEY", "")
+RESEND_FROM:    str = os.environ.get("RESEND_FROM",    "")
+
 # ── URLs ───────────────────────────────────────────────────────────────────────
 
 SITE_URL: str = os.environ.get("SITE_URL", "http://localhost:8085").rstrip("/")

--- a/compose-configs/egeria-quickstart/egeria-quickstart.yaml
+++ b/compose-configs/egeria-quickstart/egeria-quickstart.yaml
@@ -113,7 +113,7 @@ services:
       DEMO_MODE: "true"
       DEMO_DB_PATH: "/app/demo-data/demo.db"
       JWT_SECRET: "${JWT_SECRET:-change-me-before-going-public-meow}"
-      SITE_URL: "http://localhost:8085"
+      SITE_URL: "${SITE_URL:-http://localhost:8085}"
       # SMTP — set SMTP_USER/PASSWORD in .env; if blank, falls back to ADMIN_BOOTSTRAP_EMAIL/PASSWORD
       SMTP_HOST: "smtp.ionos.com"
       SMTP_PORT: "465"
@@ -121,6 +121,8 @@ services:
       SMTP_USER: "${SMTP_USER:-}"
       SMTP_PASSWORD: "${SMTP_PASSWORD:-}"
       SMTP_FROM: "${SMTP_FROM:-}"
+      RESEND_API_KEY: "${RESEND_API_KEY:-}"
+      RESEND_FROM: "${RESEND_FROM:-}"
       ADMIN_BOOTSTRAP_EMAIL: "${ADMIN_BOOTSTRAP_EMAIL:-}"
       ADMIN_BOOTSTRAP_PASSWORD: "${ADMIN_BOOTSTRAP_PASSWORD:-}"
     volumes:
@@ -151,7 +153,7 @@ services:
     ports:
       - "8085:8085"
       # SSL (port 443) — disabled by default. See demo-mode.md § SSL / HTTPS.
-      # - "443:443"
+      - "443:443"
     networks:
       - egeria_network
     volumes:
@@ -165,8 +167,8 @@ services:
       - ../../runtime-volumes/quickstart-apache-web/ErrorLogs:/usr/local/apache2/logs
       - ../../workspaces/Dr-Egeria-Samples:/usr/local/apache2/htdocs/Dr-Egeria-Samples
       # SSL cert volume — disabled by default. See demo-mode.md § SSL / HTTPS.
-      # - ./sites-available/fastapi-ssl.conf:/usr/local/apache2/conf/extra/fastapi-ssl.conf
-      # - /path/to/your/certs:/etc/ssl/egeria:ro
+      - ./sites-available/fastapi-ssl.conf:/usr/local/apache2/conf/extra/fastapi-ssl.conf
+      - ../../runtime-volumes/certs:/etc/ssl/egeria:ro
     depends_on:
       - pyegeria-web
 

--- a/compose-configs/egeria-quickstart/sites-available/fastapi-ssl.conf
+++ b/compose-configs/egeria-quickstart/sites-available/fastapi-ssl.conf
@@ -23,6 +23,9 @@ LoadModule setenvif_module        modules/mod_setenvif.so
 
 Listen 443
 
+SSLSessionCache        shmcb:/usr/local/apache2/logs/ssl_scache(512000)
+SSLSessionCacheTimeout 300
+
 <VirtualHost *:443>
     ServerAdmin webmaster@localhost
     ServerName ${SSL_SERVER_NAME}
@@ -31,8 +34,6 @@ Listen 443
     SSLCertificateFile    ${SSL_CERT_FILE}
     SSLCertificateKeyFile ${SSL_KEY_FILE}
     SSLCertificateChainFile ${SSL_CHAIN_FILE}
-    SSLSessionCache        shmcb:/usr/local/apache2/logs/ssl_scache(512000)
-    SSLSessionCacheTimeout 300
 
     DocumentRoot "/usr/local/apache2/htdocs"
     <Directory "/usr/local/apache2/htdocs">


### PR DESCRIPTION
- demo_auth_handler.py: add Resend as primary email sender with SMTP fallback
- demo_config.py: add RESEND_API_KEY / RESEND_FROM config vars
- egeria-quickstart.yaml: SITE_URL from env var, Resend vars, port 443 and SSL cert volumes now enabled by default
- Dockerfile-apache-web: use python:3.12-slim base stage, replace python3/pip with libsqlite3-0/libexpat1 (CGI venv removed — unused)
- fastapi-ssl.conf: move SSLSessionCache directives outside <VirtualHost>
  (correct Apache placement)
- demo-mode.md: add SSL cert troubleshooting section for generate-certs.sh
- .gitignore: add egeria-platform-data/, Kafka/PG data dirs, tighten freshstart secrets pattern