### PR TITLE
feat(demo): Egeria Explorer grouped nav, Obsidian tile, portal improvements, doc update

### DIFF
--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-mode.md
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-mode.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Demo mode adds user registration, authentication, and persona-based access control to Egeria Explorer. It is designed for public-facing deployments pre-loaded with Coco Pharmaceuticals data, where you want attendees to register and select a named persona before exploring the metadata.
+Demo mode adds user registration, authentication, and persona-based access control to the Egeria demo portal and Egeria Explorer. It is designed for public-facing deployments pre-loaded with Coco Pharmaceuticals data, where you want attendees to register, pick a named persona, and explore the metadata environment from that character's perspective.
 
 When `DEMO_MODE=false` (the default), all demo machinery is dormant. The Explorer behaves as a local development tool: no login required, no persona picker, no auth gate on `/egeria-explorer`. All demo page routes (`/login`, `/register`, `/admin`, `/privacy`) still exist but redirect immediately to `/egeria-explorer`.
 
@@ -34,7 +34,7 @@ docker compose up --build
 
 On first startup the container automatically creates the admin account from `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD`. If an admin already exists those vars are ignored, so it is safe to leave them set on subsequent restarts.
 
-Log in at `/login` with those credentials to access the admin panel.
+Log in at `/login` with those credentials to access the admin panel, then navigate to `/portal` to see the demo portal.
 
 ---
 
@@ -42,30 +42,72 @@ Log in at `/login` with those credentials to access the admin panel.
 
 All settings are read from container environment variables at startup.
 
-**Secrets belong in `.env`, not the yaml.** The compose yaml uses `${JWT_SECRET}` and `${SMTP_PASSWORD}` variable substitution. Docker Compose automatically reads `compose-configs/egeria-quickstart/.env` (already gitignored). Set real values there:
+**Secrets belong in `.env`, not the yaml.** The compose yaml uses variable substitution (`${JWT_SECRET}`, `${SMTP_PASSWORD}`, etc.). Docker Compose automatically reads `compose-configs/egeria-quickstart/.env` (already gitignored). Set real values there.
 
-```ini
-JWT_SECRET=your-random-32-plus-char-string
-SMTP_PASSWORD=your-smtp-password
-```
+### Core
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEMO_MODE` | `false` | Set `true` to activate demo auth gating |
-| `DEMO_DB_PATH` | `/app/demo-data/demo.db` | Path to the SQLite database file inside the container |
-| `JWT_SECRET` | `change-me-before-going-public` | HS256 signing key for session JWTs — **set in `.env`, never in yaml** |
-| `JWT_EXPIRY_USER_SECONDS` | `7200` | User session lifetime in seconds (2 hours) |
-| `JWT_EXPIRY_ADMIN_SECONDS` | `604800` | Admin session lifetime in seconds (7 days) |
-| `SITE_URL` | `http://localhost:8085` | Base URL for email verification links (no trailing slash) |
+| `SITE_URL` | `http://localhost:8085` | Base URL for email verification/reset links (no trailing slash) |
+| `JWT_SECRET` | `change-me-before-going-public` | HS256 signing key — **set in `.env`, never in yaml** |
+| `JWT_EXPIRY_USER_SECONDS` | `7200` | User session lifetime in seconds (2 h) |
+| `JWT_EXPIRY_ADMIN_SECONDS` | `604800` | Admin session lifetime in seconds (7 d) |
+
+### Demo auth database (PostgreSQL)
+
+The demo auth tables (`users`, `events`, `config`) live in the **`demo_auth` schema** of the **`coco_pharma`** database on the shared PostgreSQL instance (`egeria-shared-postgres:5442`). This is the same host as the Egeria metadata store but a separate database/schema — the two are independent.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEMO_DB_HOST` | `egeria-shared-postgres` | PostgreSQL host |
+| `DEMO_DB_PORT` | `5442` | PostgreSQL port |
+| `DEMO_DB_NAME` | `coco_pharma` | Database name |
+| `DEMO_DB_SCHEMA` | `demo_auth` | Schema for auth tables |
+| `DEMO_DB_USER` | `demo_user` | DB user |
+| `DEMO_DB_PASSWORD` | `demo4egeria` | DB password — **set in `.env`, never in yaml** |
+
+Schema and tables are created automatically on first startup via SQLAlchemy (`Base.metadata.create_all`).
+
+### Demo reset (Egeria metadata)
+
+Admin-triggered reset: stops the Egeria container, drops the metadata store schema from PostgreSQL so Egeria re-seeds fresh Coco Pharmaceuticals data on restart.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EGERIA_CONTAINER_NAME` | `quickstart-egeria-main` | Docker container name for the Egeria platform |
+| `EGERIA_META_DB_NAME` | `egeria` | Database holding Egeria's metadata store |
+| `EGERIA_META_DB_USER` | `egeria_admin` | DB user for the metadata store |
+| `EGERIA_META_DB_PASSWORD` | `admin4egeria` | DB password — **set in `.env`, never in yaml** |
+
+The Docker socket must be mounted into the container (`/var/run/docker.sock:/var/run/docker.sock`) for reset to work.
+
+### SMTP email
+
+| Variable | Default | Description |
+|----------|---------|-------------|
 | `SMTP_HOST` | _(blank)_ | SMTP server hostname. If blank, email sending is skipped |
 | `SMTP_PORT` | `587` | SMTP port (587 = STARTTLS) |
-| `SMTP_USER` | _(blank)_ | SMTP authentication username |
-| `SMTP_PASSWORD` | _(blank)_ | SMTP authentication password — **set in `.env`, never in yaml** |
-| `SMTP_FROM` | _(same as SMTP_USER)_ | Sender address for outbound emails |
-| `ADMIN_BOOTSTRAP_EMAIL` | _(blank)_ | Email for the auto-created admin account. Only used when no admin exists yet |
-| `ADMIN_BOOTSTRAP_PASSWORD` | _(blank)_ | Password for the auto-created admin account — **set in `.env`, never in yaml** |
+| `SMTP_SSL` | `false` | Set `true` for implicit TLS (port 465) |
+| `SMTP_USER` | _(blank)_ | SMTP authentication username (falls back to `ADMIN_BOOTSTRAP_EMAIL`) |
+| `SMTP_PASSWORD` | _(blank)_ | SMTP password — **set in `.env`, never in yaml** |
+| `SMTP_FROM` | _(same as `SMTP_USER`)_ | Sender address for outbound emails |
 
-**Development without SMTP:** Leave `SMTP_HOST` blank. New registrations will not receive a verification email. Use the admin panel to manually verify accounts, or promote an account to admin so it can manage others.
+### Resend email provider (alternative to SMTP)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RESEND_API_KEY` | _(blank)_ | Resend.com API key. If set, Resend is used instead of SMTP |
+| `RESEND_FROM` | _(blank)_ | Sender address when using Resend |
+
+### Bootstrap admin
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ADMIN_BOOTSTRAP_EMAIL` | _(blank)_ | Email for the auto-created admin. Only used when no admin exists yet |
+| `ADMIN_BOOTSTRAP_PASSWORD` | _(blank)_ | Password for the auto-created admin — **set in `.env`, never in yaml** |
+
+**Development without SMTP/Resend:** Leave both blank. Registrations will not receive a verification email. Use the admin panel to manually verify accounts.
 
 ---
 
@@ -73,11 +115,13 @@ SMTP_PASSWORD=your-smtp-password
 
 | Route | Behaviour |
 |-------|-----------|
-| `GET /login` | Serves login form. Auto-redirects to `/egeria-explorer` if already authenticated |
-| `GET /register` | Serves registration form |
-| `GET /egeria-explorer` | Auth-gated when `DEMO_MODE=true`. Redirects to `/login` if no valid session |
-| `GET /admin` | Serves admin panel. Requires `role=admin`; redirects to `/login` otherwise |
-| `GET /privacy` | Serves privacy policy (always accessible, no auth required) |
+| `GET /portal` | Demo portal — persona picker, app launcher tiles, resource links. Requires authentication |
+| `GET /login` | Login form. Auto-redirects to `/portal` if already authenticated |
+| `GET /register` | Registration form |
+| `GET /reset-password?token=…` | Password reset form — token arrives via email from the forgot-password flow |
+| `GET /egeria-explorer` | Egeria Explorer. Auth-gated when `DEMO_MODE=true`; redirects to `/login` if no valid session |
+| `GET /admin` | Admin panel. Requires `role=admin`; redirects to `/login` otherwise |
+| `GET /privacy` | Privacy policy (always accessible, no auth required) |
 
 ---
 
@@ -88,7 +132,7 @@ SMTP_PASSWORD=your-smtp-password
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `POST` | `/api/auth/register` | Public | Register a new account. Body: `{display_name, email, password, org?}` |
-| `GET` | `/api/auth/verify/{token}` | Public | Verify email, set cookie, redirect to Explorer |
+| `GET` | `/api/auth/verify/{token}` | Public | Verify email, set cookie, redirect to portal |
 | `POST` | `/api/auth/login` | Public | Log in. Body: `{email, password}`. Sets `demo_token` cookie |
 | `POST` | `/api/auth/logout` | Public | Clear session cookie |
 | `GET` | `/api/auth/me` | Optional | Returns `{authenticated, id, display_name, email, role}` or `{authenticated: false}` |
@@ -102,6 +146,19 @@ SMTP_PASSWORD=your-smtp-password
 | `GET` | `/api/demo/personas` | Public | List all personas (passwords excluded) |
 | `POST` | `/api/demo/select-persona` | Verified user | Select a persona. Body: `{persona}`. Returns Egeria credentials |
 
+### Portal config
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/demo/portal-config` | Verified user | Returns `{obsidian_vault_url, obsidian_github_url}` for the portal tile |
+
+### Demo reset
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/demo/reset/status` | Admin | Returns `{state, last_reset_at, reset_interval_hours}` |
+| `POST` | `/api/demo/reset` | Admin | Trigger an immediate demo reset (async — returns `{status: "reset_started"}`) |
+
 ### Admin
 
 All admin endpoints require `role=admin`.
@@ -114,6 +171,56 @@ All admin endpoints require `role=admin`.
 | `GET` | `/api/demo/events?limit=200` | Recent event log |
 | `GET` | `/api/demo/config` | Current runtime config |
 | `POST` | `/api/demo/config` | Update config. Body: `{key, value}` |
+
+---
+
+## Demo portal
+
+The portal (`/portal`) is the landing page for authenticated demo users. It shows:
+
+- **Hero banner** — welcome text, resource links (Documentation, GitHub, Coco Pharmaceuticals), and repo star prompts.
+- **Persona card** — currently selected persona with display name, role, difficulty badge, and a link to their profile on egeria-project.org.
+- **App launcher tiles** — one tile per integrated tool (Egeria Explorer, Jupyter, web resources, Obsidian workbooks).
+- **Footer** — links to documentation, GitHub, Coco Pharmaceuticals, and Privacy Policy.
+
+### Persona picker
+
+Click **Switch** on the persona card to open the persona picker modal. It lists all available personas with role, difficulty, and a Starter badge for recommended entry-level personas. The description at the top links to the Coco Pharmaceuticals practice overview on egeria-project.org.
+
+Selecting a persona:
+1. Stores display info in `localStorage` (`egeria-persona`).
+2. Calls `POST /api/demo/select-persona` to retrieve the matching Egeria credentials.
+3. Stores those credentials in `localStorage` (`egeria-creds`) so Egeria Explorer can connect immediately without a separate login step.
+
+### Obsidian tile
+
+The **Coco Pharmaceuticals Workbooks** tile links to the `coco-workbooks` Obsidian vault:
+
+- **Local access** (localhost/127.0.0.1): shows an **Open in Obsidian** button that launches the vault via the `obsidian://` protocol handler (requires Obsidian installed locally).
+- **Remote access**: shows a **GitHub ↗** link pointing to the workbooks folder in the canonical repo (configurable).
+
+Configure the tile via the admin Config panel:
+
+| Config key | Description |
+|------------|-------------|
+| `obsidian_vault_url` | Vault name or `obsidian://` URI for local users. If not a full URI, it is wrapped as `obsidian://open?vault=<name>`. Leave blank to hide the local button. |
+| `obsidian_github_url` | GitHub URL for remote users. Defaults to `https://github.com/odpi/egeria-workspaces/tree/main/coco-workbooks`. |
+
+---
+
+## Egeria Explorer
+
+When accessed via the demo portal (demo mode active), Egeria Explorer behaves differently from standalone use:
+
+- **Auto-credentials**: When a persona is selected in the portal, credentials are stored in `localStorage`. Explorer reads them automatically on load — no manual connection form needed.
+- **Connection form hidden**: On the Home/splash screen in demo mode, the connection form is hidden. Users arriving from the portal are already connected.
+- **Grouped navigation**: The top nav bar collapses the 10+ section buttons into three dropdown groups:
+  - **Reference** — Type Explorer, REST APIs, Valid Values
+  - **Review** — Glossary, Reference Data, Data Design, Solution Architect, Supply Chains, Perspectives
+  - **Act** — Report Specs, Digital Products, Dr. Egeria
+- **Type-system sub-toolbar**: When the Type Explorer is active, a secondary bar below the main nav provides the area filter and Attribute Index toggle, keeping the main nav clean.
+- **Back to Portal**: A **Portal** button in the top-right header returns the user to `/portal`.
+- **Persona badge**: The current persona name is shown in the header.
 
 ---
 
@@ -135,11 +242,45 @@ Shows the 200 most recent events (register, verify, login, persona_select) with 
 
 ### Config tab
 
-Key/value pairs from the `config` table. All values are strings. Editable in place:
+Key/value pairs from the `config` table. All values are strings. Editable in place.
 
-- `reset_interval_hours` — planned: how often the Egeria data store is reset (not yet implemented).
-- `directive_cap` — planned: maximum Dr. Egeria directive level available to demo users (`validate` prevents writes; `process` allows writes).
-- `session_lifetime_user` / `session_lifetime_admin` — informational; actual session lifetime is governed by the `JWT_EXPIRY_*` env vars set at container startup.
+| Key | Default | Description |
+|-----|---------|-------------|
+| `obsidian_vault_url` | _(blank)_ | Vault name or `obsidian://` URI for local Obsidian launch |
+| `obsidian_github_url` | `https://github.com/odpi/egeria-workspaces/tree/main/coco-workbooks` | GitHub fallback for remote users |
+| `reset_interval_hours` | `0` | Auto-reset interval; 0 = disabled. Set > 0 to enable scheduled resets |
+| `directive_cap` | `validate` | Maximum Dr. Egeria directive level for demo users |
+| `session_lifetime_user` | `7200` | Informational; actual lifetime is set by `JWT_EXPIRY_USER_SECONDS` |
+| `session_lifetime_admin` | `604800` | Informational; actual lifetime is set by `JWT_EXPIRY_ADMIN_SECONDS` |
+| `last_reset_at` | _(blank)_ | ISO timestamp of the last successful demo reset (set automatically) |
+| `reset_state` | `ready` | `ready` or `resetting` — reflects current reset progress |
+
+---
+
+## Demo reset (Egeria metadata)
+
+The demo reset wipes the Egeria metadata store and restarts it fresh with Coco Pharmaceuticals data. User accounts and config are unaffected.
+
+**What it does:**
+1. Stops the `quickstart-egeria-main` container.
+2. Drops the `repository_qs_metadata_store` schema from the `egeria` database on `egeria-shared-postgres:5442`.
+3. Restarts the container — Egeria re-seeds all Coco Pharmaceuticals data from scratch (~5 min).
+
+**Triggering manually** (admin only):
+
+```
+POST /api/demo/reset
+```
+
+Returns immediately with `{status: "reset_started"}`. Check progress via:
+
+```
+GET /api/demo/reset/status
+```
+
+**Scheduled resets**: Set `reset_interval_hours` > 0 in the Config tab. The scheduler checks every 5 minutes and triggers a reset when the elapsed time exceeds the interval.
+
+**Docker socket requirement**: Mount `/var/run/docker.sock` into the `quickstart-pyegeria-web` container (configured in `egeria-quickstart.yaml`).
 
 ---
 
@@ -162,34 +303,50 @@ All personas use the Egeria password `"secret"` — the well-known Coco Pharmace
 
 **Starter personas** are highlighted in the persona picker with a green "Starter" badge and are recommended as first picks for demo attendees new to Egeria.
 
-Persona credentials come from `personas.json` in the container. To add or update a persona, edit `personas.json` and restart the container (the file is read on each request, so a hot reload via uvicorn `--reload` works without a full container restart).
+Persona credentials come from `personas.json` in the container. To add or update a persona, edit `personas.json` and restart the container (or hot-reload via uvicorn `--reload`).
 
 ---
 
 ## Database maintenance
 
-The SQLite database persists at `DEMO_DB_PATH` on the `demo-data` volume. The schema is created automatically on first startup by SQLAlchemy (`Base.metadata.create_all`). No migration step is required for a fresh deployment.
+The demo auth database is **PostgreSQL** — the `demo_auth` schema in the `coco_pharma` database on `egeria-shared-postgres:5442`. The schema is created automatically on first startup.
 
-**Backup:**
-
-```bash
-docker cp quickstart-pyegeria-web:/app/demo-data/demo.db ./demo-backup-$(date +%Y%m%d).db
-```
-
-**Reset (wipe all users and events, preserving config):**
+### Connecting directly
 
 ```bash
-docker exec quickstart-pyegeria-web python -c "
-from demo_db import get_engine
-from sqlalchemy import text
-with get_engine().begin() as conn:
-    conn.execute(text('DELETE FROM events'))
-    conn.execute(text('DELETE FROM users'))
-print('Users and events cleared')
-"
+docker exec -it egeria-shared-postgres psql -U demo_user -d coco_pharma
 ```
 
-After a reset, set `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` in `.env` and restart the container — the bootstrap runs automatically on startup when no admin exists.
+Or from the host (if port 5442 is exposed):
+
+```bash
+psql -h localhost -p 5442 -U demo_user -d coco_pharma -n demo_auth
+```
+
+### Clearing users and events (preserving config)
+
+```sql
+DELETE FROM demo_auth.events;
+DELETE FROM demo_auth.users;
+```
+
+Or via Docker:
+
+```bash
+docker exec egeria-shared-postgres psql -U demo_user -d coco_pharma \
+  -c "DELETE FROM demo_auth.events; DELETE FROM demo_auth.users;"
+```
+
+After clearing, set `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` in `.env` and restart the `quickstart-pyegeria-web` container — the bootstrap admin is re-created automatically when no admin exists.
+
+### Full schema reset (nuclear option)
+
+```bash
+docker exec egeria-shared-postgres psql -U demo_user -d coco_pharma \
+  -c "DROP SCHEMA IF EXISTS demo_auth CASCADE;"
+```
+
+The schema is recreated automatically on the next container start.
 
 ---
 
@@ -199,15 +356,15 @@ SSL is **off by default**. The web server listens on port 8085 (HTTP) only. HTTP
 
 ### Prerequisites
 
-- A TLS certificate and private key for your domain (Let's Encrypt, self-signed, or commercial CA).
-- The certificate files accessible on the Docker host at a stable path (not `~/Downloads`).
+- A TLS certificate and private key for your domain.
+- The certificate files accessible on the Docker host at a stable path.
 - Port 443 open on any firewall between users and the host.
 - DNS pointing your domain at the host's IP address.
 
 ### Enabling SSL
 
 **Step 1 — Edit `sites-available/fastapi-ssl.conf`.**
-Change the four `Define` lines at the top to match your deployment:
+Change the four `Define` lines at the top:
 
 ```apache
 Define SSL_SERVER_NAME your.domain.com
@@ -224,14 +381,11 @@ ports:
   - "443:443"          # ← uncomment
 
 volumes:
-  # ... existing volumes ...
   - ./sites-available/fastapi-ssl.conf:/usr/local/apache2/conf/extra/fastapi-ssl.conf  # ← uncomment
   - /path/to/your/certs:/etc/ssl/egeria:ro                                             # ← uncomment, fix path
 ```
 
-Replace `/path/to/your/certs` with the directory on the host that contains the cert files named in Step 1.
-
-**Step 3 — Update `SITE_URL` in `.env`** to use `https://`:
+**Step 3 — Update `SITE_URL` in `.env`:**
 
 ```ini
 SITE_URL=https://your.domain.com
@@ -243,53 +397,29 @@ SITE_URL=https://your.domain.com
 docker compose -f egeria-quickstart.yaml up --build apache-web -d
 ```
 
-The `--build` is required because `httpd.conf` changed. After this, subsequent cert or conf edits (volume-mounted) only need a restart:
-
-```bash
-docker compose -f egeria-quickstart.yaml restart apache-web
-```
-
-HTTP on port 8085 continues to work. If you want to redirect all HTTP traffic to HTTPS, add a `Redirect permanent / https://your.domain.com` inside the `<VirtualHost *:8085>` block in `fastapi-proxy.conf`.
+After first setup, cert or conf changes only need a restart (no rebuild).
 
 ### Disabling SSL
 
-**Step 1 — Re-comment the three SSL lines** in `egeria-quickstart.yaml` (add `#` back):
-
-```yaml
-# - "443:443"
-# - ./sites-available/fastapi-ssl.conf:/usr/local/apache2/conf/extra/fastapi-ssl.conf
-# - /path/to/your/certs:/etc/ssl/egeria:ro
-```
-
-**Step 2 — Restart the Apache container:**
+Re-comment the three SSL lines in `egeria-quickstart.yaml` and restart Apache:
 
 ```bash
 docker compose -f egeria-quickstart.yaml restart apache-web
 ```
 
-No rebuild needed. `httpd.conf` contains `IncludeOptional conf/extra/fastapi-ssl.conf` — when the file is not mounted, Apache silently skips it and starts HTTP-only.
+`httpd.conf` uses `IncludeOptional conf/extra/fastapi-ssl.conf` — when the file is not mounted, Apache silently starts HTTP-only.
 
-### How it works
+### Cookie security
 
-`httpd.conf` contains a single line:
-
-```apache
-IncludeOptional conf/extra/fastapi-ssl.conf
-```
-
-When `fastapi-ssl.conf` is **not mounted**, Apache ignores it — no SSL modules are loaded, port 443 is not opened, and the container starts normally on 8085.
-
-When the file **is mounted**, Apache loads it, which in turn loads `mod_ssl`, opens port 443, and activates the `<VirtualHost *:443>` block. All proxy locations are mirrored from the HTTP VirtualHost so the full application is available over both protocols.
+Cookies are set with `Secure=true` automatically when `SITE_URL` starts with `https://`. No additional configuration is required.
 
 ### Certificate renewal
 
-When your certificate expires, replace the files in the mounted host directory and restart the Apache container — no rebuild required:
+Replace the files in the mounted cert directory and restart Apache — no rebuild required:
 
 ```bash
 docker compose -f egeria-quickstart.yaml restart apache-web
 ```
-
-For Let's Encrypt with Certbot, the renewed files land in the same path automatically. Point the cert volume mount at the live directory (`/etc/letsencrypt/live/your.domain.com/`) and the container picks up renewals on its next restart.
 
 ---
 
@@ -298,36 +428,34 @@ For Let's Encrypt with Certbot, the renewed files land in the same path automati
 Before making a deployment public:
 
 - [ ] `JWT_SECRET` set to a random 32+ character string in `.env` (not in the yaml)
-- [ ] `SMTP_PASSWORD` set in `.env` (not in the yaml)
-- [ ] `SMTP_HOST` set (or documented that email verification requires admin activation)
-- [ ] `SITE_URL` set to the actual public URL (required for correct verify/reset links)
-- [ ] HTTPS enabled for public deployments (see [SSL / HTTPS](#ssl--https) above); `SITE_URL` updated to `https://`
+- [ ] `SMTP_PASSWORD` (or `RESEND_API_KEY`) set in `.env` (not in the yaml)
+- [ ] `SITE_URL` set to the actual public URL — required for correct verify/reset links and the `Secure` cookie flag
+- [ ] HTTPS enabled for public deployments; `SITE_URL` updated to `https://`
 - [ ] Port 8000 (FastAPI) NOT exposed to the internet; all traffic via Apache on port 8085
-- [ ] `demo-data/` volume mounted on persistent storage (not ephemeral container layer)
+- [ ] `DEMO_DB_PASSWORD` and `EGERIA_META_DB_PASSWORD` set in `.env` (not in the yaml) if changed from defaults
 - [ ] Egeria data store pre-loaded with Coco Pharmaceuticals data before announcing the demo
-- [ ] `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` set in `.env` (not in the yaml) so admin is created on first startup
+- [ ] `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` set in `.env` so admin is created on first startup
 
 ---
 
 ## Troubleshooting
 
-**"SSLCertificateFile: file '/etc/ssl/egeria/server.crt' does not exist or is empty"** — This occurs when you have enabled SSL in the compose yaml but the `runtime-volumes/certs` directory is empty or missing the expected files. Either provide your own certificates in that directory or use the helper script to generate self-signed ones:
-```bash
-./generate-certs.sh
-```
+**"SSLCertificateFile: file '/etc/ssl/egeria/server.crt' does not exist"** — SSL lines are uncommented in the yaml but the cert directory is empty or missing. Generate self-signed certs with `./generate-certs.sh` from the repository root, or provide real certs in the mounted path.
 
-**"Authentication required" on /egeria-explorer** — `DEMO_MODE` is true and the session cookie is missing or expired. Visit `/login` to sign in.
+**"Authentication required" on /egeria-explorer or /portal** — `DEMO_MODE` is true and the session cookie is missing or expired. Visit `/login` to sign in.
 
-**Email verification link not arriving** — SMTP is not configured (`SMTP_HOST` blank). Log into the admin panel and enable the user's account manually: use the Users tab, find the user, and check their status. Alternatively, promote the account to admin (which also sets `verified=true`).
+**Email verification link not arriving** — Neither `SMTP_HOST` nor `RESEND_API_KEY` is configured. Log into the admin panel and manually verify the account (Users tab), or promote it to admin.
 
-**Admin panel shows "Admin access required"** — The signed-in account has `role=user`. Bootstrap an admin account using the `docker exec` command in the [Quick start](#quick-start) section, then log in with those credentials.
+**Admin panel shows "Admin access required"** — The signed-in account has `role=user`. Use the bootstrap env vars and restart the container to auto-create an admin, then log in with those credentials.
 
-**demo.db not persisting across container restarts** — The `demo-data` volume is not mounted. Check `egeria-quickstart.yaml` for the `../../runtime-volumes/quickstart-demo-data:/app/demo-data` volume mount. Create the directory if it does not exist:
+**Demo auth tables not found / schema errors** — The `demo_auth` schema has not been created yet. Restart the `quickstart-pyegeria-web` container — `get_engine()` creates the schema and tables on first call.
 
-```bash
-mkdir -p runtime-volumes/quickstart-demo-data
-```
-
-**Persona picker not appearing** — Either `DEMO_MODE` is false (the persona picker only activates when `/api/auth/me` returns `authenticated: true`), or a persona was previously selected and stored in `localStorage`. Clear `egeria-persona` from browser localStorage or click "Switch" in the header badge.
+**Persona picker not appearing** — Either `DEMO_MODE` is false, or a persona was previously selected and stored in `localStorage`. Clear `egeria-persona` (and `egeria-creds`) from browser localStorage, or click **Switch** in the header persona badge.
 
 **"Persona not found" error** — The persona ID sent to `/api/demo/select-persona` does not match any key in `personas.json`. Ensure the frontend is using the correct persona IDs (lowercase, no spaces: `erinoverview`, `peterprofile`, etc.).
+
+**Egeria Explorer shows "Connect" tab with a form in demo mode** — The persona has not been selected yet, or `egeria-creds` was cleared from localStorage. Return to `/portal` and select a persona — Explorer will pick up the credentials automatically.
+
+**Demo reset fails: "Cannot reach Docker daemon"** — `/var/run/docker.sock` is not mounted into the `quickstart-pyegeria-web` container. Check the volume mount in `egeria-quickstart.yaml`.
+
+**Obsidian tile shows only GitHub link when I'm local** — `obsidian_vault_url` is not set in the Config tab. Set it to your vault name (e.g. `coco-workbooks`) or a full `obsidian://` URI. Local vs. remote detection is based on `window.location.hostname`; ensure you are accessing the portal via `localhost` or `127.0.0.1`.

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -35,17 +35,17 @@
 
     /* ── Hero ── */
     .hero { background: linear-gradient(135deg, #16213e 0%, #0f3460 100%); border-bottom: 1px solid var(--border); padding: 40px 28px 36px; }
-    .hero-inner { max-width: 1060px; margin: 0 auto; display: flex; gap: 36px; align-items: flex-start; flex-wrap: wrap; }
-    .hero-text { flex: 1; min-width: 260px; }
+    .hero-inner { max-width: 1060px; margin: 0 auto; display: flex; gap: 32px; align-items: center; flex-wrap: wrap; }
+    .hero-text { flex: 1; min-width: 260px; text-align: center; }
     .hero h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 10px; }
     .hero p  { color: var(--muted); line-height: 1.65; font-size: 0.95rem; }
-    .hero-links { flex-shrink: 0; min-width: 200px; display: flex; flex-direction: column; gap: 14px; padding-top: 4px; }
-    .hero-links-row { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+    .hero-links { width: 160px; flex-shrink: 0; display: flex; flex-direction: column; gap: 14px; padding-top: 4px; }
+    .hero-links-row { display: flex; flex-direction: column; gap: 5px; }
     .hero-links-row a { font-size: 0.8rem; color: var(--muted); text-decoration: none; white-space: nowrap; }
     .hero-links-row a:hover { color: var(--accent); text-decoration: underline; }
     .hero-links-label { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: #555; margin-bottom: 2px; }
-    .hero-stars { font-size: 0.78rem; color: #555; }
-    .hero-stars a { color: var(--muted); text-decoration: none; margin-right: 8px; white-space: nowrap; }
+    .hero-stars { display: flex; flex-direction: column; gap: 5px; }
+    .hero-stars a { font-size: 0.8rem; color: var(--muted); text-decoration: none; white-space: nowrap; }
     .hero-stars a:hover { color: var(--accent); }
 
     /* ── Main ── */
@@ -201,7 +201,9 @@
   <div class="ftr-links">
     <a href="/privacy">Privacy Policy</a>
   </div>
-  <img src="/static/pdr-logo.png" alt="PDR Associates" style="height:26px; opacity:0.6">
+  <a href="https://pdr-associates.com" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;opacity:0.6;transition:opacity 0.15s" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'">
+    <img src="/static/pdr-logo.png" alt="PDR Associates" style="height:26px">
+  </a>
 </footer>
 
 <!-- ── Persona picker overlay ─────────────────────────────────────────────── -->

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -236,6 +236,7 @@ function _saveStored(p) {
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
 var _obsidianUrl = '';
+var _obsidianGithubUrl = '';
 
 fetch('/api/auth/me').then(function(r){ return r.json(); }).then(function(me) {
   if (!me.authenticated) { window.location.href = '/login'; return; }
@@ -245,6 +246,7 @@ fetch('/api/auth/me').then(function(r){ return r.json(); }).then(function(me) {
   ]).then(function(results) {
     _personas = results[0];
     _obsidianUrl = (results[1] && results[1].obsidian_vault_url) || '';
+    _obsidianGithubUrl = (results[1] && results[1].obsidian_github_url) || '';
     var stored = _loadStored();
     _currentPersonaId = stored ? stored.id : null;
     renderAppGrid();
@@ -293,8 +295,8 @@ function renderAppGrid() {
       desc: 'Coco Pharmaceuticals internal web resources and reference material.',
       url: '/local', newTab: true, enabled: true },
     { icon: '🗒️', name: 'Obsidian Vault',
-      desc: 'Open the Coco Pharmaceuticals workbook vault in Obsidian. Requires Obsidian installed locally.',
-      url: _obsidianUrl, newTab: false, enabled: !!_obsidianUrl, obsidian: true },
+      desc: 'Open the Coco Pharmaceuticals workbook vault in Obsidian (requires local install), or browse on GitHub.',
+      url: _obsidianUrl, newTab: false, enabled: !!(_obsidianUrl || _obsidianGithubUrl), obsidian: true },
     { icon: '🤖', name: 'Egeria Advisor',
       desc: 'AI-powered guidance for your Egeria environment.',
       url: null, newTab: true, enabled: false },
@@ -304,7 +306,13 @@ function renderAppGrid() {
     if (!a.enabled) {
       action = '<span class="soon-badge">Coming soon</span>';
     } else if (a.obsidian) {
-      action = '<button class="btn btn-accent app-action" onclick="launchObsidian()">Open ↗</button>';
+      var obsBtn = _obsidianUrl
+        ? '<button class="btn btn-accent app-action" onclick="launchObsidian()" title="Requires Obsidian installed locally">Open in Obsidian</button>'
+        : '';
+      var ghBtn = _obsidianGithubUrl
+        ? '<a class="btn app-action" href="' + esc(_obsidianGithubUrl) + '" target="_blank" rel="noopener" style="display:inline-block;text-decoration:none">GitHub ↗</a>'
+        : '';
+      action = '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px">' + obsBtn + ghBtn + '</div>';
     } else {
       action = '<button class="btn btn-accent app-action" onclick="launch(' + JSON.stringify(a.url).replace(/"/g, '&quot;') + ',' + a.newTab + ')">' + (a.newTab ? 'Open ↗' : 'Open') + '</button>';
     }

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -396,6 +396,7 @@ function confirmPersona() {
 function doLogout() {
   fetch('/api/auth/logout', { method: 'POST' }).then(function() {
     localStorage.removeItem('egeria-persona');
+    localStorage.removeItem('egeria-creds');
     window.location.href = '/login';
   });
 }

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -35,9 +35,18 @@
 
     /* ── Hero ── */
     .hero { background: linear-gradient(135deg, #16213e 0%, #0f3460 100%); border-bottom: 1px solid var(--border); padding: 40px 28px 36px; }
-    .hero-inner { max-width: 860px; margin: 0 auto; }
+    .hero-inner { max-width: 1060px; margin: 0 auto; display: flex; gap: 36px; align-items: flex-start; flex-wrap: wrap; }
+    .hero-text { flex: 1; min-width: 260px; }
     .hero h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 10px; }
-    .hero p  { color: var(--muted); line-height: 1.65; max-width: 680px; font-size: 0.95rem; }
+    .hero p  { color: var(--muted); line-height: 1.65; font-size: 0.95rem; }
+    .hero-links { flex-shrink: 0; min-width: 200px; display: flex; flex-direction: column; gap: 14px; padding-top: 4px; }
+    .hero-links-row { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+    .hero-links-row a { font-size: 0.8rem; color: var(--muted); text-decoration: none; white-space: nowrap; }
+    .hero-links-row a:hover { color: var(--accent); text-decoration: underline; }
+    .hero-links-label { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: #555; margin-bottom: 2px; }
+    .hero-stars { font-size: 0.78rem; color: #555; }
+    .hero-stars a { color: var(--muted); text-decoration: none; margin-right: 8px; white-space: nowrap; }
+    .hero-stars a:hover { color: var(--accent); }
 
     /* ── Main ── */
     .main { max-width: 1060px; margin: 0 auto; padding: 32px 28px; }
@@ -125,8 +134,29 @@
 <!-- ── Hero ───────────────────────────────────────────────────────────────── -->
 <div class="hero">
   <div class="hero-inner">
-    <h1>Welcome to the Egeria Demo Environment</h1>
-    <p>This environment showcases <strong>Egeria</strong> — the open metadata platform — using Coco Pharmaceuticals, a fictional company whose data landscape illustrates real-world governance, lineage, and cataloguing challenges. Register once, choose a persona, and explore the metadata environment from that character's perspective.</p>
+    <div class="hero-text">
+      <h1>Welcome to the Egeria Demo Environment</h1>
+      <p>This environment showcases <strong>Egeria</strong> — the open metadata platform — using Coco Pharmaceuticals, a fictional company whose data landscape illustrates real-world governance, lineage, and cataloguing challenges. Register once, choose a persona, and explore the metadata environment from that character's perspective.</p>
+    </div>
+    <div class="hero-links">
+      <div>
+        <div class="hero-links-label">Resources</div>
+        <div class="hero-links-row">
+          <a href="https://egeria-project.ai" target="_blank" rel="noopener">Documentation ↗</a>
+          <a href="https://github.com/odpi" target="_blank" rel="noopener">GitHub ↗</a>
+          <a href="https://egeria-project.org/practices/coco-pharmaceuticals" target="_blank" rel="noopener">Coco Pharmaceuticals ↗</a>
+        </div>
+      </div>
+      <div>
+        <div class="hero-links-label">Star us on GitHub</div>
+        <div class="hero-stars">
+          <a href="https://github.com/odpi/egeria" target="_blank" rel="noopener">⭐ egeria</a>
+          <a href="https://github.com/odpi/egeria-docs" target="_blank" rel="noopener">⭐ egeria-docs</a>
+          <a href="https://github.com/odpi/egeria-workspaces" target="_blank" rel="noopener">⭐ egeria-workspaces</a>
+          <a href="https://github.com/odpi/egeria-python" target="_blank" rel="noopener">⭐ egeria-python</a>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -169,16 +199,7 @@
 <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
 <footer class="ftr">
   <div class="ftr-links">
-    <a href="https://egeria-project.ai" target="_blank" rel="noopener">Documentation</a>
-    <a href="https://github.com/odpi" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://egeria-project.org/practices/coco-pharmaceuticals" target="_blank" rel="noopener">Coco Pharmaceuticals</a>
     <a href="/privacy">Privacy Policy</a>
-  </div>
-  <div class="ftr-stars">
-    If you find Egeria useful, please star us on GitHub:
-    <a href="https://github.com/odpi/egeria" target="_blank" rel="noopener">⭐ egeria</a>
-    <a href="https://github.com/odpi/egeria-workspaces" target="_blank" rel="noopener">⭐ egeria-workspaces</a>
-    <a href="https://github.com/odpi/egeria-python" target="_blank" rel="noopener">⭐ egeria-python</a>
   </div>
   <img src="/static/pdr-logo.png" alt="PDR Associates" style="height:26px; opacity:0.6">
 </footer>

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -306,13 +306,17 @@ function renderAppGrid() {
     if (!a.enabled) {
       action = '<span class="soon-badge">Coming soon</span>';
     } else if (a.obsidian) {
-      var obsBtn = _obsidianUrl
+      var isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+      var obsBtn = (_obsidianUrl && isLocal)
         ? '<button class="btn btn-accent app-action" onclick="launchObsidian()" title="Requires Obsidian installed locally">Open in Obsidian</button>'
         : '';
       var ghBtn = _obsidianGithubUrl
-        ? '<a class="btn app-action" href="' + esc(_obsidianGithubUrl) + '" target="_blank" rel="noopener" style="display:inline-block;text-decoration:none">GitHub ↗</a>'
+        ? '<a class="btn btn-accent app-action" href="' + esc(_obsidianGithubUrl) + '" target="_blank" rel="noopener" style="display:inline-block;text-decoration:none">GitHub ↗</a>'
         : '';
-      action = '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px">' + obsBtn + ghBtn + '</div>';
+      var remoteNote = (!isLocal && _obsidianUrl && !_obsidianGithubUrl)
+        ? '<span style="font-size:11px;color:var(--text-muted);align-self:center">Obsidian requires local access</span>'
+        : '';
+      action = '<div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;align-items:center">' + obsBtn + ghBtn + remoteNote + '</div>';
     } else {
       action = '<button class="btn btn-accent app-action" onclick="launch(' + JSON.stringify(a.url).replace(/"/g, '&quot;') + ',' + a.newTab + ')">' + (a.newTab ? 'Open ↗' : 'Open') + '</button>';
     }
@@ -330,9 +334,12 @@ function launch(url, newTab) {
 }
 
 function launchObsidian() {
-  if (!_obsidianUrl) return;
-  // obsidian:// links are handled by the OS protocol handler — navigate directly
-  window.location.href = _obsidianUrl;
+  var isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+  if (!isLocal) {
+    if (_obsidianGithubUrl) { window.open(_obsidianGithubUrl, '_blank', 'noopener'); }
+    return;
+  }
+  if (_obsidianUrl) { window.location.href = _obsidianUrl; }
 }
 
 // ── Picker ────────────────────────────────────────────────────────────────────

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -235,10 +235,16 @@ function _saveStored(p) {
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
+var _obsidianUrl = '';
+
 fetch('/api/auth/me').then(function(r){ return r.json(); }).then(function(me) {
   if (!me.authenticated) { window.location.href = '/login'; return; }
-  fetch('/api/demo/personas').then(function(r){ return r.json(); }).then(function(data) {
-    _personas = data;
+  Promise.all([
+    fetch('/api/demo/personas').then(function(r){ return r.json(); }),
+    fetch('/api/demo/portal-config').then(function(r){ return r.json(); }).catch(function(){ return {}; }),
+  ]).then(function(results) {
+    _personas = results[0];
+    _obsidianUrl = (results[1] && results[1].obsidian_vault_url) || '';
     var stored = _loadStored();
     _currentPersonaId = stored ? stored.id : null;
     renderAppGrid();
@@ -286,14 +292,22 @@ function renderAppGrid() {
     { icon: '🌐', name: 'Coco Web',
       desc: 'Coco Pharmaceuticals internal web resources and reference material.',
       url: '/local', newTab: true, enabled: true },
+    { icon: '🗒️', name: 'Obsidian Vault',
+      desc: 'Open the Coco Pharmaceuticals workbook vault in Obsidian. Requires Obsidian installed locally.',
+      url: _obsidianUrl, newTab: false, enabled: !!_obsidianUrl, obsidian: true },
     { icon: '🤖', name: 'Egeria Advisor',
       desc: 'AI-powered guidance for your Egeria environment.',
       url: null, newTab: true, enabled: false },
   ];
   document.getElementById('app-grid').innerHTML = apps.map(function(a) {
-    var action = a.enabled
-      ? '<button class="btn btn-accent app-action" onclick="launch(' + JSON.stringify(a.url).replace(/"/g, '&quot;') + ',' + a.newTab + ')">' + (a.newTab ? 'Open ↗' : 'Open') + '</button>'
-      : '<span class="soon-badge">Coming soon</span>';
+    var action;
+    if (!a.enabled) {
+      action = '<span class="soon-badge">Coming soon</span>';
+    } else if (a.obsidian) {
+      action = '<button class="btn btn-accent app-action" onclick="launchObsidian()">Open ↗</button>';
+    } else {
+      action = '<button class="btn btn-accent app-action" onclick="launch(' + JSON.stringify(a.url).replace(/"/g, '&quot;') + ',' + a.newTab + ')">' + (a.newTab ? 'Open ↗' : 'Open') + '</button>';
+    }
     return '<div class="app-tile' + (a.enabled ? '' : ' disabled') + '">' +
       '<div class="app-icon">' + a.icon + '</div>' +
       '<div class="app-name">' + esc(a.name) + '</div>' +
@@ -305,6 +319,12 @@ function renderAppGrid() {
 function launch(url, newTab) {
   if (!url) return;
   if (newTab) { window.open(url, '_blank', 'noopener'); } else { window.location.href = url; }
+}
+
+function launchObsidian() {
+  if (!_obsidianUrl) return;
+  // obsidian:// links are handled by the OS protocol handler — navigate directly
+  window.location.href = _obsidianUrl;
 }
 
 // ── Picker ────────────────────────────────────────────────────────────────────

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
@@ -382,14 +382,16 @@ def portal_config(request: Request, db: Session = Depends(get_db)):
     user = get_current_user(request, db)
     if not user or not user.verified:
         raise HTTPException(status_code=401, detail="Authentication required")
+    import urllib.parse
     raw = get_config("obsidian_vault_url", "")
     if raw and not raw.startswith("obsidian://"):
-        # Treat bare value as a vault name → construct the URI
-        import urllib.parse
         obsidian_url = "obsidian://open?vault=" + urllib.parse.quote(raw)
     else:
         obsidian_url = raw
-    return {"obsidian_vault_url": obsidian_url}
+    return {
+        "obsidian_vault_url": obsidian_url,
+        "obsidian_github_url": get_config("obsidian_github_url", ""),
+    }
 
 
 # ── Persona selection ──────────────────────────────────────────────────────────

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_auth_handler.py
@@ -17,6 +17,7 @@ Routes:
   GET  /api/auth/me
   POST /api/demo/select-persona
   GET  /api/demo/personas
+  GET  /api/demo/portal-config
   GET  /api/demo/config          (admin only)
   POST /api/demo/config          (admin only)
   GET  /api/demo/users           (admin only)
@@ -372,6 +373,23 @@ def reset_password(req: ResetPasswordRequest, db: Session = Depends(get_db)):
     user.reset_expires = None
     db.commit()
     return {"message": "Password reset successful — you can now log in"}
+
+
+# ── Portal config (authenticated) ─────────────────────────────────────────────
+
+@router.get("/api/demo/portal-config", summary="Return portal tile config for authenticated users")
+def portal_config(request: Request, db: Session = Depends(get_db)):
+    user = get_current_user(request, db)
+    if not user or not user.verified:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    raw = get_config("obsidian_vault_url", "")
+    if raw and not raw.startswith("obsidian://"):
+        # Treat bare value as a vault name → construct the URI
+        import urllib.parse
+        obsidian_url = "obsidian://open?vault=" + urllib.parse.quote(raw)
+    else:
+        obsidian_url = raw
+    return {"obsidian_vault_url": obsidian_url}
 
 
 # ── Persona selection ──────────────────────────────────────────────────────────

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
@@ -68,7 +68,7 @@ _engine = None
 _CONFIG_DEFAULTS = {
     "reset_interval_hours":  "0",   # 0 = disabled; set via admin page to enable
     "obsidian_vault_url":    "",    # obsidian:// URI or vault name for the portal tile
-    "obsidian_github_url":   "",    # GitHub URL for the vault (fallback for remote users)
+    "obsidian_github_url":   "https://github.com/odpi/egeria-workspaces/tree/main/coco-workbooks",
     "directive_cap":         "validate",
     "session_lifetime_user": "7200",
     "session_lifetime_admin":"604800",

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
@@ -67,7 +67,8 @@ _engine = None
 
 _CONFIG_DEFAULTS = {
     "reset_interval_hours":  "0",   # 0 = disabled; set via admin page to enable
-    "obsidian_vault_url":    "",    # obsidian:// URI for the portal tile; set via admin page
+    "obsidian_vault_url":    "",    # obsidian:// URI or vault name for the portal tile
+    "obsidian_github_url":   "",    # GitHub URL for the vault (fallback for remote users)
     "directive_cap":         "validate",
     "session_lifetime_user": "7200",
     "session_lifetime_admin":"604800",

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_reset_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_reset_handler.py
@@ -16,6 +16,7 @@ Docker socket must be mounted into the container:
 """
 
 import asyncio
+import os
 from datetime import datetime
 from typing import Optional
 
@@ -113,10 +114,20 @@ async def _run_reset() -> None:
             set_config("reset_state", "ready")
 
 
+_DOCKER_SOCKET = os.environ.get("DOCKER_HOST", "unix:///var/run/docker.sock")
+
+
 def _do_reset_blocking() -> None:
     """Blocking reset: stop container → drop schema → start container."""
     import docker  # imported here so the module loads even without docker SDK at startup
-    client = docker.from_env()
+    try:
+        client = docker.DockerClient(base_url=_DOCKER_SOCKET)
+        client.ping()  # verify connectivity before proceeding
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot reach Docker daemon at {_DOCKER_SOCKET!r}: {exc}. "
+            "Ensure /var/run/docker.sock is mounted into this container."
+        ) from exc
 
     logger.info(f"Stopping container: {EGERIA_CONTAINER_NAME}")
     try:

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -45,7 +45,7 @@
     #root { display: flex; flex-direction: column; height: 100vh; }
     .header { background: var(--panel); border-bottom: 1px solid var(--border);
               padding: 10px 20px; display: flex; align-items: center; gap: 14px;
-              flex-shrink: 0; overflow-x: auto; }
+              flex-shrink: 0; }
     .body   { display: flex; flex: 1; overflow: hidden; }
     .sidebar { flex-shrink: 0; background: rgba(11,17,28,.85);
                display: flex; flex-direction: column; overflow: hidden; }
@@ -166,11 +166,10 @@
                      padding: 4px 10px; cursor: pointer; font-size: 13px; color: var(--muted);
                      font-family: inherit; line-height: 1.5; display: flex; align-items: center; gap: 3px; }
     .nav-group-btn.on { color: var(--accent); font-weight: 600; border-bottom-color: var(--accent); }
-    .nav-group-menu { position: absolute; top: calc(100% + 2px); left: 0; background: var(--panel);
+    .nav-group-menu { position: absolute; top: 100%; left: 0; background: var(--panel);
                       border: 1px solid var(--border); border-radius: 6px; padding: 4px 0;
                       min-width: 172px; z-index: 100; display: none;
                       box-shadow: 0 8px 24px rgba(0,0,0,.4); }
-    .nav-group:hover .nav-group-menu,
     .nav-group:focus-within .nav-group-menu { display: block; }
     .nav-group-item { display: block; width: 100%; text-align: left; background: none; border: none;
                       padding: 7px 16px; font-size: 13px; color: var(--muted); font-family: inherit;
@@ -3808,7 +3807,7 @@ function ConnectionForm({ saveCreds }) {
   );
 }
 
-function SplashScreen({ onNavigate, saveCreds }) {
+function SplashScreen({ onNavigate, saveCreds, demoMode }) {
   var cardStyle = {
     background: 'var(--surface)',
     border: '1px solid var(--border)',
@@ -3844,7 +3843,7 @@ function SplashScreen({ onNavigate, saveCreds }) {
         'Browse the open metadata type system, business glossaries, reference data, digital products, ' +
         'solution blueprints, data design, and view-server REST APIs — all connected live to your running Egeria platform.'
       ),
-      React.createElement(ConnectionForm, { saveCreds: saveCreds }),
+      !demoMode && React.createElement(ConnectionForm, { saveCreds: saveCreds }),
       React.createElement('div', {
         style: {
           display: 'grid',
@@ -5720,10 +5719,19 @@ function PersonaPickerModal({ onSelect, currentPersonaId }) {
 function NavGroup(props) {
   var label = props.label, isActive = props.isActive, items = props.items,
       onSelect = props.onSelect, currentSection = props.currentSection, connected = props.connected;
+  var _open = useState(false), open = _open[0], setOpen = _open[1];
+  useEffect(function() {
+    if (!open) return;
+    function handleOutside() { setOpen(false); }
+    document.addEventListener('click', handleOutside);
+    return function() { document.removeEventListener('click', handleOutside); };
+  }, [open]);
   return React.createElement('div', { className: 'nav-group' },
-    React.createElement('button', { className: 'nav-group-btn' + (isActive ? ' on' : '') },
-      label, ' ▾'),
-    React.createElement('div', { className: 'nav-group-menu' },
+    React.createElement('button', {
+      className: 'nav-group-btn' + (isActive ? ' on' : ''),
+      onClick: function(e) { e.stopPropagation(); setOpen(function(o) { return !o; }); }
+    }, label, ' \u25be'),
+    open && React.createElement('div', { className: 'nav-group-menu', style: { display: 'block' } },
       items.map(function(item) {
         var dis = item.needsConnect && !connected;
         return React.createElement('button', {
@@ -5731,7 +5739,11 @@ function NavGroup(props) {
           className: 'nav-group-item' + (currentSection === item.id ? ' on' : ''),
           disabled: dis,
           title: dis ? 'Connect on the Home tab first' : '',
-          onClick: function() { onSelect(item.id); }
+          onClick: function(e) {
+            e.stopPropagation();
+            setOpen(false);
+            if (!dis) onSelect(item.id);
+          }
         }, item.label);
       })
     )
@@ -5994,7 +6006,7 @@ function App() {
     ),
     // Body — dispatches to section, then to Type System sub-view
     section === 'splash'
-      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); }, saveCreds: saveCreds })
+      ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); }, saveCreds: saveCreds, demoMode: demoMode })
       : section === 'report-specs'
       ? React.createElement(ReportSpecView, { key: credsKey })
       : section === 'glossary'

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -160,6 +160,31 @@
                  font-family: inherit; }
     .theme-btn:hover { background: var(--hover); color: var(--text); }
 
+    /* ── Nav dropdown groups ──────────────────────────────────────────── */
+    .nav-group { position: relative; display: flex; align-items: stretch; }
+    .nav-group-btn { background: none; border: none; border-bottom: 2px solid transparent;
+                     padding: 4px 10px; cursor: pointer; font-size: 13px; color: var(--muted);
+                     font-family: inherit; line-height: 1.5; display: flex; align-items: center; gap: 3px; }
+    .nav-group-btn.on { color: var(--accent); font-weight: 600; border-bottom-color: var(--accent); }
+    .nav-group-menu { position: absolute; top: calc(100% + 2px); left: 0; background: var(--panel);
+                      border: 1px solid var(--border); border-radius: 6px; padding: 4px 0;
+                      min-width: 172px; z-index: 100; display: none;
+                      box-shadow: 0 8px 24px rgba(0,0,0,.4); }
+    .nav-group:hover .nav-group-menu,
+    .nav-group:focus-within .nav-group-menu { display: block; }
+    .nav-group-item { display: block; width: 100%; text-align: left; background: none; border: none;
+                      padding: 7px 16px; font-size: 13px; color: var(--muted); font-family: inherit;
+                      cursor: pointer; white-space: nowrap; }
+    .nav-group-item:hover:not(:disabled) { background: var(--hover); color: var(--text); }
+    .nav-group-item.on { color: var(--accent); font-weight: 600; }
+    .nav-group-item:disabled { opacity: 0.35; cursor: not-allowed; }
+    :root.light .nav-group-menu { box-shadow: 0 4px 14px rgba(0,0,0,.15); }
+
+    /* ── Type-system sub-toolbar ──────────────────────────────────────── */
+    .type-subbar { background: var(--panel); border-bottom: 1px solid var(--border);
+                   padding: 4px 20px; display: flex; align-items: center; gap: 12px;
+                   flex-shrink: 0; font-size: 12px; }
+
     /* ── REST API Explorer ───────────────────────────────────────── */
     .method-badge { border-radius: 3px; padding: 1px 6px; font-size: 10px; font-weight: 700;
                     font-family: ui-monospace, monospace; letter-spacing: .5px; flex-shrink: 0; }
@@ -5690,6 +5715,29 @@ function PersonaPickerModal({ onSelect, currentPersonaId }) {
   );
 }
 
+// ── Nav dropdown group component ──────────────────────────────────────────────
+
+function NavGroup(props) {
+  var label = props.label, isActive = props.isActive, items = props.items,
+      onSelect = props.onSelect, currentSection = props.currentSection, connected = props.connected;
+  return React.createElement('div', { className: 'nav-group' },
+    React.createElement('button', { className: 'nav-group-btn' + (isActive ? ' on' : '') },
+      label, ' ▾'),
+    React.createElement('div', { className: 'nav-group-menu' },
+      items.map(function(item) {
+        var dis = item.needsConnect && !connected;
+        return React.createElement('button', {
+          key: item.id,
+          className: 'nav-group-item' + (currentSection === item.id ? ' on' : ''),
+          disabled: dis,
+          title: dis ? 'Connect on the Home tab first' : '',
+          onClick: function() { onSelect(item.id); }
+        }, item.label);
+      })
+    )
+  );
+}
+
 // ── App ───────────────────────────────────────────────────────────────────────
 
 function App() {
@@ -5878,21 +5926,55 @@ function App() {
       /*#__PURE__*/React.createElement("span", { style: { fontFamily: 'ui-monospace,monospace', fontSize: 11, color: 'var(--dim)', letterSpacing: 3, textTransform: 'uppercase' } }, "Egeria"),
       /*#__PURE__*/React.createElement("span", { style: { width: 1, height: 14, background: 'var(--border)', display: 'inline-block' } }),
       /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'splash' ? " on" : ""), onClick: () => setSection('splash') }, "⌂ Home"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'type-system' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => { setSection('type-system'); setView('types'); } }, "Type Explorer"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'glossary' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('glossary') }, "Glossary"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'reference-data' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('reference-data') }, "Reference Data"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'digital-products' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('digital-products') }, "Digital Products"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'report-specs' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('report-specs') }, "Report Specs"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'valid-values' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('valid-values') }, "Valid Values"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'rest-apis' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('rest-apis') }, "REST APIs"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'solution-architect' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('solution-architect') }, "Solution Architect"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'data-design' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('data-design') }, "Data Design"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'perspectives' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('perspectives') }, "Perspectives"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'dr-egeria' ? " on" : ""), onClick: () => setSection('dr-egeria') }, "Dr. Egeria"),
-      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'isc' ? " on" : ""), disabled: !connected, title: connected ? '' : 'Connect on the Home tab first', onClick: () => setSection('isc') }, "Supply Chains"),
+      section !== 'splash' && React.createElement(React.Fragment, null,
+        React.createElement(NavGroup, {
+          label: 'Reference', connected: connected, currentSection: section,
+          isActive: ['type-system','rest-apis','valid-values'].includes(section),
+          onSelect: function(id) { setSection(id); if (id === 'type-system') setView('types'); },
+          items: [
+            { id: 'type-system',  label: 'Type Explorer', needsConnect: true },
+            { id: 'rest-apis',    label: 'REST APIs',      needsConnect: true },
+            { id: 'valid-values', label: 'Valid Values',   needsConnect: true },
+          ]
+        }),
+        React.createElement(NavGroup, {
+          label: 'Review', connected: connected, currentSection: section,
+          isActive: ['glossary','reference-data','data-design','solution-architect','isc','perspectives'].includes(section),
+          onSelect: setSection,
+          items: [
+            { id: 'glossary',           label: 'Glossary',           needsConnect: true },
+            { id: 'reference-data',     label: 'Reference Data',     needsConnect: true },
+            { id: 'data-design',        label: 'Data Design',        needsConnect: true },
+            { id: 'solution-architect', label: 'Solution Architect', needsConnect: true },
+            { id: 'isc',                label: 'Supply Chains',      needsConnect: true },
+            { id: 'perspectives',       label: 'Perspectives',       needsConnect: true },
+          ]
+        }),
+        React.createElement(NavGroup, {
+          label: 'Act', connected: connected, currentSection: section,
+          isActive: ['report-specs','digital-products'].includes(section),
+          onSelect: setSection,
+          items: [
+            { id: 'report-specs',     label: 'Report Specs',     needsConnect: true },
+            { id: 'digital-products', label: 'Digital Products', needsConnect: true },
+          ]
+        }),
+        /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'dr-egeria' ? " on" : ""), onClick: () => setSection('dr-egeria') }, "Dr. Egeria")
+      ),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
-      section === 'type-system' && /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
-      section === 'type-system' && view === 'types' && /*#__PURE__*/React.createElement("select", {
+      /*#__PURE__*/React.createElement("button", {
+        className: "theme-btn",
+        onClick: () => setTheme(t => t === 'dark' ? 'light' : 'dark'),
+        title: theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+      }, theme === 'dark' ? "☀ Light" : "☾ Dark"),
+      demoMode && activePersona && React.createElement(React.Fragment, null,
+        React.createElement('span', { className: 'persona-badge-btn', title: activePersona.coco_title || '' }, '🎭 ' + activePersona.display_name),
+        React.createElement('a', { className: 'theme-btn', style: { marginLeft: 4, textDecoration: 'none' }, href: '/portal' }, 'Portal')
+      ),
+      demoMode && !activePersona && React.createElement('a', { className: 'persona-badge-btn', href: '/portal' }, '🎭 Choose persona')
+    ),
+    section === 'type-system' && /*#__PURE__*/React.createElement("div", { className: "type-subbar" },
+      /*#__PURE__*/React.createElement("select", {
         className: "area-select",
         value: areaFilter,
         onChange: e => {
@@ -5902,23 +5984,15 @@ function App() {
           if (first) setSelected({ kind: 'type', name: first });
         }
       }, Object.entries(AREA_NAMES).map(([k, v]) => /*#__PURE__*/React.createElement("option", { key: k, value: k }, v))),
-      section === 'type-system' && /*#__PURE__*/React.createElement("div", { style: { fontSize: 11, color: 'var(--dim)', display: 'flex', gap: 12 } },
+      /*#__PURE__*/React.createElement("button", { className: "view-tab" + (view === 'attrs' ? " on" : ""), onClick: () => setView('attrs') }, "Attribute Index"),
+      /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
+      view === 'types' && /*#__PURE__*/React.createElement("div", { style: { fontSize: 11, color: 'var(--dim)', display: 'flex', gap: 12 } },
         /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", { style: { color: 'var(--accent)' } }, Object.keys(entities).length), " Entities"),
         /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", { style: { color: 'var(--classif)' } }, Object.keys(classifications).length), " Classifications"),
         /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", { style: { color: 'var(--rel)' } }, Object.keys(relationships).length), " Relationships")
-      ),
-      /*#__PURE__*/React.createElement("button", {
-        className: "theme-btn",
-        onClick: () => setTheme(t => t === 'dark' ? 'light' : 'dark'),
-        title: theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
-      }, theme === 'dark' ? "\u2600 Light" : "\u263E Dark"),
-      demoMode && activePersona && React.createElement(React.Fragment, null,
-        React.createElement('span', { className: 'persona-badge-btn', title: activePersona.coco_title || '' }, '\uD83C\uDFAD ' + activePersona.display_name),
-        React.createElement('a', { className: 'theme-btn', style: { marginLeft: 4, textDecoration: 'none' }, href: '/portal' }, 'Portal')
-      ),
-      demoMode && !activePersona && React.createElement('a', { className: 'persona-badge-btn', href: '/portal' }, '\uD83C\uDFAD Choose persona')
+      )
     ),
-    // Body \u2014 dispatches to section, then to Type System sub-view
+    // Body — dispatches to section, then to Type System sub-view
     section === 'splash'
       ? React.createElement(SplashScreen, { onNavigate: function(s) { setSection(s); if (s === 'type-system') setView('types'); }, saveCreds: saveCreds })
       : section === 'report-specs'

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -5964,14 +5964,14 @@ function App() {
         }),
         React.createElement(NavGroup, {
           label: 'Act', connected: connected, currentSection: section,
-          isActive: ['report-specs','digital-products'].includes(section),
+          isActive: ['report-specs','digital-products','dr-egeria'].includes(section),
           onSelect: setSection,
           items: [
             { id: 'report-specs',     label: 'Report Specs',     needsConnect: true },
             { id: 'digital-products', label: 'Digital Products', needsConnect: true },
+            { id: 'dr-egeria',        label: 'Dr. Egeria' },
           ]
-        }),
-        /*#__PURE__*/React.createElement("button", { className: "view-tab" + (section === 'dr-egeria' ? " on" : ""), onClick: () => setSection('dr-egeria') }, "Dr. Egeria")
+        })
       ),
       /*#__PURE__*/React.createElement("div", { style: { flex: 1 } }),
       /*#__PURE__*/React.createElement("button", {

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -168,9 +168,8 @@
     .nav-group-btn.on { color: var(--accent); font-weight: 600; border-bottom-color: var(--accent); }
     .nav-group-menu { position: absolute; top: 100%; left: 0; background: var(--panel);
                       border: 1px solid var(--border); border-radius: 6px; padding: 4px 0;
-                      min-width: 172px; z-index: 100; display: none;
+                      min-width: 172px; z-index: 100;
                       box-shadow: 0 8px 24px rgba(0,0,0,.4); }
-    .nav-group:focus-within .nav-group-menu { display: block; }
     .nav-group-item { display: block; width: 100%; text-align: left; background: none; border: none;
                       padding: 7px 16px; font-size: 13px; color: var(--muted); font-family: inherit;
                       cursor: pointer; white-space: nowrap; }
@@ -5720,16 +5719,20 @@ function NavGroup(props) {
   var label = props.label, isActive = props.isActive, items = props.items,
       onSelect = props.onSelect, currentSection = props.currentSection, connected = props.connected;
   var _open = useState(false), open = _open[0], setOpen = _open[1];
+  var ref = React.useRef(null);
   useEffect(function() {
     if (!open) return;
-    function handleOutside() { setOpen(false); }
-    document.addEventListener('click', handleOutside);
-    return function() { document.removeEventListener('click', handleOutside); };
+    function handleOutside(e) {
+      if (ref.current && ref.current.contains(e.target)) return;
+      setOpen(false);
+    }
+    document.addEventListener('mousedown', handleOutside);
+    return function() { document.removeEventListener('mousedown', handleOutside); };
   }, [open]);
-  return React.createElement('div', { className: 'nav-group' },
+  return React.createElement('div', { className: 'nav-group', ref: ref },
     React.createElement('button', {
       className: 'nav-group-btn' + (isActive ? ' on' : ''),
-      onClick: function(e) { e.stopPropagation(); setOpen(function(o) { return !o; }); }
+      onClick: function() { setOpen(function(o) { return !o; }); }
     }, label, ' \u25be'),
     open && React.createElement('div', { className: 'nav-group-menu', style: { display: 'block' } },
       items.map(function(item) {
@@ -5739,8 +5742,7 @@ function NavGroup(props) {
           className: 'nav-group-item' + (currentSection === item.id ? ' on' : ''),
           disabled: dis,
           title: dis ? 'Connect on the Home tab first' : '',
-          onClick: function(e) {
-            e.stopPropagation();
+          onClick: function() {
             setOpen(false);
             if (!dis) onSelect(item.id);
           }

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/type-explorer.html
@@ -5705,10 +5705,22 @@ function App() {
     fetch('/api/auth/me').then(function(r) { return r.json(); }).then(function(me) {
       if (me.authenticated) {
         setDemoMode(true);
-        // If no persona chosen yet, show the picker
         var storedPersona = null;
         try { var s = localStorage.getItem('egeria-persona'); storedPersona = s ? JSON.parse(s) : null; } catch(e) {}
         if (!storedPersona) { window.location.href = '/portal'; return; }
+        // Persona selected in portal but egeria-creds not yet set — derive them now so nav tabs unlock
+        var hasCreds = false;
+        try { hasCreds = !!localStorage.getItem('egeria-creds'); } catch(e) {}
+        if (!hasCreds) {
+          fetch('/api/demo/select-persona', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ persona: storedPersona.id })
+          }).then(function(r) { return r.json(); }).then(function(sel) {
+            if (sel.egeria_user) {
+              saveCreds({ url: '', server: 'qs-view-server', userId: sel.egeria_user, password: sel.egeria_password });
+            }
+          }).catch(function() {});
+        }
       }
     }).catch(function() {});
   }, []);


### PR DESCRIPTION
## Summary

A batch of demo environment improvements spanning the portal, Egeria Explorer, and documentation:

**Portal**
- Obsidian vault tile: local users get "Open in Obsidian", remote users get "GitHub ↗" (locality detected from `window.location.hostname`)
- Default `obsidian_github_url` config seeded to `odpi/egeria-workspaces/.../coco-workbooks` so remote users see the link out of the box
- Hero banner redesign: narrow sidebar with resource links (Documentation, GitHub, Coco Pharmaceuticals) and repo star prompts
- Persona picker modal now includes a link to the Coco Pharmaceuticals practice overview
- Login page footer adds Documentation and GitHub links

**Egeria Explorer**
- Grouped nav dropdowns: Reference (Type Explorer, REST APIs, Valid Values), Review (Glossary, Reference Data, Data Design, Solution Architect, Supply Chains, Perspectives), Act (Report Specs, Digital Products, Dr. Egeria)
- Nav hidden on splash/home screen; type-system-specific controls moved to a dedicated sub-toolbar
- Auto-derives Egeria credentials from the portal persona on load — no manual connection form in demo mode
- Connection form hidden on splash in demo mode
- Portal back button and persona badge in header

**Bug fixes**
- NavGroup dropdown: replaced bare `document click` listener (unreliable in React 17+ where synthetic `stopPropagation` doesn't prevent native bubbling) with `useRef + mousedown + contains()` — the standard robust pattern
- Removed `focus-within` CSS rule that was redundant with React conditional rendering
- Docker reset handler: explicit socket URL with `client.ping()` verification instead of `from_env()`

**Docs**
- `demo-mode.md` comprehensively updated: PostgreSQL replaces SQLite references, all new env vars (DEMO_DB_*, EGERIA_META_DB_*, RESEND_*, SMTP_SSL), new routes (/portal, /reset-password), new API endpoints, portal/explorer feature docs, updated DB maintenance commands, expanded troubleshooting

## Test plan

- [ ] Portal: register, verify, select persona → Explorer opens connected, no form visible
- [ ] Explorer nav: dropdowns open/close correctly; clicking item closes dropdown and navigates; clicking outside closes; switching groups works without leaving previous group open
- [ ] Explorer: Dr. Egeria accessible via Act dropdown; stays in dropdown after selection
- [ ] Portal Obsidian tile: on localhost shows "Open in Obsidian"; on remote shows "GitHub ↗"
- [ ] Admin Config: set `obsidian_vault_url` → local button appears; clear it → button hidden
- [ ] Password reset flow: forgot-password → email → /reset-password?token= → form works
- [ ] Demo reset API: `POST /api/demo/reset` requires admin auth; returns 409 if already resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)