### PR TITLE
Add Obsidian session lock, portal-docs documentation hub, and portal UX improvements

### DIFF
--- a/coco-workbooks/Dr-Egeria-Samples/# create-egeria-markdown-glossary.md
+++ b/coco-workbooks/Dr-Egeria-Samples/# create-egeria-markdown-glossary.md
@@ -1,0 +1,3 @@
+## Create Glossary
+### Display Name
+Dr. Egeria Help

--- a/compose-configs/egeria-freshstart/egeria-freshstart.yaml
+++ b/compose-configs/egeria-freshstart/egeria-freshstart.yaml
@@ -146,6 +146,7 @@ services:
       - ../egeria-quickstart/markdown-header.html:/usr/local/apache2/conf/markdown-header.html
       - ../../runtime-volumes/freshstart-apache-web/ErrorLogs:/usr/local/apache2/logs
       - ../../workspaces/Dr-Egeria-Samples:/usr/local/apache2/htdocs/Dr-Egeria-Samples
+      - ../../portal-docs:/usr/local/apache2/htdocs/docs
     depends_on:
       - freshstart-pyegeria-web
 

--- a/compose-configs/egeria-quickstart/.env.example
+++ b/compose-configs/egeria-quickstart/.env.example
@@ -35,6 +35,10 @@ RESEND_FROM=
 
 
 # ── Obsidian integration ──────────────────────────────────────────────────────
+# Set to false to disable the session lock entirely (single-user / freshstart).
+# When disabled, the portal tile shows a direct link with no acquire/release flow.
+OBSIDIAN_LOCK_ENABLED=true
+
 # Controls which Obsidian the portal tile opens.
 #
 #   Empty (default) — portal opens the containerized Obsidian at port 3000.

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-admin.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-admin.html
@@ -76,6 +76,20 @@
     .reset-note { font-size: 0.78rem; color: var(--muted); margin-top: 0.6rem; line-height: 1.5; }
     .spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid var(--muted); border-top-color: var(--warn); border-radius: 50%; animation: spin 0.8s linear infinite; vertical-align: middle; margin-right: 4px; }
     @keyframes spin { to { transform: rotate(360deg); } }
+    /* Obsidian lock panel */
+    .obs-state-row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.25rem; }
+    .obs-state-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.25rem; flex: 1; min-width: 140px; }
+    .obs-state-card .label { font-size: 0.74rem; color: var(--muted); margin-bottom: 0.25rem; }
+    .obs-state-card .val   { font-size: 0.95rem; font-weight: 600; }
+    .state-FREE   { color: var(--success); }
+    .state-IN_USE { color: #64b5f6; }
+    .state-ADMIN_IN_USE { color: #a5b4fc; }
+    .state-STUCK  { color: var(--warn); }
+    .obs-form-row { display: flex; gap: 0.6rem; align-items: flex-end; flex-wrap: wrap; margin-top: 0.75rem; }
+    .obs-form-row label { font-size: 0.78rem; color: var(--muted); display: flex; flex-direction: column; gap: 0.25rem; }
+    .obs-form-row input, .obs-form-row select { padding: 0.35rem 0.55rem; background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); font-size: 0.82rem; }
+    .obs-form-row input:focus, .obs-form-row select:focus { border-color: var(--accent); outline: none; }
+    .obs-actions-row { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.75rem; }
   </style>
 </head>
 <body>
@@ -102,6 +116,7 @@
   <div class="tab" onclick="showTab('events')">Events</div>
   <div class="tab" onclick="showTab('config')">Config</div>
   <div class="tab" onclick="showTab('reset')">Reset</div>
+  <div class="tab" onclick="showTab('obsidian')">Obsidian</div>
 </div>
 
 <div class="content">
@@ -185,6 +200,67 @@
 
   </div>
 
+  <!-- Obsidian panel -->
+  <div class="panel" id="panel-obsidian">
+    <button class="refresh-btn" onclick="loadObsidian()">↻ Refresh</button>
+    <div class="section-title">Obsidian Session Lock</div>
+
+    <!-- Current status -->
+    <div class="obs-state-row" id="obsStateRow">
+      <div class="obs-state-card"><div class="label">State</div><div class="val" id="obsState">—</div></div>
+      <div class="obs-state-card"><div class="label">Held by</div><div class="val" id="obsHolder">—</div></div>
+      <div class="obs-state-card"><div class="label">Persona</div><div class="val" id="obsPersona">—</div></div>
+      <div class="obs-state-card"><div class="label">Time remaining</div><div class="val" id="obsMins">—</div></div>
+    </div>
+
+    <!-- Admin actions -->
+    <div class="reset-card">
+      <h3>Override Actions</h3>
+      <div class="obs-actions-row">
+        <div style="display:flex;align-items:center;gap:0.5rem">
+          <label for="graceSelect" style="font-size:0.82rem;color:var(--muted)">Grace period:</label>
+          <select class="obs-form-row" id="graceSelect" style="padding:0.35rem 0.55rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:0.82rem">
+            <option value="30">30 seconds</option>
+            <option value="60">1 minute</option>
+            <option value="120">2 minutes</option>
+            <option value="300" selected>5 minutes (default)</option>
+            <option value="600">10 minutes</option>
+          </select>
+        </div>
+        <button class="btn-danger" id="evictBtn" onclick="obsEvict()">Evict current holder</button>
+        <button class="btn-danger" id="unlockBtn" onclick="obsUnlock()">Force unlock</button>
+      </div>
+      <p class="reset-note" style="margin-top:0.6rem">
+        <strong>Evict</strong> starts a grace-period countdown — the holder sees a warning in the portal.
+        <strong>Force unlock</strong> releases the lock immediately (use for stuck sessions).
+      </p>
+    </div>
+
+    <!-- Reservations -->
+    <div class="reset-card">
+      <h3>Reserved Blocks</h3>
+      <table id="obsResTable">
+        <thead><tr><th>Label</th><th>Starts</th><th>Ends</th><th>Created</th><th></th></tr></thead>
+        <tbody id="obsResBody"><tr><td colspan="5" class="empty">Loading…</td></tr></tbody>
+      </table>
+      <div class="obs-form-row" style="margin-top:1rem">
+        <label>Label<input id="resLabel" placeholder="e.g. Product demo — Acme Corp" style="width:220px"></label>
+        <label>Starts<input type="datetime-local" id="resStart"></label>
+        <label>Ends<input type="datetime-local" id="resEnd"></label>
+        <button class="btn-primary" onclick="obsCreateRes()" style="margin-top:1.1rem">Reserve</button>
+      </div>
+    </div>
+
+    <!-- Audit log -->
+    <div class="reset-card">
+      <h3>Recent Lock Events</h3>
+      <table>
+        <thead><tr><th>Time</th><th>Action</th><th>Holder</th><th>Persona</th></tr></thead>
+        <tbody id="obsAuditBody"><tr><td colspan="4" class="empty">Loading…</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+
   <!-- Config panel -->
   <div class="panel" id="panel-config">
     <div class="section-title">Runtime Configuration</div>
@@ -211,16 +287,17 @@
   function showTab(name) {
     activeTab = name;
     document.querySelectorAll('.tab').forEach(function(t, i) {
-      t.classList.toggle('active', ['users','events','config','reset'][i] === name);
+      t.classList.toggle('active', ['users','events','config','reset','obsidian'][i] === name);
     });
     document.querySelectorAll('.panel').forEach(function(p) {
       p.classList.remove('active');
     });
     document.getElementById('panel-' + name).classList.add('active');
-    if (name === 'users')  loadUsers();
-    if (name === 'events') loadEvents();
-    if (name === 'config') loadConfig();
-    if (name === 'reset')  loadResetStatus();
+    if (name === 'users')    loadUsers();
+    if (name === 'events')   loadEvents();
+    if (name === 'config')   loadConfig();
+    if (name === 'reset')    loadResetStatus();
+    if (name === 'obsidian') loadObsidian();
   }
 
   function showGlobalMsg(type, text) {
@@ -419,6 +496,125 @@
         showGlobalMsg('error', 'Reset request failed');
         document.getElementById('forceResetBtn').disabled = false;
       });
+  }
+
+  // ── Obsidian lock tab ────────────────────────────────────────────────────────
+
+  var _obsPollTimer = null;
+
+  function loadObsidian() {
+    Promise.all([
+      fetch('/api/obsidian/status').then(function(r) { return r.json(); }),
+      fetch('/api/obsidian/reservations').then(function(r) { return r.json(); }),
+      fetch('/api/obsidian/audit').then(function(r) { return r.json(); }),
+    ]).then(function(results) {
+      _renderObsStatus(results[0]);
+      _renderObsReservations(results[1].reservations || []);
+      _renderObsAudit(results[2].audit || []);
+      // Auto-poll while this tab is open and the lock is active
+      if (!_obsPollTimer && results[0].state !== 'FREE') {
+        _obsPollTimer = setInterval(loadObsidian, 15000);
+      } else if (_obsPollTimer && results[0].state === 'FREE') {
+        clearInterval(_obsPollTimer); _obsPollTimer = null;
+      }
+    }).catch(function() { showGlobalMsg('error', 'Failed to load Obsidian lock status'); });
+  }
+
+  function _renderObsStatus(s) {
+    var stateEl = document.getElementById('obsState');
+    stateEl.textContent = s.state;
+    stateEl.className = 'val state-' + s.state;
+    document.getElementById('obsHolder').textContent  = s.holder_display || '—';
+    document.getElementById('obsPersona').textContent = s.holder_persona || '—';
+    var mins = s.minutes_left !== null && s.minutes_left !== undefined ? s.minutes_left + ' min' : '—';
+    if (s.evicting && s.evict_deadline) {
+      var secs = Math.max(0, Math.round((new Date(s.evict_deadline + 'Z') - Date.now()) / 1000));
+      mins += ' (evicting in ' + secs + 's)';
+    }
+    document.getElementById('obsMins').textContent = mins;
+    document.getElementById('evictBtn').disabled  = s.state === 'FREE';
+    document.getElementById('unlockBtn').disabled = s.state === 'FREE';
+  }
+
+  function _renderObsReservations(reservations) {
+    if (!reservations.length) {
+      document.getElementById('obsResBody').innerHTML = '<tr><td colspan="5" class="empty">No upcoming reservations</td></tr>';
+      return;
+    }
+    document.getElementById('obsResBody').innerHTML = reservations.map(function(r) {
+      return '<tr>'
+        + '<td>' + esc(r.label) + '</td>'
+        + '<td>' + fmt(r.starts_at) + '</td>'
+        + '<td>' + fmt(r.ends_at)   + '</td>'
+        + '<td>' + fmt(r.created_at)+ '</td>'
+        + '<td><button class="btn-xs danger" onclick="obsDeleteRes(' + r.id + ')">Delete</button></td>'
+        + '</tr>';
+    }).join('');
+  }
+
+  function _renderObsAudit(audit) {
+    if (!audit.length) {
+      document.getElementById('obsAuditBody').innerHTML = '<tr><td colspan="4" class="empty">No events yet</td></tr>';
+      return;
+    }
+    document.getElementById('obsAuditBody').innerHTML = audit.map(function(e) {
+      return '<tr>'
+        + '<td>' + fmt(e.at) + '</td>'
+        + '<td><span class="badge badge-user">' + esc(e.action) + '</span></td>'
+        + '<td>' + esc(e.display || '—') + '</td>'
+        + '<td>' + esc(e.persona || '—') + '</td>'
+        + '</tr>';
+    }).join('');
+  }
+
+  function obsEvict() {
+    var grace = parseInt(document.getElementById('graceSelect').value, 10);
+    if (!confirm('Start eviction with ' + grace + 's grace period?\nThe current holder will see a warning in the portal.')) return;
+    fetch('/api/obsidian/evict', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grace_seconds: grace, message: '' })
+    }).then(function(r) { return r.json(); })
+      .then(function(d) {
+        showGlobalMsg('success', 'Eviction started — grace period: ' + grace + 's');
+        loadObsidian();
+      }).catch(function() { showGlobalMsg('error', 'Eviction request failed'); });
+  }
+
+  function obsUnlock() {
+    if (!confirm('Force-release the Obsidian lock immediately?')) return;
+    fetch('/api/obsidian/unlock', { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function() { showGlobalMsg('success', 'Lock released'); loadObsidian(); })
+      .catch(function() { showGlobalMsg('error', 'Unlock request failed'); });
+  }
+
+  function obsCreateRes() {
+    var label = document.getElementById('resLabel').value.trim();
+    var start = document.getElementById('resStart').value;
+    var end   = document.getElementById('resEnd').value;
+    if (!label || !start || !end) { showGlobalMsg('error', 'Label, start, and end are all required'); return; }
+    // datetime-local gives local time without TZ; send as ISO with UTC assumption
+    fetch('/api/obsidian/reservations', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: label, starts_at: start, ends_at: end })
+    }).then(function(r) {
+      if (!r.ok) return r.json().then(function(d) { throw new Error(d.detail || 'Error'); });
+      return r.json();
+    }).then(function() {
+      showGlobalMsg('success', 'Reservation created');
+      document.getElementById('resLabel').value = '';
+      document.getElementById('resStart').value = '';
+      document.getElementById('resEnd').value   = '';
+      loadObsidian();
+    }).catch(function(e) { showGlobalMsg('error', 'Could not create reservation: ' + e.message); });
+  }
+
+  function obsDeleteRes(id) {
+    if (!confirm('Delete this reservation?')) return;
+    fetch('/api/obsidian/reservations/' + id, { method: 'DELETE' })
+      .then(function(r) { return r.json(); })
+      .then(function() { showGlobalMsg('success', 'Reservation deleted'); loadObsidian(); })
+      .catch(function() { showGlobalMsg('error', 'Delete failed'); });
   }
 
   function doLogout() {

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -205,6 +205,9 @@
   <div class="section-label">Available Tools</div>
   <div class="app-grid" id="app-grid"></div>
 
+  <div class="section-label" style="margin-top:32px">Documentation</div>
+  <div class="app-grid" id="doc-grid"></div>
+
 </main>
 
 <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
@@ -332,9 +335,9 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
     { icon: '📓', name: 'Jupyter Lab',
       desc: 'Interactive notebooks for data science and hands-on Egeria API exploration.',
       url: jupyterUrl, newTab: true, enabled: true },
-    { icon: '📚', name: 'Documentation',
+    { icon: '📚', name: 'Egeria Workspaces Documentation',
       desc: 'User guides, tool reference, Dr. Egeria templates, Coco Pharmaceuticals scenarios, and admin docs.',
-      url: '/docs/', newTab: true, enabled: true },
+      url: '/docs/', newTab: true, enabled: true, isDoc: true },
     { icon: '🗒️', name: 'Obsidian Vault',
       desc: _obsidianUrl
         ? 'Open the Coco Pharmaceuticals workbook vault in your local Obsidian install.'
@@ -350,7 +353,7 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
       desc: 'Java API reference documentation for the Egeria platform and connectors.',
       url: 'https://odpi.github.io/egeria/index.html', newTab: true, enabled: true },
   ];
-  document.getElementById('app-grid').innerHTML = apps.map(function(a) {
+  function _renderTile(a) {
     var action;
     if (!a.enabled) {
       action = '<span class="soon-badge">Coming soon</span>';
@@ -366,7 +369,9 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
       '<div class="app-name">' + esc(a.name) + '</div>' +
       '<div class="app-desc">' + esc(a.desc) + '</div>' +
       action + '</div>';
-  }).join('');
+  }
+  document.getElementById('app-grid').innerHTML = apps.filter(function(a) { return !a.isDoc; }).map(_renderTile).join('');
+  document.getElementById('doc-grid').innerHTML  = apps.filter(function(a) { return  a.isDoc; }).map(_renderTile).join('');
 }
 
 function launch(url, newTab) {

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -174,6 +174,16 @@
 <!-- ── Main ───────────────────────────────────────────────────────────────── -->
 <main class="main">
 
+  <!-- Coco Pharmaceuticals intro — always visible -->
+  <div style="background:var(--card);border:1px solid var(--border);border-radius:10px;padding:18px 24px;margin-bottom:24px;line-height:1.65;">
+    <span style="font-weight:700;color:var(--text)">Coco Pharmaceuticals</span>
+    <span style="color:var(--muted);font-size:0.88rem"> is a fictional mid-sized pharmaceutical company undergoing a data governance transformation.
+    They are deploying Egeria to establish trusted data lineage for regulatory submissions, build a governed business glossary, break down silos between their clinical, manufacturing, and finance operations, and enable confident data-driven decision making across the business.
+    Explore their metadata environment from the perspective of one of their employees — each with a different role, focus, and view of the data landscape.
+    </span>
+    <a href="/docs/viewer.html?src=quickstart/coco/overview.md" target="_blank" rel="noopener" style="color:var(--accent);font-size:0.82rem;text-decoration:none;white-space:nowrap"> Learn more ↗</a>
+  </div>
+
   <!-- Persona section -->
   <div class="persona-section">
 

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -332,9 +332,9 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
     { icon: '📓', name: 'Jupyter Lab',
       desc: 'Interactive notebooks for data science and hands-on Egeria API exploration.',
       url: jupyterUrl, newTab: true, enabled: true },
-    { icon: '🌐', name: 'Coco Web',
-      desc: 'Coco Pharmaceuticals internal web resources and reference material.',
-      url: '/local', newTab: true, enabled: !demoMode },
+    { icon: '📚', name: 'Documentation',
+      desc: 'User guides, tool reference, Dr. Egeria templates, Coco Pharmaceuticals scenarios, and admin docs.',
+      url: '/docs/', newTab: true, enabled: true },
     { icon: '🗒️', name: 'Obsidian Vault',
       desc: _obsidianUrl
         ? 'Open the Coco Pharmaceuticals workbook vault in your local Obsidian install.'

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -432,6 +432,16 @@ function _renderObsTile(s) {
     return;
   }
 
+  // Lock disabled: show direct link with no state management
+  if (s.state === 'DISABLED') {
+    html = '<div class="obs-actions">'
+      + '<button class="btn btn-accent" onclick="window.open(\'http://\'+location.hostname+\':3000\',\'_blank\',\'noopener\')">Open Obsidian →</button>'
+      + _obsGhBtn()
+      + '</div>';
+    el.innerHTML = html;
+    return;
+  }
+
   // Container Obsidian: full lock UI
   if (s.evicting && isMine) {
     var deadline = new Date(s.evict_deadline + 'Z');

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -358,10 +358,10 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
       url: advisorUrl, newTab: true, enabled: !demoMode, unavailable: !demoMode && !advisorRunning },
     { icon: '📖', name: 'Egeria Documentation',
       desc: 'Official Egeria project documentation, guides, and community resources.',
-      url: 'https://egeria.ai', newTab: true, enabled: true },
+      url: 'https://egeria.ai', newTab: true, enabled: true, isDoc: true },
     { icon: '📚', name: 'Egeria JavaDocs',
       desc: 'Java API reference documentation for the Egeria platform and connectors.',
-      url: 'https://odpi.github.io/egeria/index.html', newTab: true, enabled: true },
+      url: 'https://odpi.github.io/egeria/index.html', newTab: true, enabled: true, isDoc: true },
   ];
   function _renderTile(a) {
     var action;

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -103,6 +103,17 @@
     .d-Technical { background: #2a1a3a; color: #ce93d8; }
     .sbadge { font-size: 0.68rem; background: #4caf50; color: #fff; padding: 2px 7px; border-radius: 4px; }
 
+    /* ── Obsidian tile live states ── */
+    .obs-status { font-size: 0.78rem; padding: 4px 8px; border-radius: 4px; margin-bottom: 6px; display: flex; align-items: center; gap: 6px; }
+    .obs-free  { background: #1a3a1a; color: #4caf50; }
+    .obs-mine  { background: #0d2a3a; color: #69f0ae; }
+    .obs-busy  { background: #3a1a1a; color: #ef9a9a; }
+    .obs-stuck { background: #3a2a1a; color: #ffcc80; }
+    .obs-hint  { font-size: 0.74rem; color: var(--muted); margin-top: 4px; }
+    .obs-evict { background: var(--accent); color: #fff; border-radius: 6px; padding: 8px 10px; font-size: 0.8rem; margin-bottom: 8px; }
+    .obs-actions { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+    .obs-actions .btn { width: 100%; display: block; text-align: center; box-sizing: border-box; }
+
     /* ── Footer ── */
     .ftr { border-top: 1px solid var(--border); padding: 16px 28px; display: flex; flex-direction: column; align-items: center; gap: 10px; }
     .ftr-links { display: flex; flex-wrap: wrap; gap: 6px 18px; justify-content: center; font-size: 0.78rem; }
@@ -256,6 +267,8 @@ Promise.all([
     document.getElementById('logout-btn').style.display = 'none';
     document.title = orgName;
     renderAppGrid(me.demo_mode, advisorRunning, platformCfg.advisor_url || '');
+    refreshObsidianTile();
+    setInterval(refreshObsidianTile, 30000);
     fetch('/api/demo/personas').then(function(r){ return r.json(); }).then(function(data) {
       _personas = data;
       var stored = _loadStored();
@@ -275,6 +288,8 @@ Promise.all([
     var stored = _loadStored();
     _currentPersonaId = stored ? stored.id : null;
     renderAppGrid(true, false, '');
+    refreshObsidianTile();
+    setInterval(refreshObsidianTile, 30000);
     if (stored) {
       applyPersonaUI(stored);
     } else {
@@ -321,8 +336,10 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
       desc: 'Coco Pharmaceuticals internal web resources and reference material.',
       url: '/local', newTab: true, enabled: !demoMode },
     { icon: '🗒️', name: 'Obsidian Vault',
-      desc: 'Open the Coco Pharmaceuticals workbook vault in Obsidian (requires local install), or browse on GitHub.',
-      url: _obsidianUrl, newTab: false, enabled: !!(_obsidianUrl || _obsidianGithubUrl), obsidian: true },
+      desc: _obsidianUrl
+        ? 'Open the Coco Pharmaceuticals workbook vault in your local Obsidian install.'
+        : 'Open the workbook vault in the shared browser-based Obsidian, or browse on GitHub.',
+      enabled: true, obsidian: true },
     { icon: '🤖', name: 'Egeria Advisor',
       desc: advisorRunning ? 'AI-powered guidance for your Egeria environment.' : 'AI-powered guidance for your Egeria environment. (Not currently running)',
       url: advisorUrl, newTab: true, enabled: !demoMode, unavailable: !demoMode && !advisorRunning },
@@ -340,14 +357,7 @@ function renderAppGrid(demoMode, advisorRunning, advisorUrl) {
     } else if (a.unavailable) {
       action = '<span class="soon-badge" style="background:var(--hover);color:var(--muted)">Not running</span>';
     } else if (a.obsidian) {
-      var isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
-      var obsBtn = isLocal
-        ? '<button class="btn btn-accent app-action" onclick="launchObsidian()" style="width:100%;display:block" title="Requires Obsidian installed locally">Open in Obsidian</button>'
-        : '<a class="btn btn-accent app-action" href="https://obsidian.md" target="_blank" rel="noopener" style="width:100%;display:block;text-align:center">Download Obsidian ↗</a>';
-      var ghBtn = _obsidianGithubUrl
-        ? '<a class="btn btn-accent app-action" href="' + esc(_obsidianGithubUrl) + '" target="_blank" rel="noopener" style="width:100%;display:block;text-align:center">GitHub ↗</a>'
-        : '';
-      action = '<div style="display:flex;flex-direction:column;gap:6px;margin-top:8px">' + obsBtn + ghBtn + '</div>';
+      action = '<div id="obs-tile-action"><span style="color:var(--muted);font-size:0.8rem">Loading…</span></div>';
     } else {
       action = '<button class="btn btn-accent app-action" onclick="launch(' + JSON.stringify(a.url).replace(/"/g, '&quot;') + ',' + a.newTab + ')">' + (a.newTab ? 'Open ↗' : 'Open') + '</button>';
     }
@@ -364,15 +374,172 @@ function launch(url, newTab) {
   if (newTab) { window.open(url, '_blank', 'noopener'); } else { window.location.href = url; }
 }
 
-function launchObsidian() {
-  var isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
-  if (!isLocal) {
-    if (_obsidianGithubUrl) { window.open(_obsidianGithubUrl, '_blank', 'noopener'); }
+// ── Obsidian lock management ──────────────────────────────────────────────────
+var _obsToken     = sessionStorage.getItem('obs-token') || null;
+var _obsKeepalive = null;   // setInterval handle
+var _obsTileTimer = null;   // setInterval handle for countdown display
+var _obsStatus    = null;   // last fetched status object
+
+function _obsIsLocal() { return !!_obsidianUrl; }
+
+function _obsContainerUrl() {
+  return 'http://' + location.hostname + ':3000';
+}
+
+function _obsLaunchTarget() {
+  if (_obsIsLocal()) {
+    window.location.href = _obsidianUrl.startsWith('obsidian://') ? _obsidianUrl : ('obsidian://open?vault=' + encodeURIComponent(_obsidianUrl));
+  } else {
+    window.open(_obsContainerUrl(), '_blank', 'noopener');
+  }
+}
+
+function refreshObsidianTile() {
+  fetch('/api/obsidian/status').then(function(r) { return r.json(); }).then(function(s) {
+    _obsStatus = s;
+    _renderObsTile(s);
+  }).catch(function() {
+    var el = document.getElementById('obs-tile-action');
+    if (el) el.innerHTML = _obsGhBtn() || '<span class="obs-hint">Status unavailable</span>';
+  });
+}
+
+function _obsGhBtn() {
+  return _obsidianGithubUrl
+    ? '<a class="btn obs-actions" href="' + esc(_obsidianGithubUrl) + '" target="_blank" rel="noopener" style="display:block;text-align:center;margin-top:6px">Browse on GitHub ↗</a>'
+    : '';
+}
+
+function _renderObsTile(s) {
+  var el = document.getElementById('obs-tile-action');
+  if (!el) return;
+  var isMine = _obsToken && s.holder_token === undefined
+    ? false   // server never returns holder_token; we infer from sessionStorage match
+    : !!_obsToken && s.state !== 'FREE';
+
+  // If I have a token but the lock is free, someone else released it - clear my token
+  if (_obsToken && s.state === 'FREE') { _clearObsToken(); isMine = false; }
+
+  var html = '';
+
+  if (_obsIsLocal()) {
+    // Local Obsidian: no lock interaction, just a launch button
+    html = '<div class="obs-actions">'
+      + '<button class="btn btn-accent" onclick="_obsLaunchTarget()">Open in Obsidian</button>'
+      + _obsGhBtn()
+      + '</div>';
+    el.innerHTML = html;
     return;
   }
-  // Use configured vault URL, or fall back to bare obsidian:// which opens the app
-  window.location.href = _obsidianUrl || 'obsidian://';
+
+  // Container Obsidian: full lock UI
+  if (s.evicting && isMine) {
+    var deadline = new Date(s.evict_deadline + 'Z');
+    var secsLeft = Math.max(0, Math.round((deadline - Date.now()) / 1000));
+    html += '<div class="obs-evict">⚠ Admin needs Obsidian in ~' + Math.ceil(secsLeft / 60) + ' min. Please save and close.</div>';
+  }
+
+  if (s.state === 'FREE') {
+    html += '<div class="obs-status obs-free">● Available</div>'
+      + '<div class="obs-actions">'
+      + '<button class="btn btn-accent" onclick="acquireObsidian()">Use Obsidian →</button>'
+      + _obsGhBtn()
+      + '</div>';
+
+  } else if (isMine) {
+    var mins = s.minutes_left !== null ? s.minutes_left : '?';
+    var idleWarn = s.idle_warning ? ' ⚠ idle' : '';
+    html += '<div class="obs-status obs-mine">● Your session · ' + mins + ' min left' + idleWarn + '</div>'
+      + '<div class="obs-actions">'
+      + '<button class="btn btn-accent" onclick="_obsLaunchTarget()">Open Obsidian →</button>'
+      + '<button class="btn" onclick="extendObsidian()">Extend</button>'
+      + '<button class="btn" onclick="releaseObsidian()" style="color:var(--muted)">Release</button>'
+      + '</div>';
+
+  } else if (s.state === 'STUCK') {
+    html += '<div class="obs-status obs-stuck">⚠ Session may be idle</div>'
+      + '<div class="obs-hint">An admin can free it using the admin panel.</div>'
+      + _obsGhBtn();
+
+  } else {
+    // IN_USE or ADMIN_IN_USE by someone else
+    var who = s.holder_display ? ' by ' + esc(s.holder_display) : '';
+    var eta  = s.minutes_left ? ' · ~' + s.minutes_left + ' min remaining' : '';
+    var ev   = (s.evicting && s.evict_deadline)
+      ? ' (eviction in ~' + Math.ceil(Math.max(0, new Date(s.evict_deadline + 'Z') - Date.now()) / 60000) + ' min)'
+      : '';
+    html += '<div class="obs-status obs-busy">● In use' + who + eta + ev + '</div>'
+      + '<div class="obs-hint">Check back later</div>'
+      + _obsGhBtn();
+  }
+
+  el.innerHTML = html;
 }
+
+function acquireObsidian() {
+  var persona   = _currentPersonaId || '';
+  var display   = persona && _personas[persona] ? _personas[persona].display_name : 'User';
+  fetch('/api/obsidian/acquire', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ persona: persona, display_name: display })
+  }).then(function(r) { return r.json(); }).then(function(data) {
+    if (!data.acquired) {
+      alert('Could not acquire Obsidian: ' + (data.reason || 'unavailable'));
+      refreshObsidianTile();
+      return;
+    }
+    _obsToken = data.token;
+    sessionStorage.setItem('obs-token', _obsToken);
+    _startObsKeepalive();
+    refreshObsidianTile();
+    _obsLaunchTarget();
+  }).catch(function(e) { alert('Error: ' + e.message); });
+}
+
+function releaseObsidian() {
+  if (!_obsToken) return;
+  fetch('/api/obsidian/release', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: _obsToken })
+  }).then(function() { _clearObsToken(); refreshObsidianTile(); })
+    .catch(function() { _clearObsToken(); refreshObsidianTile(); });
+}
+
+function extendObsidian() {
+  if (!_obsToken) return;
+  fetch('/api/obsidian/extend', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: _obsToken })
+  }).then(function(r) { return r.json(); }).then(function(d) {
+    if (!d.extended) { alert('Could not extend: ' + (d.reason || 'blocked by reservation')); }
+    refreshObsidianTile();
+  });
+}
+
+function _startObsKeepalive() {
+  _stopObsKeepalive();
+  _obsKeepalive = setInterval(function() {
+    if (!_obsToken) { _stopObsKeepalive(); return; }
+    fetch('/api/obsidian/keepalive', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: _obsToken })
+    }).catch(function() {});
+    refreshObsidianTile();
+  }, 60000);
+}
+
+function _stopObsKeepalive() {
+  if (_obsKeepalive) { clearInterval(_obsKeepalive); _obsKeepalive = null; }
+}
+
+function _clearObsToken() {
+  _obsToken = null;
+  sessionStorage.removeItem('obs-token');
+  _stopObsKeepalive();
+}
+
+// Restore keepalive if we already hold the lock (page reload)
+if (_obsToken) { _startObsKeepalive(); }
 
 // ── Picker ────────────────────────────────────────────────────────────────────
 var _pendingId = null;

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo-portal.html
@@ -177,9 +177,7 @@
   <!-- Coco Pharmaceuticals intro — always visible -->
   <div style="background:var(--card);border:1px solid var(--border);border-radius:10px;padding:18px 24px;margin-bottom:24px;line-height:1.65;">
     <span style="font-weight:700;color:var(--text)">Coco Pharmaceuticals</span>
-    <span style="color:var(--muted);font-size:0.88rem"> is a fictional mid-sized pharmaceutical company undergoing a data governance transformation.
-    They are deploying Egeria to establish trusted data lineage for regulatory submissions, build a governed business glossary, break down silos between their clinical, manufacturing, and finance operations, and enable confident data-driven decision making across the business.
-    Explore their metadata environment from the perspective of one of their employees — each with a different role, focus, and view of the data landscape.
+    <span style="color:var(--muted);font-size:0.88rem"> is a fictional mid-sized pharmaceutical company that is growing and evolving quickly to meet new challenges and opportunities. New products are being developed and evaluated through Clinical Trials, new mergers and acquisitions are evolving the business, and new regulations need to be addressed and accommodated. To support them in their efforts, Coco Pharmaceuticals has been adopting Egeria to help them understand, transform and manage their business data, and support the use of AI, new applications and new analytical techniques. Come and join them on this exciting journey. Start by choosing one of the many personas that are part of Coco Pharmaceuticals to view this environment from their perspective.
     </span>
     <a href="/docs/viewer.html?src=quickstart/coco/overview.md" target="_blank" rel="noopener" style="color:var(--accent);font-size:0.82rem;text-decoration:none;white-space:nowrap"> Learn more ↗</a>
   </div>

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/demo_db.py
@@ -66,15 +66,21 @@ class Config(Base):
 _engine = None
 
 _CONFIG_DEFAULTS = {
-    "reset_interval_hours":  "0",   # 0 = disabled; set via admin page to enable
-    "obsidian_vault_url":    "",    # obsidian:// URI or vault name for the portal tile
-    "obsidian_github_url":   "https://github.com/odpi/egeria-workspaces/tree/main/coco-workbooks",
-    "directive_cap":         "validate",
-    "session_lifetime_user": "7200",
-    "session_lifetime_admin":"604800",
-    "reset_notify_minutes":  "30",
-    "last_reset_at":         "",
-    "reset_state":           "ready",   # 'ready' | 'resetting'
+    "reset_interval_hours":       "0",   # 0 = disabled; set via admin page to enable
+    "obsidian_vault_url":         "",    # obsidian:// URI or vault name for the portal tile
+    "obsidian_github_url":        "https://github.com/odpi/egeria-workspaces/tree/main/coco-workbooks",
+    "directive_cap":              "validate",
+    "session_lifetime_user":      "7200",
+    "session_lifetime_admin":     "604800",
+    "reset_notify_minutes":       "30",
+    "last_reset_at":              "",
+    "reset_state":                "ready",   # 'ready' | 'resetting'
+    # Obsidian lock tuning (all overridable via env vars too)
+    "obsidian_session_minutes":   "20",   # default session length
+    "obsidian_idle_soft_minutes": "5",    # show idle warning after this many minutes
+    "obsidian_idle_hard_minutes": "10",   # mark STUCK after this many minutes
+    "obsidian_buffer_minutes":    "10",   # buffer before a reserved block
+    "obsidian_evict_grace_secs":  "300",  # 5 min grace period for admin eviction
 }
 
 

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
@@ -1,0 +1,604 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright Contributors to the ODPi Egeria project.
+
+Obsidian session lock — manages exclusive access to the containerised Obsidian
+(KasmVNC) instance so multiple demo users don't collide.
+
+States
+------
+  FREE          Nobody holds the lock; anyone can acquire it.
+  IN_USE        A user holds the lock; has an expiry and a keepalive timer.
+  ADMIN_IN_USE  An admin holds the lock (e.g. live demo presentation).
+  STUCK         The holder stopped sending keepalives; eligible for auto-release.
+
+Persona injection
+-----------------
+On acquire, if a valid persona is supplied the handler merges that persona's
+Egeria credentials into the Call Dr. Egeria plugin's data.json inside the
+shared coco-workbooks vault volume.  The plugin's file-watcher detects the
+change and reloads settings automatically.
+
+On release / expiry, data.json is cleared back to defaults so the next user
+doesn't inherit a previous persona.
+
+Auth
+----
+In DEMO_MODE the acquire endpoint requires a verified JWT user; admin endpoints
+require the admin role.  Outside DEMO_MODE all endpoints are open (single-user
+local operation).
+"""
+
+import asyncio
+import json
+import os
+import secrets
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from loguru import logger
+from pydantic import BaseModel
+
+from demo_config import DEMO_MODE
+
+router = APIRouter(prefix="/api/obsidian", tags=["obsidian-lock"])
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+_SESSION_MINUTES     = int(os.environ.get("OBSIDIAN_SESSION_MINUTES",     "20"))
+_IDLE_SOFT_MINUTES   = int(os.environ.get("OBSIDIAN_IDLE_SOFT_MINUTES",    "5"))
+_IDLE_HARD_MINUTES   = int(os.environ.get("OBSIDIAN_IDLE_HARD_MINUTES",   "10"))
+_BUFFER_MINUTES      = int(os.environ.get("OBSIDIAN_BUFFER_MINUTES",      "10"))
+_EVICT_GRACE_SECONDS = int(os.environ.get("OBSIDIAN_EVICT_GRACE_SECONDS", "300"))
+_CLEANUP_INTERVAL    = 60   # background task interval in seconds
+
+_PLUGIN_DATA_JSON = Path(os.environ.get(
+    "OBSIDIAN_PLUGIN_DATA_JSON",
+    "/coco-workbooks/.obsidian/plugins/call-dr-egeria/data.json",
+))
+_LOCK_FILE = Path(os.environ.get(
+    "OBSIDIAN_LOCK_STATE_FILE",
+    "/app/demo-data/obsidian_lock.json",
+))
+_PERSONAS_FILE = Path(__file__).parent / "personas.json"
+
+# ── In-memory state ────────────────────────────────────────────────────────────
+
+_mu = asyncio.Lock()   # protects _state mutations
+
+_state: dict = {
+    "state":          "FREE",
+    "holder_token":   None,   # opaque string; proves ownership for release/keepalive
+    "holder_display": None,   # human-readable name shown in the portal
+    "holder_persona": None,   # egeria user_id (e.g. "erinoverview")
+    "acquired_at":    None,   # ISO datetime
+    "expires_at":     None,   # ISO datetime
+    "last_keepalive": None,   # ISO datetime
+    "evicting":       False,  # True while grace period is running
+    "evict_deadline": None,   # ISO datetime when eviction takes effect
+}
+_audit: list[dict] = []       # capped at 200 entries
+_reservations: list[dict] = []
+_res_seq = 0
+
+_scheduler_task: Optional[asyncio.Task] = None
+
+
+# ── Persistence helpers ────────────────────────────────────────────────────────
+
+def _save_state() -> None:
+    try:
+        _LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _LOCK_FILE.write_text(json.dumps(_state, default=str))
+    except Exception as exc:
+        logger.warning(f"obsidian lock: could not persist state: {exc}")
+
+
+def _load_state() -> None:
+    try:
+        if _LOCK_FILE.exists():
+            data = json.loads(_LOCK_FILE.read_text())
+            _state.update(data)
+            logger.info(f"obsidian lock: restored state '{_state['state']}' from disk")
+    except Exception as exc:
+        logger.warning(f"obsidian lock: could not load saved state: {exc}")
+
+
+def _audit_entry(action: str, display: Optional[str] = None) -> None:
+    global _audit
+    _audit.append({
+        "action":  action,
+        "display": display or _state.get("holder_display"),
+        "persona": _state.get("holder_persona"),
+        "at":      datetime.utcnow().isoformat(),
+    })
+    if len(_audit) > 200:
+        _audit = _audit[-200:]
+
+
+# ── Persona injection ──────────────────────────────────────────────────────────
+
+def _load_personas() -> dict:
+    try:
+        return json.loads(_PERSONAS_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def _inject_persona(persona_id: str) -> None:
+    """Write persona credentials into the plugin's data.json."""
+    if not _PLUGIN_DATA_JSON.exists():
+        logger.warning(f"obsidian lock: plugin data.json not found at {_PLUGIN_DATA_JSON}")
+        return
+    personas = _load_personas()
+    if persona_id not in personas:
+        logger.warning(f"obsidian lock: unknown persona '{persona_id}' — skipping inject")
+        return
+    try:
+        existing = json.loads(_PLUGIN_DATA_JSON.read_text())
+    except Exception:
+        existing = {}
+    existing.update({
+        "userId":   persona_id,
+        "userPass": personas[persona_id].get("password", "secret"),
+        "mcpToken": os.environ.get("MCP_ACCESS_TOKEN", "egeria-secret-mcp-token"),
+    })
+    _PLUGIN_DATA_JSON.write_text(json.dumps(existing, indent=2))
+    logger.info(f"obsidian lock: injected persona '{persona_id}' into data.json")
+
+
+def _clear_persona() -> None:
+    """Reset persona-specific fields in the plugin's data.json."""
+    if not _PLUGIN_DATA_JSON.exists():
+        return
+    try:
+        existing = json.loads(_PLUGIN_DATA_JSON.read_text())
+    except Exception:
+        existing = {}
+    existing.update({"userId": "", "userPass": "", "mcpToken": ""})
+    _PLUGIN_DATA_JSON.write_text(json.dumps(existing, indent=2))
+    logger.info("obsidian lock: cleared persona from data.json")
+
+
+# ── State transitions ──────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def _expiry_iso(minutes: int) -> str:
+    return (datetime.utcnow() + timedelta(minutes=minutes)).isoformat()
+
+
+def _parse_iso(s: Optional[str]) -> Optional[datetime]:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _next_reservation_start() -> Optional[datetime]:
+    now = datetime.utcnow()
+    upcoming = [
+        r for r in _reservations
+        if _parse_iso(r["starts_at"]) and _parse_iso(r["starts_at"]) > now
+    ]
+    if not upcoming:
+        return None
+    return min(_parse_iso(r["starts_at"]) for r in upcoming)
+
+
+def _buffer_clash() -> bool:
+    """True if acquiring now would intrude on a reserved block's buffer window."""
+    nrs = _next_reservation_start()
+    if not nrs:
+        return False
+    buffer_end = datetime.utcnow() + timedelta(minutes=_SESSION_MINUTES + _BUFFER_MINUTES)
+    return buffer_end > nrs
+
+
+def _minutes_until_free() -> Optional[int]:
+    exp = _parse_iso(_state.get("expires_at"))
+    if not exp:
+        return None
+    delta = exp - datetime.utcnow()
+    return max(0, int(delta.total_seconds() / 60))
+
+
+def _do_release(reason: str = "released") -> None:
+    _audit_entry(reason)
+    if _state.get("holder_persona"):
+        _clear_persona()
+    _state.update({
+        "state":          "FREE",
+        "holder_token":   None,
+        "holder_display": None,
+        "holder_persona": None,
+        "acquired_at":    None,
+        "expires_at":     None,
+        "last_keepalive": None,
+        "evicting":       False,
+        "evict_deadline": None,
+    })
+    _save_state()
+
+
+# ── Background cleanup ─────────────────────────────────────────────────────────
+
+async def start_scheduler() -> None:
+    global _scheduler_task
+    _load_state()
+    _scheduler_task = asyncio.create_task(_cleanup_loop())
+    logger.info("obsidian lock scheduler started")
+
+
+async def stop_scheduler() -> None:
+    global _scheduler_task
+    if _scheduler_task and not _scheduler_task.done():
+        _scheduler_task.cancel()
+        try:
+            await _scheduler_task
+        except asyncio.CancelledError:
+            pass
+    _scheduler_task = None
+
+
+async def _cleanup_loop() -> None:
+    while True:
+        await asyncio.sleep(_CLEANUP_INTERVAL)
+        try:
+            await _run_cleanup()
+        except Exception as exc:
+            logger.error(f"obsidian lock cleanup error: {exc}")
+
+
+async def _run_cleanup() -> None:
+    async with _mu:
+        now = datetime.utcnow()
+        state = _state.get("state")
+
+        if state in ("IN_USE", "ADMIN_IN_USE"):
+            # Hard expiry
+            exp = _parse_iso(_state.get("expires_at"))
+            if exp and now > exp:
+                logger.info("obsidian lock: session expired — releasing")
+                _do_release("expired")
+                return
+
+            # Eviction deadline passed
+            if _state.get("evicting"):
+                deadline = _parse_iso(_state.get("evict_deadline"))
+                if deadline and now > deadline:
+                    logger.info("obsidian lock: eviction grace period over — releasing")
+                    _do_release("evicted")
+                    return
+
+            # Idle hard timeout → STUCK
+            ka = _parse_iso(_state.get("last_keepalive"))
+            if ka:
+                idle_seconds = (now - ka).total_seconds()
+                if idle_seconds > _IDLE_HARD_MINUTES * 60:
+                    logger.info(f"obsidian lock: idle {idle_seconds:.0f}s — marking STUCK")
+                    _state["state"] = "STUCK"
+                    _save_state()
+
+        elif state == "STUCK":
+            # Auto-release stuck sessions after double the hard idle timeout
+            ka = _parse_iso(_state.get("last_keepalive"))
+            if ka:
+                idle_seconds = (now - ka).total_seconds()
+                if idle_seconds > _IDLE_HARD_MINUTES * 2 * 60:
+                    logger.info("obsidian lock: stuck session auto-released")
+                    _do_release("auto_released_stuck")
+
+
+# ── Auth helpers ───────────────────────────────────────────────────────────────
+
+def _opt_user(request: Request):
+    """Returns the current user if in demo mode + authenticated, else None."""
+    if not DEMO_MODE:
+        return None
+    try:
+        from demo_auth_handler import get_current_user
+        from demo_db import get_db
+        db = next(get_db())
+        return get_current_user(request, db)
+    except Exception:
+        return None
+
+
+def _require_admin_or_local(request: Request):
+    if not DEMO_MODE:
+        return None   # local mode: admin operations always allowed
+    from demo_auth_handler import require_admin
+    from demo_db import get_db
+    db = next(get_db())
+    return require_admin(request, db)
+
+
+def _require_verified_or_local(request: Request):
+    if not DEMO_MODE:
+        return None
+    from demo_auth_handler import require_verified_user
+    from demo_db import get_db
+    db = next(get_db())
+    return require_verified_user(request, db)
+
+
+# ── Request / response models ──────────────────────────────────────────────────
+
+class AcquireRequest(BaseModel):
+    persona:      str = ""   # egeria user_id from personas.json
+    display_name: str = ""   # human-readable name for the portal UI
+
+
+class ReleaseRequest(BaseModel):
+    token: str
+
+
+class KeepaliveRequest(BaseModel):
+    token: str
+
+
+class ExtendRequest(BaseModel):
+    token: str
+
+
+class ReservationRequest(BaseModel):
+    label:     str
+    starts_at: str   # ISO datetime
+    ends_at:   str   # ISO datetime
+
+
+class EvictRequest(BaseModel):
+    grace_seconds: int = _EVICT_GRACE_SECONDS
+    message: str = ""
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────────
+
+@router.get("/status")
+async def obsidian_status(request: Request):
+    """Public — current lock state, time remaining, next reservation."""
+    async with _mu:
+        now = datetime.utcnow()
+        state = _state["state"]
+        minutes_left = _minutes_until_free()
+
+        # Soft-idle warning flag for the portal (no state change here)
+        idle_warning = False
+        ka = _parse_iso(_state.get("last_keepalive"))
+        if ka and state in ("IN_USE", "ADMIN_IN_USE"):
+            idle_warning = (now - ka).total_seconds() > _IDLE_SOFT_MINUTES * 60
+
+        # Next reservation
+        nrs = _next_reservation_start()
+
+        return {
+            "state":           state,
+            "holder_display":  _state.get("holder_display"),
+            "holder_persona":  _state.get("holder_persona"),
+            "acquired_at":     _state.get("acquired_at"),
+            "expires_at":      _state.get("expires_at"),
+            "minutes_left":    minutes_left,
+            "idle_warning":    idle_warning,
+            "evicting":        _state.get("evicting", False),
+            "evict_deadline":  _state.get("evict_deadline"),
+            "next_reservation_at": nrs.isoformat() if nrs else None,
+            "buffer_minutes":  _BUFFER_MINUTES,
+            "session_minutes": _SESSION_MINUTES,
+        }
+
+
+@router.post("/acquire")
+async def acquire(request: Request, body: AcquireRequest):
+    """Acquire the Obsidian lock. Returns a session token the caller must use for keepalive/release."""
+    user = _require_verified_or_local(request)
+
+    async with _mu:
+        state = _state["state"]
+        if state not in ("FREE",):
+            minutes = _minutes_until_free()
+            nrs = _next_reservation_start()
+            return {
+                "acquired": False,
+                "reason": f"Obsidian is {state.lower().replace('_', ' ')}",
+                "minutes_left": minutes,
+                "next_reservation_at": nrs.isoformat() if nrs else None,
+            }
+
+        if _buffer_clash():
+            nrs = _next_reservation_start()
+            return {
+                "acquired": False,
+                "reason": "Too close to a reserved block — session would run into reserved time",
+                "next_reservation_at": nrs.isoformat() if nrs else None,
+            }
+
+        # Determine identity
+        if user:
+            token = user.id
+            display = body.display_name or getattr(user, "display_name", user.email)
+            is_admin = getattr(user, "role", "") == "admin"
+        else:
+            token = secrets.token_urlsafe(24)
+            display = body.display_name or "Local user"
+            is_admin = False
+
+        persona = body.persona or ""
+
+        _state.update({
+            "state":          "ADMIN_IN_USE" if is_admin else "IN_USE",
+            "holder_token":   token,
+            "holder_display": display,
+            "holder_persona": persona or None,
+            "acquired_at":    _now_iso(),
+            "expires_at":     _expiry_iso(_SESSION_MINUTES),
+            "last_keepalive": _now_iso(),
+            "evicting":       False,
+            "evict_deadline": None,
+        })
+        _audit_entry("acquired")
+        _save_state()
+
+        if persona:
+            _inject_persona(persona)
+
+        logger.info(f"obsidian lock acquired by '{display}' (persona={persona or 'none'})")
+
+        return {
+            "acquired":   True,
+            "token":      token,
+            "expires_at": _state["expires_at"],
+            "session_minutes": _SESSION_MINUTES,
+        }
+
+
+@router.post("/release")
+async def release(request: Request, body: ReleaseRequest):
+    """Release the lock. Must present the token returned at acquire time."""
+    async with _mu:
+        if _state["state"] == "FREE":
+            return {"released": True, "note": "already free"}
+        if _state.get("holder_token") != body.token:
+            raise HTTPException(status_code=403, detail="Not the lock holder")
+        _do_release("released")
+        logger.info("obsidian lock released by holder")
+        return {"released": True}
+
+
+@router.post("/keepalive")
+async def keepalive(request: Request, body: KeepaliveRequest):
+    """Heartbeat — resets the idle clock. Portal should call this every 60 s."""
+    async with _mu:
+        if _state["state"] == "FREE":
+            raise HTTPException(status_code=409, detail="No active session")
+        if _state.get("holder_token") != body.token:
+            raise HTTPException(status_code=403, detail="Not the lock holder")
+        _state["last_keepalive"] = _now_iso()
+        # Recover from STUCK if the holder comes back
+        if _state["state"] == "STUCK":
+            _state["state"] = "IN_USE"
+        _save_state()
+        return {"ok": True, "expires_at": _state.get("expires_at")}
+
+
+@router.post("/extend")
+async def extend(request: Request, body: ExtendRequest):
+    """Extend the session by _SESSION_MINUTES, if no reservation is blocking."""
+    async with _mu:
+        if _state["state"] == "FREE":
+            raise HTTPException(status_code=409, detail="No active session")
+        if _state.get("holder_token") != body.token:
+            raise HTTPException(status_code=403, detail="Not the lock holder")
+        if _buffer_clash():
+            nrs = _next_reservation_start()
+            return {
+                "extended": False,
+                "reason": "Too close to a reserved block",
+                "next_reservation_at": nrs.isoformat() if nrs else None,
+            }
+        _state["expires_at"] = _expiry_iso(_SESSION_MINUTES)
+        _save_state()
+        return {"extended": True, "expires_at": _state["expires_at"]}
+
+
+# ── Reservation endpoints ──────────────────────────────────────────────────────
+
+@router.get("/reservations")
+async def list_reservations(request: Request):
+    """Public — list upcoming reservations."""
+    now = datetime.utcnow()
+    upcoming = [r for r in _reservations if _parse_iso(r["ends_at"]) and _parse_iso(r["ends_at"]) > now]
+    return {"reservations": sorted(upcoming, key=lambda r: r["starts_at"])}
+
+
+@router.post("/reservations")
+async def create_reservation(request: Request, body: ReservationRequest):
+    """Admin — reserve a future block."""
+    global _res_seq
+    _require_admin_or_local(request)
+
+    starts = _parse_iso(body.starts_at)
+    ends   = _parse_iso(body.ends_at)
+    if not starts or not ends or ends <= starts:
+        raise HTTPException(status_code=400, detail="Invalid starts_at / ends_at")
+
+    # Conflict check
+    for r in _reservations:
+        rs = _parse_iso(r["starts_at"])
+        re = _parse_iso(r["ends_at"])
+        if rs and re and not (ends <= rs or starts >= re):
+            raise HTTPException(status_code=409, detail=f"Conflicts with reservation {r['id']}: {r['label']}")
+
+    _res_seq += 1
+    entry = {
+        "id":         _res_seq,
+        "label":      body.label,
+        "starts_at":  body.starts_at,
+        "ends_at":    body.ends_at,
+        "created_at": _now_iso(),
+    }
+    _reservations.append(entry)
+    logger.info(f"obsidian reservation created: {body.label} ({body.starts_at} → {body.ends_at})")
+    return entry
+
+
+@router.delete("/reservations/{res_id}")
+async def delete_reservation(request: Request, res_id: int):
+    """Admin — cancel a reservation."""
+    global _reservations
+    _require_admin_or_local(request)
+    before = len(_reservations)
+    _reservations = [r for r in _reservations if r["id"] != res_id]
+    if len(_reservations) == before:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    return {"deleted": True}
+
+
+# ── Admin override endpoints ───────────────────────────────────────────────────
+
+@router.post("/evict")
+async def evict(request: Request, body: EvictRequest):
+    """Admin — begin grace-period eviction of the current holder."""
+    _require_admin_or_local(request)
+    async with _mu:
+        if _state["state"] == "FREE":
+            raise HTTPException(status_code=409, detail="Nothing to evict — lock is free")
+        if _state.get("evicting"):
+            return {"evicting": True, "evict_deadline": _state.get("evict_deadline"), "note": "already evicting"}
+        grace = max(10, body.grace_seconds)
+        deadline = (datetime.utcnow() + timedelta(seconds=grace)).isoformat()
+        _state["evicting"]      = True
+        _state["evict_deadline"] = deadline
+        _save_state()
+        logger.info(f"obsidian lock eviction started — grace {grace}s, deadline {deadline}")
+        return {
+            "evicting":       True,
+            "evict_deadline": deadline,
+            "grace_seconds":  grace,
+            "message":        body.message or f"An admin needs Obsidian in {grace // 60} min. Please save and close.",
+        }
+
+
+@router.post("/unlock")
+async def force_unlock(request: Request):
+    """Admin — force-release a stuck or frozen lock."""
+    _require_admin_or_local(request)
+    async with _mu:
+        if _state["state"] == "FREE":
+            return {"unlocked": False, "note": "already free"}
+        _do_release("force_unlocked")
+        logger.info("obsidian lock force-unlocked by admin")
+        return {"unlocked": True}
+
+
+@router.get("/audit")
+async def get_audit(request: Request):
+    """Admin — recent lock audit log."""
+    _require_admin_or_local(request)
+    return {"audit": list(reversed(_audit[-50:]))}

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
@@ -110,16 +110,22 @@ def _load_state() -> None:
 
 def _startup_cleanup() -> None:
     """Release sessions left over from a previous server run that are now stale."""
-    now = datetime.utcnow()
     if _state.get("state") not in ("IN_USE", "ADMIN_IN_USE", "STUCK"):
         return
-    # Expired by the clock
+
+    # Local mode: single user, stale locks from previous runs are always garbage
+    if not DEMO_MODE:
+        logger.info("obsidian lock: local mode — clearing lock left from previous run")
+        _do_release("startup_cleanup")
+        return
+
+    # Demo mode: release if expired or keepalive is stale
+    now = datetime.utcnow()
     exp = _parse_iso(_state.get("expires_at"))
     if exp and now > exp:
         logger.info("obsidian lock: releasing expired session from previous run")
         _do_release("startup_cleanup")
         return
-    # Keepalive too stale — server was clearly restarted without a clean release
     ka = _parse_iso(_state.get("last_keepalive"))
     if ka and (now - ka).total_seconds() > _IDLE_HARD_MINUTES * 2 * 60:
         logger.info("obsidian lock: releasing stale session from previous run (keepalive dead)")

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
@@ -108,6 +108,24 @@ def _load_state() -> None:
         logger.warning(f"obsidian lock: could not load saved state: {exc}")
 
 
+def _startup_cleanup() -> None:
+    """Release sessions left over from a previous server run that are now stale."""
+    now = datetime.utcnow()
+    if _state.get("state") not in ("IN_USE", "ADMIN_IN_USE", "STUCK"):
+        return
+    # Expired by the clock
+    exp = _parse_iso(_state.get("expires_at"))
+    if exp and now > exp:
+        logger.info("obsidian lock: releasing expired session from previous run")
+        _do_release("startup_cleanup")
+        return
+    # Keepalive too stale — server was clearly restarted without a clean release
+    ka = _parse_iso(_state.get("last_keepalive"))
+    if ka and (now - ka).total_seconds() > _IDLE_HARD_MINUTES * 2 * 60:
+        logger.info("obsidian lock: releasing stale session from previous run (keepalive dead)")
+        _do_release("startup_cleanup")
+
+
 def _audit_entry(action: str, display: Optional[str] = None) -> None:
     global _audit
     _audit.append({
@@ -234,6 +252,7 @@ def _do_release(reason: str = "released") -> None:
 async def start_scheduler() -> None:
     global _scheduler_task
     _load_state()
+    _startup_cleanup()
     _scheduler_task = asyncio.create_task(_cleanup_loop())
     logger.info("obsidian lock scheduler started")
 

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/obsidian_lock_handler.py
@@ -47,6 +47,8 @@ router = APIRouter(prefix="/api/obsidian", tags=["obsidian-lock"])
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 
+LOCK_ENABLED         = os.environ.get("OBSIDIAN_LOCK_ENABLED", "true").lower() not in ("false", "0", "no")
+
 _SESSION_MINUTES     = int(os.environ.get("OBSIDIAN_SESSION_MINUTES",     "20"))
 _IDLE_SOFT_MINUTES   = int(os.environ.get("OBSIDIAN_IDLE_SOFT_MINUTES",    "5"))
 _IDLE_HARD_MINUTES   = int(os.environ.get("OBSIDIAN_IDLE_HARD_MINUTES",   "10"))
@@ -298,6 +300,11 @@ async def _run_cleanup() -> None:
 
 # ── Auth helpers ───────────────────────────────────────────────────────────────
 
+def _require_lock_enabled():
+    if not LOCK_ENABLED:
+        raise HTTPException(status_code=503, detail="Obsidian lock is disabled on this instance (OBSIDIAN_LOCK_ENABLED=false)")
+
+
 def _opt_user(request: Request):
     """Returns the current user if in demo mode + authenticated, else None."""
     if not DEMO_MODE:
@@ -364,6 +371,8 @@ class EvictRequest(BaseModel):
 @router.get("/status")
 async def obsidian_status(request: Request):
     """Public — current lock state, time remaining, next reservation."""
+    if not LOCK_ENABLED:
+        return {"state": "DISABLED"}
     async with _mu:
         now = datetime.utcnow()
         state = _state["state"]
@@ -395,7 +404,7 @@ async def obsidian_status(request: Request):
 
 
 @router.post("/acquire")
-async def acquire(request: Request, body: AcquireRequest):
+async def acquire(request: Request, body: AcquireRequest, _: None = Depends(_require_lock_enabled)):
     """Acquire the Obsidian lock. Returns a session token the caller must use for keepalive/release."""
     user = _require_verified_or_local(request)
 
@@ -459,7 +468,7 @@ async def acquire(request: Request, body: AcquireRequest):
 
 
 @router.post("/release")
-async def release(request: Request, body: ReleaseRequest):
+async def release(request: Request, body: ReleaseRequest, _: None = Depends(_require_lock_enabled)):
     """Release the lock. Must present the token returned at acquire time."""
     async with _mu:
         if _state["state"] == "FREE":
@@ -472,7 +481,7 @@ async def release(request: Request, body: ReleaseRequest):
 
 
 @router.post("/keepalive")
-async def keepalive(request: Request, body: KeepaliveRequest):
+async def keepalive(request: Request, body: KeepaliveRequest, _: None = Depends(_require_lock_enabled)):
     """Heartbeat — resets the idle clock. Portal should call this every 60 s."""
     async with _mu:
         if _state["state"] == "FREE":
@@ -488,7 +497,7 @@ async def keepalive(request: Request, body: KeepaliveRequest):
 
 
 @router.post("/extend")
-async def extend(request: Request, body: ExtendRequest):
+async def extend(request: Request, body: ExtendRequest, _: None = Depends(_require_lock_enabled)):
     """Extend the session by _SESSION_MINUTES, if no reservation is blocking."""
     async with _mu:
         if _state["state"] == "FREE":
@@ -518,7 +527,7 @@ async def list_reservations(request: Request):
 
 
 @router.post("/reservations")
-async def create_reservation(request: Request, body: ReservationRequest):
+async def create_reservation(request: Request, body: ReservationRequest, _: None = Depends(_require_lock_enabled)):
     """Admin — reserve a future block."""
     global _res_seq
     _require_admin_or_local(request)
@@ -549,7 +558,7 @@ async def create_reservation(request: Request, body: ReservationRequest):
 
 
 @router.delete("/reservations/{res_id}")
-async def delete_reservation(request: Request, res_id: int):
+async def delete_reservation(request: Request, res_id: int, _: None = Depends(_require_lock_enabled)):
     """Admin — cancel a reservation."""
     global _reservations
     _require_admin_or_local(request)
@@ -563,7 +572,7 @@ async def delete_reservation(request: Request, res_id: int):
 # ── Admin override endpoints ───────────────────────────────────────────────────
 
 @router.post("/evict")
-async def evict(request: Request, body: EvictRequest):
+async def evict(request: Request, body: EvictRequest, _: None = Depends(_require_lock_enabled)):
     """Admin — begin grace-period eviction of the current holder."""
     _require_admin_or_local(request)
     async with _mu:
@@ -586,7 +595,7 @@ async def evict(request: Request, body: EvictRequest):
 
 
 @router.post("/unlock")
-async def force_unlock(request: Request):
+async def force_unlock(request: Request, _: None = Depends(_require_lock_enabled)):
     """Admin — force-release a stuck or frozen lock."""
     _require_admin_or_local(request)
     async with _mu:
@@ -598,7 +607,7 @@ async def force_unlock(request: Request):
 
 
 @router.get("/audit")
-async def get_audit(request: Request):
+async def get_audit(request: Request, _: None = Depends(_require_lock_enabled)):
     """Admin — recent lock audit log."""
     _require_admin_or_local(request)
     return {"audit": list(reversed(_audit[-50:]))}

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/pyegeria_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/pyegeria_handler.py
@@ -69,6 +69,8 @@ from rate_limiter import limiter
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
+    from obsidian_lock_handler import start_scheduler as obs_start, stop_scheduler as obs_stop
+    await obs_start()
     if DEMO_MODE:
         from demo_reset_handler import start_scheduler, stop_scheduler
         await start_scheduler()
@@ -76,6 +78,7 @@ async def _lifespan(app: FastAPI):
     if DEMO_MODE:
         from demo_reset_handler import stop_scheduler
         await stop_scheduler()
+    await obs_stop()
 
 
 app = FastAPI(
@@ -209,6 +212,8 @@ from demo_feedback_handler import router as demo_feedback_router
 app.include_router(demo_feedback_router)
 from egeria_feedback_handler import router as egeria_feedback_router
 app.include_router(egeria_feedback_router)
+from obsidian_lock_handler import router as obsidian_lock_router
+app.include_router(obsidian_lock_router)
 
 # ── Demo mode ──────────────────────────────────────────────────────────────────
 

--- a/compose-configs/egeria-quickstart/egeria-quickstart.yaml
+++ b/compose-configs/egeria-quickstart/egeria-quickstart.yaml
@@ -178,6 +178,7 @@ services:
       - ./markdown-header.html:/usr/local/apache2/conf/markdown-header.html
       - ../../runtime-volumes/quickstart-apache-web/ErrorLogs:/usr/local/apache2/logs
       - ../../workspaces/Dr-Egeria-Samples:/usr/local/apache2/htdocs/Dr-Egeria-Samples
+      - ../../portal-docs:/usr/local/apache2/htdocs/docs
       # SSL cert volume — disabled by default. See demo-mode.md § SSL / HTTPS.
       # - ./sites-available/fastapi-ssl.conf:/usr/local/apache2/conf/extra/fastapi-ssl.conf
       # - /path/to/your/certs:/etc/ssl/egeria:ro

--- a/compose-configs/egeria-quickstart/egeria-quickstart.yaml
+++ b/compose-configs/egeria-quickstart/egeria-quickstart.yaml
@@ -208,10 +208,9 @@ services:
       - egeria_network
     restart: unless-stopped
 #    mem_limit: 2g # Optional: limit memory usage
-
-    environment:
-      - CUSTOM_USER=youruser
-      - PASSWORD=yourpassword
+#   To add KasmVNC authentication, add to environment above:
+#     - CUSTOM_USER=youruser
+#     - PASSWORD=yourpassword
     logging:
       driver: "json-file"
       options:

--- a/compose-configs/egeria-quickstart/httpd.conf
+++ b/compose-configs/egeria-quickstart/httpd.conf
@@ -133,6 +133,7 @@ Alias /markdown-viewer "/usr/local/apache2/conf/markdown-header.html"
 ScriptAlias /api/dr.egeria/ "/usr/local/apache2/htdocs/cgi-bin/"
 
 # Directory Alias for additional content directories - order matters, more specific first
+Alias /docs          "/usr/local/apache2/htdocs/docs"
 Alias /dr-egeria-outbox "/usr/local/apache2/htdocs/dr-egeria-outbox"
 Alias /dr-egeria-inbox "/usr/local/apache2/htdocs/dr-egeria-inbox"
 
@@ -151,6 +152,14 @@ Alias /dr-egeria-inbox "/usr/local/apache2/htdocs/dr-egeria-inbox"
     Options +Includes +FollowSymLinks
     AllowOverride None
     Require all granted
+</Directory>
+
+# Portal documentation (client-side markdown rendering)
+<Directory "/usr/local/apache2/htdocs/docs">
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+    DirectoryIndex index.html
 </Directory>
 
 # Set access permissions for the dr-egeria-outbox directory

--- a/compose-configs/egeria-quickstart/httpd.conf
+++ b/compose-configs/egeria-quickstart/httpd.conf
@@ -133,7 +133,6 @@ Alias /markdown-viewer "/usr/local/apache2/conf/markdown-header.html"
 ScriptAlias /api/dr.egeria/ "/usr/local/apache2/htdocs/cgi-bin/"
 
 # Directory Alias for additional content directories - order matters, more specific first
-Alias /docs          "/usr/local/apache2/htdocs/docs"
 Alias /dr-egeria-outbox "/usr/local/apache2/htdocs/dr-egeria-outbox"
 Alias /dr-egeria-inbox "/usr/local/apache2/htdocs/dr-egeria-inbox"
 
@@ -152,14 +151,6 @@ Alias /dr-egeria-inbox "/usr/local/apache2/htdocs/dr-egeria-inbox"
     Options +Includes +FollowSymLinks
     AllowOverride None
     Require all granted
-</Directory>
-
-# Portal documentation (client-side markdown rendering)
-<Directory "/usr/local/apache2/htdocs/docs">
-    Options FollowSymLinks
-    AllowOverride None
-    Require all granted
-    DirectoryIndex index.html
 </Directory>
 
 # Set access permissions for the dr-egeria-outbox directory

--- a/compose-configs/egeria-quickstart/sites-available/fastapi-proxy.conf
+++ b/compose-configs/egeria-quickstart/sites-available/fastapi-proxy.conf
@@ -24,6 +24,15 @@
         Require all granted
     </Directory>
 
+    # Portal documentation hub (client-side markdown rendering)
+    Alias /docs /usr/local/apache2/htdocs/docs
+    <Directory "/usr/local/apache2/htdocs/docs">
+        Options FollowSymLinks
+        AllowOverride None
+        Require all granted
+        DirectoryIndex index.html
+    </Directory>
+
     # Demo portal hub
     <Location "/portal">
         ProxyPreserveHost On

--- a/portal-docs/freshstart/getting-started.md
+++ b/portal-docs/freshstart/getting-started.md
@@ -1,0 +1,71 @@
+# Getting Started with Freshstart
+
+---
+
+## 1. Configure your environment
+
+```bash
+cd compose-configs/egeria-freshstart
+cp .env.example .env
+```
+
+Edit `.env`:
+```
+HOST_FQDN=localhost
+KAFKA_BOOTSTRAP_SERVERS=localhost:9194
+```
+
+---
+
+## 2. Start the stack
+
+```bash
+docker compose -f egeria-freshstart.yaml up -d
+```
+
+Egeria takes 2–3 minutes to initialise. Check readiness:
+```bash
+curl -k https://localhost:9443/open-metadata/platform-services/users/garygeeke/server-platform/origin
+```
+
+---
+
+## 3. Open the portal
+
+**http://localhost:8086**
+
+---
+
+## 4. Connect with pyegeria
+
+```python
+from pyegeria import EgeriaTech
+
+egeria = EgeriaTech(
+    view_server="fs-view-server",
+    platform_url="https://localhost:9443",
+    user_id="garygeeke",
+    user_pwd="secret"
+)
+
+# Check the platform is running
+print(egeria.get_platform_origin())
+```
+
+---
+
+## 5. Connect Dr. Egeria
+
+In Obsidian (or via the MCP plugin), set:
+- **MCP Server URL:** `http://localhost:8000/sse`
+- **Egeria Platform URL:** `https://host.docker.internal:9443`
+- **View Server:** `fs-view-server`
+- **User ID / Password:** `garygeeke` / `secret`
+
+---
+
+## Next steps
+
+- Explore the [Type System](http://localhost:8086/egeria-explorer) to understand the open metadata model
+- Create your first [glossary term](../tools/dr-egeria/templates-basic.md) using Dr. Egeria
+- Browse the [Jupyter workbooks](../tools/jupyter.md) for API examples

--- a/portal-docs/freshstart/overview.md
+++ b/portal-docs/freshstart/overview.md
@@ -1,0 +1,46 @@
+# Freshstart Environment
+
+Freshstart is a clean-slate Egeria environment for development and experimentation. Unlike Quickstart, it starts with no pre-loaded metadata — you define your own types, assets, and governance structures from scratch.
+
+---
+
+## What's included
+
+| Service | Port | Purpose |
+|---|---|---|
+| Egeria platform | 9443 | Metadata store and API server |
+| pyegeria-web | 8000 | FastAPI backend — Dr. Egeria MCP |
+| Apache web server | 8086 | Portal and documentation |
+| Jupyter Lab | 7888 | Interactive Python notebooks |
+| Shared PostgreSQL | 5442 | Metadata database |
+| Kafka | 9194 | Event bus |
+
+---
+
+## When to use Freshstart vs Quickstart
+
+| Use case | Recommended environment |
+|---|---|
+| Learning Egeria with realistic data | Quickstart |
+| Building a custom metadata model | Freshstart |
+| Developing Egeria connectors | Freshstart |
+| Running demos for external audiences | Quickstart (demo mode) |
+| API exploration with pyegeria | Either |
+
+---
+
+## Starting the stack
+
+```bash
+cd compose-configs/egeria-freshstart
+docker compose -f egeria-freshstart.yaml up -d
+```
+
+Open the portal at **http://localhost:8086**.
+
+---
+
+## Further reading
+
+- [Getting started with Freshstart](getting-started.md)
+- [Egeria project documentation](https://egeria-project.org)

--- a/portal-docs/index.html
+++ b/portal-docs/index.html
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Egeria Workspaces — Documentation</title>
+  <style>
+    :root {
+      --bg: #1a1a2e; --card: #16213e; --border: #0f3460;
+      --accent: #e94560; --text: #e0e0e0; --muted: #888;
+      --green: #4caf50; --blue: #64b5f6; --purple: #ce93d8;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; min-height: 100vh; }
+    .hdr { background: var(--card); border-bottom: 1px solid var(--border); padding: 12px 28px; display: flex; align-items: center; gap: 14px; }
+    .hdr img { height: 26px; }
+    .hdr-title { font-size: 1rem; font-weight: 700; }
+    .hdr-right { margin-left: auto; }
+    .hdr-right a { color: var(--muted); font-size: 0.82rem; text-decoration: none; }
+    .hdr-right a:hover { color: var(--accent); }
+    .hero { background: linear-gradient(135deg, #16213e 0%, #0f3460 100%); border-bottom: 1px solid var(--border); padding: 40px 28px 36px; text-align: center; }
+    .hero h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 10px; }
+    .hero p  { color: var(--muted); font-size: 0.95rem; max-width: 640px; margin: 0 auto; line-height: 1.65; }
+    .main { max-width: 1060px; margin: 0 auto; padding: 36px 28px; }
+    .section-label { font-size: 0.72rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 14px; margin-top: 36px; }
+    .section-label:first-child { margin-top: 0; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 16px; }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 22px 18px; display: flex; flex-direction: column; gap: 8px; text-decoration: none; color: inherit; transition: border-color 0.15s; }
+    .card:hover { border-color: var(--accent); }
+    .card-icon { font-size: 1.8rem; }
+    .card-name { font-size: 0.95rem; font-weight: 600; }
+    .card-desc { font-size: 0.78rem; color: var(--muted); flex: 1; line-height: 1.45; }
+    .card-tag  { font-size: 0.68rem; padding: 2px 7px; border-radius: 4px; display: inline-block; margin-top: 4px; align-self: flex-start; }
+    .tag-tool  { background: #1a2a3a; color: var(--blue); }
+    .tag-qs    { background: #1a3a1a; color: var(--green); }
+    .tag-fs    { background: #2a1a3a; color: var(--purple); }
+    .ftr { border-top: 1px solid var(--border); padding: 14px 28px; text-align: center; font-size: 0.76rem; color: var(--muted); }
+    .ftr a { color: var(--muted); text-decoration: none; margin: 0 8px; }
+    .ftr a:hover { color: var(--accent); }
+  </style>
+</head>
+<body>
+
+<header class="hdr">
+  <img src="/static/egeria-logo.png" alt="Egeria">
+  <span class="hdr-title">Egeria Workspaces — Documentation</span>
+  <div class="hdr-right"><a href="/">← Portal</a></div>
+</header>
+
+<div class="hero">
+  <h1>Egeria Workspaces Reference</h1>
+  <p>Guides for the Egeria tools, the Quickstart demo environment, and the Freshstart development environment.</p>
+</div>
+
+<main class="main">
+
+  <div class="section-label">Tools — available in all environments</div>
+  <div class="grid">
+    <a class="card" href="viewer.html?src=tools/egeria-explorer.md">
+      <div class="card-icon">🔍</div>
+      <div class="card-name">Egeria Explorer</div>
+      <div class="card-desc">Browse types, glossary, lineage, governance blueprints, digital products, and information supply chains.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+    <a class="card" href="viewer.html?src=tools/obsidian.md">
+      <div class="card-icon">🗒️</div>
+      <div class="card-name">Obsidian Vault</div>
+      <div class="card-desc">Using Obsidian with Egeria — local install, containerised browser version, and the session lock system.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+    <a class="card" href="viewer.html?src=tools/dr-egeria/overview.md">
+      <div class="card-icon">🩺</div>
+      <div class="card-name">Dr. Egeria</div>
+      <div class="card-desc">Write Egeria commands as Markdown, send them via the Call Dr. Egeria plugin, and get rich results back in your vault.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+    <a class="card" href="viewer.html?src=tools/dr-egeria/templates-basic.md">
+      <div class="card-icon">📋</div>
+      <div class="card-name">Dr. Egeria Templates</div>
+      <div class="card-desc">Ready-to-use command templates — basic and advanced — covering glossary, governance, lineage, and more.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+    <a class="card" href="viewer.html?src=tools/egeria-advisor.md">
+      <div class="card-icon">🤖</div>
+      <div class="card-name">Egeria Advisor</div>
+      <div class="card-desc">AI-powered guidance for navigating and querying your Egeria metadata environment.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+    <a class="card" href="viewer.html?src=tools/jupyter.md">
+      <div class="card-icon">📓</div>
+      <div class="card-name">Jupyter Lab</div>
+      <div class="card-desc">Interactive notebooks for data science exploration and hands-on Egeria API work.</div>
+      <span class="card-tag tag-tool">Tool</span>
+    </a>
+  </div>
+
+  <div class="section-label">Quickstart environment</div>
+  <div class="grid">
+    <a class="card" href="viewer.html?src=quickstart/overview.md">
+      <div class="card-icon">🚀</div>
+      <div class="card-name">Quickstart Overview</div>
+      <div class="card-desc">What the Quickstart stack includes, how to start it, and which ports are used.</div>
+      <span class="card-tag tag-qs">Quickstart</span>
+    </a>
+    <a class="card" href="viewer.html?src=quickstart/local/overview.md">
+      <div class="card-icon">💻</div>
+      <div class="card-name">Local Setup</div>
+      <div class="card-desc">Running Quickstart on your own machine — configuration, .env settings, and first-time setup.</div>
+      <span class="card-tag tag-qs">Quickstart · Local</span>
+    </a>
+    <a class="card" href="viewer.html?src=quickstart/demo/overview.md">
+      <div class="card-icon">🎭</div>
+      <div class="card-name">Demo Environment</div>
+      <div class="card-desc">Running Quickstart as a public demo — user registration, personas, and the portal experience.</div>
+      <span class="card-tag tag-qs">Quickstart · Demo</span>
+    </a>
+    <a class="card" href="viewer.html?src=quickstart/demo/admin-guide.md">
+      <div class="card-icon">⚙️</div>
+      <div class="card-name">Admin Guide</div>
+      <div class="card-desc">Managing users, configuring reset schedules, and the Obsidian session lock reservation system.</div>
+      <span class="card-tag tag-qs">Quickstart · Demo</span>
+    </a>
+    <a class="card" href="viewer.html?src=quickstart/coco/overview.md">
+      <div class="card-icon">🏭</div>
+      <div class="card-name">Coco Pharmaceuticals</div>
+      <div class="card-desc">Background on the fictional company used to demonstrate Egeria — personas, data landscape, and governance challenges.</div>
+      <span class="card-tag tag-qs">Quickstart</span>
+    </a>
+    <a class="card" href="viewer.html?src=quickstart/coco/scenarios.md">
+      <div class="card-icon">🗺️</div>
+      <div class="card-name">Demo Scenarios</div>
+      <div class="card-desc">Guided walk-throughs of common Egeria capabilities using Coco Pharmaceuticals data.</div>
+      <span class="card-tag tag-qs">Quickstart</span>
+    </a>
+  </div>
+
+  <div class="section-label">Freshstart environment</div>
+  <div class="grid">
+    <a class="card" href="viewer.html?src=freshstart/overview.md">
+      <div class="card-icon">🌱</div>
+      <div class="card-name">Freshstart Overview</div>
+      <div class="card-desc">A clean-slate Egeria environment for development and experimentation with no pre-loaded data.</div>
+      <span class="card-tag tag-fs">Freshstart</span>
+    </a>
+    <a class="card" href="viewer.html?src=freshstart/getting-started.md">
+      <div class="card-icon">📖</div>
+      <div class="card-name">Getting Started</div>
+      <div class="card-desc">Starting Freshstart, connecting tools, and loading your first metadata.</div>
+      <span class="card-tag tag-fs">Freshstart</span>
+    </a>
+  </div>
+
+</main>
+
+<footer class="ftr">
+  <a href="https://egeria-project.org" target="_blank" rel="noopener">egeria-project.org</a>
+  <a href="https://github.com/odpi/egeria-workspaces" target="_blank" rel="noopener">GitHub</a>
+  <a href="https://egeria-project.org/practices/coco-pharmaceuticals" target="_blank" rel="noopener">Coco Pharmaceuticals</a>
+</footer>
+
+</body>
+</html>

--- a/portal-docs/quickstart/coco/overview.md
+++ b/portal-docs/quickstart/coco/overview.md
@@ -1,0 +1,46 @@
+# Coco Pharmaceuticals
+
+Coco Pharmaceuticals is a fictional mid-sized pharmaceutical company used throughout Egeria's documentation and demonstrations. It provides a realistic, legally-safe dataset for exploring metadata governance, data lineage, and cataloguing challenges.
+
+---
+
+## The company
+
+Coco Pharmaceuticals researches and manufactures specialised drugs for cancer treatments. The company:
+
+- Has multiple sites across the US and Europe
+- Runs clinical trials subject to regulatory reporting requirements
+- Manages a complex data landscape spanning lab systems, finance, manufacturing, and HR
+- Is undertaking a digital transformation to improve data governance and trust
+
+This makes Coco an ideal vehicle for demonstrating how Egeria addresses real-world data challenges.
+
+---
+
+## Data landscape
+
+The Quickstart environment includes pre-loaded metadata covering:
+
+| Domain | What's included |
+|---|---|
+| **Clinical** | Trial data, lab results, patient cohort definitions |
+| **Finance** | Accounts, reporting pipelines, regulatory submissions |
+| **Manufacturing** | Production data, batch records, quality rules |
+| **HR** | Organisational structure, roles, responsibilities |
+| **IT** | Deployed systems, infrastructure assets |
+
+---
+
+## Exploring Coco data
+
+- **[Egeria Explorer](../../tools/egeria-explorer.md)** — browse types, glossaries, lineage, and governance across the full Coco dataset
+- **[Obsidian vault](../../tools/obsidian.md)** — the `coco-workbooks` vault contains scenario workbooks and templates
+- **[Jupyter Lab](../../tools/jupyter.md)** — Python notebooks for API-level exploration of Coco data
+
+---
+
+## Further reading
+
+- [Personas](personas.md) — who the Coco characters are
+- [Demo scenarios](scenarios.md) — guided walk-throughs using Coco data
+- [Coco Pharmaceuticals on egeria-project.org](https://egeria-project.org/practices/coco-pharmaceuticals) ↗

--- a/portal-docs/quickstart/coco/personas.md
+++ b/portal-docs/quickstart/coco/personas.md
@@ -1,0 +1,84 @@
+# Coco Pharmaceuticals — Personas
+
+Each persona represents a Coco employee with a distinct role. Selecting a persona in the portal sets your Egeria credentials and highlights the most relevant tools and Explorer tabs for that perspective.
+
+---
+
+## Starter personas — recommended for first-time users
+
+### Erin Overview — Information Architect
+Erin sets IT standards and manages information supply chains. She has the broadest view of the metadata landscape and is the natural starting point for understanding how information flows between systems.
+
+**Best for:** ISC tab, governance zones, glossary standards
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/erin-overview/)
+
+---
+
+### Peter Profile — Data Analyst
+Peter assesses and reports on data quality. He automates quality rules and profilers to track improvement in data trustworthiness.
+
+**Best for:** Data Design tab, Glossary, Governance (quality metrics)
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/peter-profile/)
+
+---
+
+### Callie Quartile — Data Scientist
+Callie works with clinical and research data, relying on lineage to trust her datasets.
+
+**Best for:** Data Design, Glossary, ISC (lineage)
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/callie-quartile/)
+
+---
+
+### Ivor Padlock — Chief Security Officer
+Ivor tracks accountability for data protection and security classifications across all assets.
+
+**Best for:** Governance (security zones), Perspectives
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/ivor-padlock/)
+
+---
+
+## Additional personas
+
+### Gary Geeke — IT Infrastructure Administrator
+Manages day-to-day IT operations; uses Egeria to maintain systems inventory and compliance.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/gary-geeke/)
+
+### Faith Broker — HR Director and Privacy Officer
+Monitors regulatory compliance and organisational roles.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/faith-broker/)
+
+### Polly Tasker — Project Manager
+Leads IT development; uses Egeria to track data dependencies and project metadata.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/polly-tasker/)
+
+### Tom Tally — Accounts Manager
+Traces data lineage for regulatory financial submissions.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/tom-tally/)
+
+### Lemmie Stage — DevOps Specialist
+Tracks deployed system assets and their security profiles.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/lemmie-stage/)
+
+### Jules Keeper — Chief Data Officer
+Leads the data-driven transformation strategy across Coco.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/jules-keeper/)
+
+### Stew Faster — Manufacturing Manager
+Manages production lines; tracks operational data flows and quality.
+[Full profile ↗](https://egeria-project.org/practices/coco-pharmaceuticals/personas/stew-faster/)
+
+---
+
+## Choosing a persona for a demo
+
+| Goal | Suggested persona |
+|---|---|
+| Broad overview of the platform | Erin Overview |
+| Data quality and governance | Peter Profile |
+| Lineage and data science | Callie Quartile |
+| Security and compliance | Ivor Padlock |
+| Technical infrastructure | Gary Geeke |
+| Executive / strategy view | Jules Keeper |
+
+See [Demo scenarios](scenarios.md) for guided walk-throughs matched to specific personas.

--- a/portal-docs/quickstart/coco/scenarios.md
+++ b/portal-docs/quickstart/coco/scenarios.md
@@ -1,0 +1,83 @@
+# Demo Scenarios
+
+Guided walk-throughs using Coco Pharmaceuticals data to demonstrate key Egeria capabilities. Each scenario is self-contained and takes approximately 5–15 minutes.
+
+---
+
+## Scenario 1 — Exploring the metadata landscape (Erin Overview)
+
+**Goal:** Show the breadth of Egeria's metadata coverage across a real organisation.
+**Persona:** Erin Overview
+**Tools:** Egeria Explorer, Obsidian
+
+1. Open Egeria Explorer → **ISC tab** — walk through the information supply chains showing how clinical data flows from lab systems into the warehouse and regulatory reports
+2. Switch to **Governance tab** — show the governance zones and which assets are in each zone
+3. Switch to **Glossary tab** — search for "Patient Cohort" and show the full term definition, linked assets, and stewardship
+4. In Obsidian, open a workbook and run `# View Glossaries` with the `display` directive
+
+**Key message:** Egeria connects business terms, data assets, and lineage in one place.
+
+---
+
+## Scenario 2 — Data quality governance (Peter Profile)
+
+**Goal:** Demonstrate how data quality rules are tracked and enforced.
+**Persona:** Peter Profile
+**Tools:** Egeria Explorer, Dr. Egeria
+
+1. Open Egeria Explorer → **Data Design tab** — show the data structures with quality rules attached
+2. Open Obsidian, run `# View Data Structures` — see the same structures with field-level detail
+3. Create a new quality note and validate it with Dr. Egeria using the `validate` directive
+
+**Key message:** Data quality is a first-class citizen in Egeria's open metadata model.
+
+---
+
+## Scenario 3 — Lineage for regulatory reporting (Tom Tally)
+
+**Goal:** Show how Egeria traces data lineage from source to regulatory submission.
+**Persona:** Tom Tally
+**Tools:** Egeria Explorer
+
+1. Open Egeria Explorer → **ISC tab** — find the financial reporting supply chain
+2. Walk the lineage from the treasury data through transformation steps to the final report
+3. Show the governance zone at each step — demonstrating that regulated data is properly classified throughout
+
+**Key message:** Egeria provides the audit trail regulators require.
+
+---
+
+## Scenario 4 — Security classification (Ivor Padlock)
+
+**Goal:** Show how sensitive data is classified and tracked.
+**Persona:** Ivor Padlock
+**Tools:** Egeria Explorer
+
+1. Open Egeria Explorer → **Governance tab** — show security classifications
+2. Filter to "Confidential" zone — show which data assets carry that classification
+3. Show the Perspectives tab — organisational accountability for classified assets
+
+**Key message:** Egeria makes security accountability visible and auditable.
+
+---
+
+## Scenario 5 — Using Dr. Egeria to create governed metadata (Erin Overview)
+
+**Goal:** Show how practitioners create and link metadata using natural-language Markdown commands.
+**Persona:** Erin Overview
+**Tools:** Obsidian, Dr. Egeria
+
+1. Open Obsidian, create a new note
+2. Write a `# Create Glossary Term` command for a new business concept
+3. Run it with the `process` directive
+4. Switch to Egeria Explorer → Glossary tab — show the new term appearing
+
+**Key message:** Dr. Egeria removes the API complexity — business users can contribute metadata directly.
+
+---
+
+## Adding more scenarios
+
+Scenarios can be added as Markdown files in this directory. The viewer will render them with full Mermaid diagram support — use sequence or flow diagrams to illustrate data flows.
+
+See also: [Coco Pharmaceuticals overview](overview.md) · [Personas](personas.md)

--- a/portal-docs/quickstart/demo/admin-guide.md
+++ b/portal-docs/quickstart/demo/admin-guide.md
@@ -1,0 +1,80 @@
+# Admin Guide
+
+The admin panel is at `/admin`. It is only accessible to users with the admin role.
+
+---
+
+## Users tab
+
+View all registered users. Actions per user:
+
+| Action | When to use |
+|---|---|
+| **Promote / Demote** | Grant or remove admin role |
+| **Verify** | Manually verify a user who didn't receive the email |
+| **Resend Email** | Re-send the verification link (also shows the raw link for manual sharing) |
+| **Disable** | Block a user from logging in |
+| **Delete** | Permanently remove a user and their event history |
+
+Stats at the top show total users, verified count, and admin count.
+
+---
+
+## Events tab
+
+Shows the last 200 events across all users — registrations, logins, persona selections, and admin actions. Useful for auditing who did what and when.
+
+---
+
+## Config tab
+
+Runtime configuration key-value store. Changes take effect immediately without a restart.
+
+Key config values:
+
+| Key | Purpose |
+|---|---|
+| `reset_interval_hours` | Auto-reset interval (0 = disabled) |
+| `obsidian_session_minutes` | Default Obsidian session length |
+| `obsidian_idle_soft_minutes` | Minutes before idle warning shows |
+| `obsidian_idle_hard_minutes` | Minutes before session marked STUCK |
+| `obsidian_buffer_minutes` | Buffer before a reserved block |
+| `obsidian_evict_grace_secs` | Default grace period for eviction |
+
+---
+
+## Reset tab
+
+Controls the Egeria metadata store reset — stops the platform, drops the metadata schema, and restarts from scratch. User accounts are not affected.
+
+- **Auto-reset schedule** — configure an interval (6h, 12h, 24h, etc.) to reset automatically
+- **Force Reset Now** — trigger an immediate reset; Egeria takes ~5 minutes to reinitialise
+
+---
+
+## Obsidian tab
+
+Manages the shared Obsidian session lock.
+
+### Status cards
+
+Show the current lock state, who holds it, their persona, and time remaining.
+
+### Override actions
+
+| Action | Effect |
+|---|---|
+| **Evict** | Starts a grace-period countdown — holder sees a warning in the portal |
+| **Force unlock** | Releases the lock immediately — use for stuck sessions |
+
+The grace period defaults to 5 minutes and is configurable per-eviction.
+
+### Reservations
+
+Create future reserved blocks (label, start time, end time) to block regular users from acquiring Obsidian during a scheduled presentation. Conflict detection prevents overlapping reservations.
+
+### Audit log
+
+Shows the last 50 lock events — acquisitions, releases, evictions, and auto-releases.
+
+See also: [Obsidian session management](obsidian-sessions.md)

--- a/portal-docs/quickstart/demo/obsidian-sessions.md
+++ b/portal-docs/quickstart/demo/obsidian-sessions.md
@@ -1,0 +1,73 @@
+# Obsidian Session Management
+
+The containerised Obsidian runs as a single shared desktop. The portal manages exclusive access through a session lock so multiple demo users don't collide.
+
+---
+
+## Session states
+
+| State | Meaning |
+|---|---|
+| **FREE** | Available — anyone can acquire |
+| **IN_USE** | A user holds the session |
+| **ADMIN_IN_USE** | An admin holds the session |
+| **STUCK** | Holder stopped sending keepalives — eligible for admin override |
+
+---
+
+## Regular user flow
+
+1. The Obsidian tile shows **● Available** when free.
+2. Click **Use Obsidian →** to acquire a session (your current persona is injected automatically).
+3. A session timer counts down in the tile.
+4. Click **Extend** to add another session block (blocked if a reservation is within the buffer window).
+5. Click **Release** when done.
+
+If you close the portal page without releasing, the session is automatically released after the idle timeout (default 10 minutes).
+
+---
+
+## Persona injection
+
+When you acquire Obsidian, the portal writes your persona's Egeria credentials into the plugin's `data.json`. The Call Dr. Egeria plugin detects this change via a file-watcher and reloads settings — you'll see a notice in Obsidian: *"Dr. Egeria: session updated — persona is now `{userId}`"*.
+
+This means you don't need to manually configure the plugin.
+
+---
+
+## Admin capabilities
+
+| Action | Where | Effect |
+|---|---|---|
+| **Reserve a block** | Admin → Obsidian tab | Blocks regular users from acquiring during that window |
+| **Evict current holder** | Admin → Obsidian tab | Shows warning to holder; releases after grace period |
+| **Force unlock** | Admin → Obsidian tab | Releases immediately — use for stuck sessions |
+| **View audit log** | Admin → Obsidian tab | Last 50 lock events |
+
+### Reservations for presentations
+
+Before a scheduled demo:
+1. Go to **Admin → Obsidian tab → Reserved Blocks**
+2. Enter a label (e.g. "Product demo — Acme Corp"), start time, and end time
+3. Click **Reserve**
+
+Regular users cannot acquire Obsidian within the **buffer window** (default 10 minutes) before a reservation starts. This ensures the desktop is ready when the demo begins.
+
+### Eviction grace period
+
+When you evict a holder, they see a warning banner in the portal counting down. The default grace period is 5 minutes — configurable per-eviction in the admin panel. After the deadline, the lock is released automatically.
+
+---
+
+## Configuration
+
+Session behaviour is tunable via the [Config tab](admin-guide.md#config-tab) or `.env`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OBSIDIAN_SESSION_MINUTES` | `20` | Session length |
+| `OBSIDIAN_IDLE_SOFT_MINUTES` | `5` | Idle warning threshold |
+| `OBSIDIAN_IDLE_HARD_MINUTES` | `10` | STUCK threshold |
+| `OBSIDIAN_BUFFER_MINUTES` | `10` | Buffer before reserved block |
+| `OBSIDIAN_EVICT_GRACE_SECONDS` | `300` | Default eviction grace period |
+| `OBSIDIAN_LOCK_ENABLED` | `true` | Set `false` to disable locking entirely |

--- a/portal-docs/quickstart/demo/overview.md
+++ b/portal-docs/quickstart/demo/overview.md
@@ -1,0 +1,62 @@
+# Quickstart — Demo Environment
+
+Demo mode enables public access to the Quickstart stack with user registration, persona selection, and a managed Obsidian session. It is designed for running structured demonstrations to external audiences.
+
+---
+
+## Enabling demo mode
+
+In `compose-configs/egeria-quickstart/.env`:
+
+```
+DEMO_MODE=true
+JWT_SECRET=<long-random-string>         # change before going public
+ADMIN_BOOTSTRAP_EMAIL=you@example.com
+ADMIN_BOOTSTRAP_PASSWORD=<strong-password>
+```
+
+Optionally configure email notifications (magic-link registration):
+```
+RESEND_API_KEY=re_...
+RESEND_FROM=noreply@yourdomain.com
+```
+
+---
+
+## User flow
+
+1. Visitor arrives at the portal → redirected to `/login`
+2. They register with email + password → receive a verification email
+3. After verifying → they reach the portal and choose a persona
+4. The persona sets their Egeria credentials for Explorer and Dr. Egeria
+
+---
+
+## Personas
+
+Each persona represents a [Coco Pharmaceuticals](../coco/overview.md) employee with a different role and focus. Choosing a persona sets:
+- The Egeria user ID and password used for all API calls
+- The Dr. Egeria plugin credentials (auto-populated when acquiring Obsidian)
+- The highlighted tools shown in the bio card
+
+See [Coco Pharmaceuticals personas](../coco/personas.md) for the full list.
+
+---
+
+## Obsidian in demo mode
+
+The containerised Obsidian instance is shared among all demo users. The portal manages access with a session lock:
+
+- Users acquire a timed session (default 20 min) before Obsidian opens
+- Credentials are injected automatically from the selected persona
+- Admins can reserve blocks, evict current holders, and view the audit log
+
+See [Obsidian session management](obsidian-sessions.md) for full details.
+
+---
+
+## Admin responsibilities
+
+- Monitor and manage registered users in the [Admin panel](admin-guide.md)
+- Set the Egeria reset schedule if you want the metadata store refreshed periodically
+- Create Obsidian reservations before scheduled presentations

--- a/portal-docs/quickstart/local/overview.md
+++ b/portal-docs/quickstart/local/overview.md
@@ -1,0 +1,74 @@
+# Quickstart — Local Setup
+
+Local mode runs the full Quickstart stack on your own machine for personal exploration and development. There is no user registration — you access all tools directly.
+
+---
+
+## Prerequisites
+
+- Docker Desktop (Mac/Windows) or Docker Engine + Compose (Linux)
+- 8 GB RAM allocated to Docker (16 GB recommended)
+- Ports 8085, 8000, 9443, 7888, 3000, 9194, 5442 available
+
+---
+
+## Initial configuration
+
+1. Copy the environment template:
+   ```bash
+   cd compose-configs/egeria-quickstart
+   cp .env.example .env
+   ```
+
+2. Edit `.env` — the minimum required settings:
+   ```
+   HOST_FQDN=localhost         # or your machine's hostname
+   KAFKA_BOOTSTRAP_SERVERS=localhost:9194
+   ```
+
+3. Optional but recommended — set your Obsidian preference:
+   ```
+   # Use your local Obsidian app (vault name or obsidian:// URI)
+   OBSIDIAN_VAULT_URL=coco-workbooks
+
+   # Or leave empty to use the containerised Obsidian at port 3000
+   OBSIDIAN_VAULT_URL=
+   ```
+
+---
+
+## Start the stack
+
+```bash
+cd compose-configs/egeria-quickstart
+docker compose -f egeria-quickstart.yaml up -d
+```
+
+Open the portal at **http://localhost:8085**.
+
+---
+
+## Key differences from demo mode
+
+| Feature | Local | Demo |
+|---|---|---|
+| User registration / login | No — open access | Yes — email + password |
+| Persona selection | Stored in browser (localStorage) | Stored per account |
+| Obsidian session lock | Available (auto-clears on restart) | Full lock + reservation system |
+| Admin panel | Not needed | `/admin` |
+| Email notifications | Not needed | Requires Resend API key |
+
+---
+
+## Configuration reference
+
+All settings are in `compose-configs/egeria-quickstart/.env`. See `.env.example` for the full list with descriptions.
+
+Key variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HOST_FQDN` | — | Hostname used by Egeria and Kafka |
+| `OBSIDIAN_VAULT_URL` | *(empty)* | Local Obsidian vault name or URI |
+| `OBSIDIAN_LOCK_ENABLED` | `true` | Set `false` to disable session lock |
+| `EGERIA_ADVISOR_URL` | `http://localhost:8080/` | Egeria Advisor URL if running |

--- a/portal-docs/quickstart/overview.md
+++ b/portal-docs/quickstart/overview.md
@@ -1,0 +1,52 @@
+# Quickstart Environment
+
+The Quickstart stack is a fully-configured Egeria environment pre-loaded with Coco Pharmaceuticals data. It is designed for demos, learning, and hands-on exploration.
+
+---
+
+## What's included
+
+| Service | Port | Purpose |
+|---|---|---|
+| Egeria platform | 9443 | Metadata store and API server |
+| pyegeria-web | 8000 | FastAPI backend — Dr. Egeria MCP, portal API |
+| Apache web server | 8085 | Portal, documentation, static content |
+| Jupyter Lab | 7888 | Interactive Python notebooks |
+| Obsidian (container) | 3000 | Browser-based Obsidian via KasmVNC |
+| Shared PostgreSQL | 5442 | Metadata + demo auth database |
+| Kafka | 9194 | Event bus for Egeria integration daemons |
+
+---
+
+## Operating modes
+
+| Mode | Who | How to enable |
+|---|---|---|
+| **Local** | Single developer on their own machine | `DEMO_MODE=false` (default) |
+| **Demo** | Multiple external users via registration | `DEMO_MODE=true` |
+
+- [Local setup guide](local/overview.md)
+- [Demo environment guide](demo/overview.md)
+
+---
+
+## Starting the stack
+
+```bash
+cd compose-configs/egeria-quickstart
+docker compose -f egeria-quickstart.yaml up -d
+```
+
+Egeria takes approximately 2–3 minutes to fully initialise after startup. The platform healthcheck will turn green once it is ready.
+
+---
+
+## Pre-loaded data
+
+The Quickstart stack starts with:
+
+- **Coco Pharmaceuticals** metadata — glossaries, governance zones, data assets, lineage, and supply chains
+- **Demo users** (in demo mode) — pre-configured admin account via `ADMIN_BOOTSTRAP_EMAIL`
+- **Personas** — 11 Coco employees with different roles and perspectives
+
+See [Coco Pharmaceuticals](coco/overview.md) for background on the scenario.

--- a/portal-docs/tools/dr-egeria/overview.md
+++ b/portal-docs/tools/dr-egeria/overview.md
@@ -1,0 +1,104 @@
+# Dr. Egeria
+
+Dr. Egeria is a markdown-driven command interface for Egeria. You write commands as structured Markdown in Obsidian, send them via the **Call Dr. Egeria** plugin, and receive results directly back into your vault.
+
+---
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant You
+    participant Obsidian
+    participant Backend as pyegeria-web
+    participant Egeria
+
+    You->>Obsidian: Write command in a note
+    You->>Obsidian: Click Briefcase icon
+    Obsidian->>Backend: Send note content (MCP)
+    Backend->>Egeria: Execute command
+    Egeria-->>Backend: Results
+    Backend-->>Obsidian: Markdown result
+    Obsidian->>Obsidian: Save to outbox
+    Obsidian->>You: Show results modal
+```
+
+---
+
+## Directives
+
+Each note is processed with a **directive** that controls what Dr. Egeria does:
+
+| Directive | Behaviour |
+|---|---|
+| `process` | Execute the command and save output to the outbox |
+| `validate` | Check the command syntax without executing |
+| `display` | Show current metadata without making changes |
+
+The default directive is set in the plugin settings. You can also override it per-note using front matter:
+
+```markdown
+---
+directive: validate
+---
+# View Glossaries
+```
+
+---
+
+## Writing commands
+
+Commands follow a consistent Markdown pattern:
+
+```markdown
+# Command Name
+Property: Value
+Another Property: Another Value
+```
+
+For example, to view all glossaries:
+
+```markdown
+# View Glossaries
+```
+
+To create a glossary term:
+
+```markdown
+# Create Glossary Term
+Term: Customer
+Glossary: Business Glossary
+Summary: A person or organisation that purchases products or services.
+```
+
+See the [Basic Templates](templates-basic.md) and [Advanced Templates](templates-advanced.md) for ready-to-use examples.
+
+---
+
+## Output
+
+Results are saved to the **outbox folder** (default: `dr-egeria-outbox`) with a timestamp:
+
+```
+dr-egeria-outbox/
+  MyNote-processed-20260601-142300.md
+```
+
+The results modal shows the full output with status icons:
+- ✅ Success
+- ❌ Error — check the command syntax or Egeria connectivity
+- ⚠️ Warning — command ran but something to note
+
+---
+
+## Refreshing command specs
+
+If you update Dr. Egeria command definitions on the backend, click **Refresh Now** in the plugin settings to reload the dispatcher without restarting the container.
+
+---
+
+## Further reading
+
+- [Basic Templates](templates-basic.md) — ready-to-use command templates
+- [Advanced Templates](templates-advanced.md) — complex operations and batch commands
+- [Obsidian setup](../obsidian.md) — configuring the plugin and vault

--- a/portal-docs/tools/dr-egeria/templates-advanced.md
+++ b/portal-docs/tools/dr-egeria/templates-advanced.md
@@ -1,0 +1,104 @@
+# Dr. Egeria — Advanced Templates
+
+Advanced command templates for information supply chains, data design, and complex governance operations.
+
+The full template library is also available at [/Dr-Egeria-Samples](/Dr-Egeria-Samples).
+
+---
+
+## Information Supply Chains
+
+### View information supply chains
+```markdown
+# View Information Supply Chains
+```
+
+### Create an information supply chain
+```markdown
+# Create Information Supply Chain
+Name: Clinical Trial Data Flow
+Description: Flow of data from lab systems through QA into the clinical data warehouse.
+```
+
+### Link information supply chain peers
+```markdown
+# Link Information Supply Chain Peers
+ISC 1: Clinical Trial Data Flow
+ISC 2: Regulatory Reporting Pipeline
+```
+
+---
+
+## Solution Architecture
+
+### Create a solution component
+```markdown
+# Create Solution Component
+Name: Lab Data Extractor
+Description: Extracts raw assay data from the LIMS system.
+Blueprint: Clinical Data Pipeline
+```
+
+### Create a solution role
+```markdown
+# Create Solution Role
+Name: Data Steward — Clinical
+Description: Responsible for clinical data quality and compliance.
+```
+
+### Link solution component peers
+```markdown
+# Link Solution Component Peers
+Component 1: Lab Data Extractor
+Component 2: QA Validator
+```
+
+---
+
+## Data Design
+
+### View data structures
+```markdown
+# View Data Structures
+```
+
+### View data fields for a structure
+```markdown
+# View Data Fields
+Structure: [qualified name or display name]
+```
+
+---
+
+## Digital Products
+
+### View digital products
+```markdown
+# View Digital Products
+```
+
+---
+
+## Batch processing
+
+Dr. Egeria processes one command block per note. For batch operations, create a note with multiple commands separated by horizontal rules — each block is processed in sequence:
+
+```markdown
+# Create Glossary Term
+Term: Supplier
+Glossary: Business Glossary
+Summary: An organisation that provides goods or services to Coco Pharmaceuticals.
+
+---
+
+# Create Glossary Term
+Term: Product Batch
+Glossary: Manufacturing Glossary
+Summary: A quantity of product manufactured in a single production run.
+```
+
+> **Note:** Batch support depends on the backend version. Check with `validate` first.
+
+---
+
+See also: [Basic Templates](templates-basic.md) · [Dr. Egeria overview](overview.md)

--- a/portal-docs/tools/dr-egeria/templates-basic.md
+++ b/portal-docs/tools/dr-egeria/templates-basic.md
@@ -1,0 +1,116 @@
+# Dr. Egeria — Basic Templates
+
+Ready-to-use command templates for common Egeria operations. Copy any template into an Obsidian note and run it with the [Call Dr. Egeria](../obsidian.md) plugin.
+
+The full template library is also available at [/Dr-Egeria-Samples](/Dr-Egeria-Samples) — browse the folder structure directly.
+
+---
+
+## Glossary
+
+### View all glossaries
+```markdown
+# View Glossaries
+```
+
+### View terms in a glossary
+```markdown
+# View Glossary Terms
+Glossary: Business Glossary
+```
+
+### Create a glossary term
+```markdown
+# Create Glossary Term
+Term: Customer
+Glossary: Business Glossary
+Summary: A person or organisation that purchases products or services.
+```
+
+### Create an informal tag
+```markdown
+# Create Informal Tag
+Tag Name: confidential
+Description: Marks assets containing sensitive information.
+```
+
+---
+
+## Governance
+
+### View governance zones
+```markdown
+# View Governance Zones
+```
+
+### View governance definitions
+```markdown
+# View Governance Definitions
+```
+
+---
+
+## Feedback
+
+### Create a comment
+```markdown
+# Create Comment
+Element: [GUID or qualified name]
+Comment: This dataset needs quality review before use in reporting.
+```
+
+### Create a journal entry
+```markdown
+# Create Journal Entry
+Subject: Data quality review — Q2 2026
+Entry: Completed initial review of clinical trial datasets. Three tables flagged for remediation.
+```
+
+---
+
+## Solution Architect
+
+### View solution blueprints
+```markdown
+# View Solution Blueprints
+```
+
+### Create a solution blueprint
+```markdown
+# Create Solution Blueprint
+Name: Clinical Data Pipeline
+Description: End-to-end pipeline from lab systems to analytics platform.
+```
+
+---
+
+## Project management
+
+### Create a project
+```markdown
+# Create Project
+Name: Data Governance Initiative 2026
+Description: Programme to improve data quality across all Coco systems.
+```
+
+### Create a personal project
+```markdown
+# Create Personal Project
+Name: Glossary review — finance terms
+```
+
+---
+
+## General
+
+### View a report
+```markdown
+# View Report
+Report: [report name or qualified name]
+```
+
+---
+
+> **Tip:** Set **Default Directive** to `validate` in the plugin settings while drafting new commands. Switch to `process` when ready to execute.
+
+See also: [Advanced Templates](templates-advanced.md)

--- a/portal-docs/tools/egeria-advisor.md
+++ b/portal-docs/tools/egeria-advisor.md
@@ -1,0 +1,39 @@
+# Egeria Advisor
+
+Egeria Advisor is an AI-powered assistant for navigating and querying your Egeria metadata environment. It provides natural-language guidance, answers questions about the metadata landscape, and helps you find relevant types, terms, and assets.
+
+> **Status:** Egeria Advisor runs as a separate service. It appears in the portal tile only when the service is running (indicated by the tile being active rather than showing "Not running").
+
+---
+
+## Accessing the Advisor
+
+The portal tile links to the Advisor URL configured in `.env`:
+
+```
+EGERIA_ADVISOR_URL=http://localhost:8080/
+```
+
+If you are running the Advisor on a different host or port, update this value.
+
+---
+
+## Use cases
+
+- **Discovery:** "What data assets relate to clinical trials?"
+- **Governance:** "Which assets are in the quarantine zone?"
+- **Lineage:** "Where does the revenue figure in the Q2 report come from?"
+- **Type questions:** "What is the difference between a DataSet and a DataStore?"
+
+---
+
+## Configuration
+
+*(Further documentation to be added as the Egeria Advisor integration develops.)*
+
+---
+
+## Further reading
+
+- [Egeria project documentation](https://egeria-project.org)
+- [Egeria Explorer](egeria-explorer.md) — for direct metadata browsing without AI assistance

--- a/portal-docs/tools/egeria-explorer.md
+++ b/portal-docs/tools/egeria-explorer.md
@@ -1,0 +1,42 @@
+# Egeria Explorer
+
+Egeria Explorer is the primary browser-based interface for navigating Egeria metadata. It provides tab-by-tab views of types, glossary terms, lineage, governance blueprints, digital products, and more.
+
+Access it from the portal tile or directly at `/egeria-explorer`.
+
+---
+
+## Tabs overview
+
+| Tab | What it shows | Good for |
+|---|---|---|
+| **Type System** | All open metadata types and their inheritance | Developers, architects |
+| **Glossary** | Business terms and their definitions | Business users, data stewards |
+| **Data Design** | Data structures, schemas, quality rules | Data analysts, engineers |
+| **Governance** | Policies, zones, security classifications, compliance rules | Governance officers |
+| **Digital Products** | Published data products and their assets | Data consumers |
+| **ISC** | Information supply chains and data lineage | Data engineers, auditors |
+| **Solution Architect** | Blueprints, solution components, and roles | Architects |
+| **Perspectives** | Organisational views — teams, roles, responsibilities | HR, management |
+
+---
+
+## Switching personas
+
+The persona you select in the portal determines which Egeria user ID is used for Explorer queries. Different personas may have different visibility into governance zones and classified assets.
+
+---
+
+## Links from documentation
+
+Where documentation refers to a specific type or glossary term, you can explore it directly:
+
+- Type System: `/egeria-explorer` → Type System tab → search for the type name
+- Glossary term: `/egeria-explorer` → Glossary tab → search for the term
+
+---
+
+## Further resources
+
+- [Egeria project documentation](https://egeria-project.org) — full open metadata type reference
+- [Coco Pharmaceuticals scenarios](../quickstart/coco/scenarios.md) — guided Explorer walk-throughs

--- a/portal-docs/tools/jupyter.md
+++ b/portal-docs/tools/jupyter.md
@@ -1,0 +1,49 @@
+# Jupyter Lab
+
+Jupyter Lab provides interactive Python notebooks for Egeria API exploration, data science work, and hands-on learning.
+
+Access it from the portal tile or directly at `http://localhost:7888/?token=egeria`.
+
+---
+
+## Getting started
+
+The notebooks are pre-loaded with the Egeria Python client (`pyegeria`). The workbooks directory is mounted at `/home/jovyan/coco-workbooks` inside the container.
+
+### Default token
+
+```
+egeria
+```
+
+---
+
+## Available workbook collections
+
+| Path | Contents |
+|---|---|
+| `/home/jovyan/coco-workbooks` | Coco Pharmaceuticals scenario workbooks |
+| `/home/jovyan/workbooks` | General Egeria API workbooks |
+| `/home/jovyan/work` | Your personal working directory |
+
+---
+
+## Connecting to Egeria from a notebook
+
+```python
+from pyegeria import EgeriaTech
+
+egeria = EgeriaTech(
+    view_server="qs-view-server",
+    platform_url="https://host.docker.internal:9443",
+    user_id="erinoverview",
+    user_pwd="secret"
+)
+```
+
+---
+
+## Further reading
+
+- [pyegeria documentation](https://egeria-project.org/guides/developer/python-client/)
+- [Coco Pharmaceuticals scenarios](../quickstart/coco/scenarios.md)

--- a/portal-docs/tools/obsidian.md
+++ b/portal-docs/tools/obsidian.md
@@ -1,0 +1,96 @@
+# Obsidian Vault
+
+Obsidian is a note-taking app that doubles as the primary interface for writing and running [Dr. Egeria](dr-egeria/overview.md) commands. The **Call Dr. Egeria** plugin connects Obsidian to the Egeria backend via the Model Context Protocol (MCP).
+
+---
+
+## How to access Obsidian
+
+The portal Obsidian tile offers three paths depending on your setup:
+
+| Scenario | How it opens |
+|---|---|
+| `OBSIDIAN_VAULT_URL` set in `.env` | Launches your local Obsidian app via `obsidian://` |
+| Container available (lock free) | Opens the browser-based Obsidian (KasmVNC) at port 3000 |
+| Container in use | Shows "in use" status and a **Browse on GitHub** fallback |
+| `OBSIDIAN_LOCK_ENABLED=false` | Direct link to port 3000, no acquire/release flow |
+
+---
+
+## Option A — Local Obsidian (recommended for regular use)
+
+Install [Obsidian](https://obsidian.md) on your machine. Set in `.env`:
+
+```
+OBSIDIAN_VAULT_URL=coco-workbooks
+```
+
+The portal tile will launch `obsidian://open?vault=coco-workbooks`. No session lock is involved.
+
+---
+
+## Option B — Containerised Obsidian (browser-based)
+
+No install needed. The Quickstart stack runs an Obsidian desktop session accessible at `http://localhost:3000` via KasmVNC.
+
+### Session lock
+
+Because there is only one containerised Obsidian instance, the portal manages exclusive access with a session lock:
+
+1. The tile shows **● Available** when free. Click **Use Obsidian →** to acquire a session.
+2. Your session has a configurable timer (default 20 min). Click **Extend** to add another block if no reservation is blocking.
+3. Click **Release** when done so others can use it.
+4. If you close the browser without releasing, the session expires automatically after the idle timeout (default 10 min hard, 5 min warning).
+
+In demo mode the portal also writes your persona's Egeria credentials into the plugin's settings file when you acquire the lock — see [Persona auto-configuration](#persona-auto-configuration).
+
+---
+
+## Call Dr. Egeria plugin
+
+### MCP Server URL
+
+| Where Obsidian is running | URL to use |
+|---|---|
+| Local Obsidian, same machine as Docker | `http://localhost:8000/sse` |
+| Local Obsidian, different machine on LAN | `http://<host-ip>:8000/sse` |
+| Containerised Obsidian (KasmVNC) | `http://pyegeria-web:8000/sse` |
+
+The containerised URL is set automatically when deploying via `npm run deploy:coco`.
+
+### Settings
+
+Open **Settings → Call Dr. Egeria Settings (MCP)**:
+
+- **MCP Server URL** — see table above
+- **MCP Access Token** — must match `MCP_ACCESS_TOKEN` in the backend (default: `egeria-secret-mcp-token`)
+- **Egeria User ID / Password** — your persona credentials; auto-populated by the portal in demo mode
+- **Default Directive** — `process` / `validate` / `display`
+- **Outbox Path** — where results are saved (relative to vault root, default: `dr-egeria-outbox`)
+- **Vault Root** — absolute path to the vault inside the pyegeria-web container (e.g. `/coco-workbooks`)
+
+### Running a command
+
+1. Open a note containing a Dr. Egeria command.
+2. Click the **Briefcase** icon in the left ribbon, or use **Command Palette → Run Note via MCP**.
+3. Results appear in a resizable modal. If the directive is `process`, output is also saved to the outbox.
+
+---
+
+## Persona auto-configuration
+
+In demo mode, when you select a persona in the portal and acquire the Obsidian lock, the portal writes your persona's Egeria credentials (`userId`, `userPass`) into the plugin's `data.json`. The plugin's file-watcher detects the change and reloads settings automatically — you'll see a notice: *"Dr. Egeria: session updated — persona is now `{userId}`"*.
+
+This means you don't need to manually configure the plugin when switching personas.
+
+---
+
+## Troubleshooting
+
+| Symptom | Resolution |
+|---|---|
+| 403 Forbidden | MCP Access Token mismatch — check plugin settings vs `MCP_ACCESS_TOKEN` env var |
+| Connection refused | `quickstart-pyegeria-web` container not running |
+| Timeout | Backend still processing — check outbox after a moment |
+| Wrong persona credentials | Wait for file-watcher notice, or re-acquire the lock |
+| Blank screen in browser Obsidian | Container needs `shm_size: 1gb` and `seccomp:unconfined` — check compose config |

--- a/portal-docs/viewer.html
+++ b/portal-docs/viewer.html
@@ -1,0 +1,220 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Egeria Docs</title>
+  <!-- marked.js — markdown parser -->
+  <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+  <!-- mermaid.js — diagram rendering -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <!-- highlight.js — code syntax highlighting -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <style>
+    :root {
+      --bg: #1a1a2e; --card: #16213e; --border: #0f3460;
+      --accent: #e94560; --text: #e0e0e0; --muted: #888;
+      --code-bg: #0d1117;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif; min-height: 100vh; }
+
+    /* ── Header ── */
+    .hdr { background: var(--card); border-bottom: 1px solid var(--border); padding: 10px 28px; display: flex; align-items: center; gap: 14px; }
+    .hdr img { height: 22px; }
+    .hdr-nav { display: flex; align-items: center; gap: 6px; font-size: 0.82rem; flex: 1; overflow: hidden; }
+    .hdr-nav a { color: var(--muted); text-decoration: none; white-space: nowrap; }
+    .hdr-nav a:hover { color: var(--accent); }
+    .hdr-nav .sep { color: var(--border); }
+    .hdr-nav .crumb-current { color: var(--text); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* ── Layout ── */
+    .layout { display: flex; max-width: 1060px; margin: 0 auto; padding: 28px; gap: 28px; align-items: flex-start; }
+    .toc-col { width: 220px; flex-shrink: 0; position: sticky; top: 20px; }
+    .toc-col h3 { font-size: 0.72rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
+    .toc-list { list-style: none; }
+    .toc-list li { margin-bottom: 4px; }
+    .toc-list a { font-size: 0.8rem; color: var(--muted); text-decoration: none; display: block; padding: 2px 0 2px 8px; border-left: 2px solid transparent; }
+    .toc-list a:hover { color: var(--text); border-left-color: var(--accent); }
+    .toc-list a.h3 { padding-left: 18px; font-size: 0.75rem; }
+    .content-col { flex: 1; min-width: 0; }
+
+    /* ── Markdown content ── */
+    .md-body { line-height: 1.7; font-size: 0.92rem; }
+    .md-body h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 18px; padding-bottom: 12px; border-bottom: 1px solid var(--border); }
+    .md-body h2 { font-size: 1.2rem; font-weight: 600; margin: 32px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--border); color: var(--text); }
+    .md-body h3 { font-size: 1rem; font-weight: 600; margin: 22px 0 8px; color: var(--text); }
+    .md-body h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: var(--muted); }
+    .md-body p  { margin-bottom: 14px; color: var(--text); }
+    .md-body a  { color: var(--accent); text-decoration: none; }
+    .md-body a:hover { text-decoration: underline; }
+    .md-body ul, .md-body ol { margin: 0 0 14px 22px; }
+    .md-body li { margin-bottom: 5px; }
+    .md-body li > p { margin-bottom: 4px; }
+    .md-body blockquote { border-left: 3px solid var(--accent); margin: 0 0 14px; padding: 8px 14px; background: var(--card); border-radius: 0 6px 6px 0; }
+    .md-body blockquote p { margin: 0; color: var(--muted); font-style: italic; }
+    .md-body table { width: 100%; border-collapse: collapse; margin-bottom: 18px; font-size: 0.85rem; }
+    .md-body th { text-align: left; padding: 8px 12px; background: var(--card); border: 1px solid var(--border); font-weight: 600; color: var(--muted); }
+    .md-body td { padding: 7px 12px; border: 1px solid var(--border); vertical-align: top; }
+    .md-body tr:nth-child(even) td { background: rgba(15,52,96,0.2); }
+    .md-body code:not(pre code) { background: var(--code-bg); padding: 2px 6px; border-radius: 4px; font-size: 0.85em; font-family: monospace; color: #e6edf3; }
+    .md-body pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin-bottom: 18px; overflow-x: auto; }
+    .md-body pre code { background: none; padding: 0; font-size: 0.85rem; }
+    .md-body hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+    .md-body img { max-width: 100%; border-radius: 6px; margin: 8px 0; }
+
+    /* ── Mermaid diagrams ── */
+    .md-body .mermaid { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px; margin-bottom: 18px; text-align: center; overflow-x: auto; }
+
+    /* ── Error / loading states ── */
+    .loading { color: var(--muted); padding: 40px; text-align: center; font-size: 0.9rem; }
+    .error-msg { background: rgba(233,69,96,0.12); border: 1px solid rgba(233,69,96,0.4); border-radius: 8px; padding: 16px; color: #ef9a9a; margin: 20px 0; }
+
+    @media (max-width: 720px) {
+      .toc-col { display: none; }
+      .layout { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+
+<header class="hdr">
+  <a href="/docs/"><img src="/static/egeria-logo.png" alt="Egeria"></a>
+  <nav class="hdr-nav" id="breadcrumb">
+    <a href="/docs/">Documentation</a>
+  </nav>
+</header>
+
+<div class="layout">
+  <aside class="toc-col" id="toc-col" style="display:none">
+    <h3>On this page</h3>
+    <ul class="toc-list" id="toc-list"></ul>
+  </aside>
+  <main class="content-col">
+    <div id="content" class="md-body"><div class="loading">Loading…</div></div>
+  </main>
+</div>
+
+<script>
+  mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' });
+
+  // ── Resolve internal markdown links ──────────────────────────────────────────
+  function _mdLinkHref(href, currentSrc) {
+    if (!href || href.startsWith('http') || href.startsWith('#')) return href;
+    if (href.endsWith('.md')) {
+      // relative to current doc
+      var base = currentSrc.substring(0, currentSrc.lastIndexOf('/') + 1);
+      var resolved = base + href;
+      // normalise ../ segments
+      var parts = resolved.split('/');
+      var out = [];
+      parts.forEach(function(p) {
+        if (p === '..') { out.pop(); } else if (p !== '.') { out.push(p); }
+      });
+      return 'viewer.html?src=' + out.join('/');
+    }
+    return href;
+  }
+
+  // ── Build breadcrumb ──────────────────────────────────────────────────────────
+  var _LABELS = {
+    tools: 'Tools', quickstart: 'Quickstart', freshstart: 'Freshstart',
+    local: 'Local', demo: 'Demo', coco: 'Coco Pharmaceuticals',
+    'dr-egeria': 'Dr. Egeria',
+    'overview': 'Overview', 'getting-started': 'Getting Started',
+    'egeria-explorer': 'Egeria Explorer', 'obsidian': 'Obsidian',
+    'egeria-advisor': 'Egeria Advisor', 'jupyter': 'Jupyter',
+    'commands': 'Commands', 'templates-basic': 'Basic Templates',
+    'templates-advanced': 'Advanced Templates',
+    'admin-guide': 'Admin Guide', 'obsidian-sessions': 'Obsidian Sessions',
+    'personas': 'Personas', 'scenarios': 'Scenarios',
+    'configuration': 'Configuration',
+  };
+
+  function _label(slug) {
+    return _LABELS[slug] || slug.replace(/-/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+  }
+
+  function _buildBreadcrumb(src) {
+    var parts = src.replace(/\.md$/, '').split('/');
+    var bc = document.getElementById('breadcrumb');
+    bc.innerHTML = '<a href="/docs/">Documentation</a>';
+    var path = '';
+    parts.forEach(function(p, i) {
+      bc.insertAdjacentHTML('beforeend', '<span class="sep"> › </span>');
+      path += (i === 0 ? '' : '/') + p;
+      if (i === parts.length - 1) {
+        bc.insertAdjacentHTML('beforeend', '<span class="crumb-current">' + _label(p) + '</span>');
+        document.title = _label(p) + ' — Egeria Docs';
+      } else {
+        bc.insertAdjacentHTML('beforeend', '<a href="viewer.html?src=' + path + '/overview.md">' + _label(p) + '</a>');
+      }
+    });
+  }
+
+  // ── Build TOC from rendered headings ─────────────────────────────────────────
+  function _buildToc() {
+    var headings = document.querySelectorAll('#content h2, #content h3');
+    if (headings.length < 2) return;
+    var list = document.getElementById('toc-list');
+    list.innerHTML = '';
+    headings.forEach(function(h, i) {
+      var id = 'heading-' + i;
+      h.id = id;
+      var li = document.createElement('li');
+      var a  = document.createElement('a');
+      a.href = '#' + id;
+      a.textContent = h.textContent;
+      if (h.tagName === 'H3') a.classList.add('h3');
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+    document.getElementById('toc-col').style.display = 'block';
+  }
+
+  // ── Main load ─────────────────────────────────────────────────────────────────
+  var params = new URLSearchParams(location.search);
+  var src = params.get('src') || 'tools/overview.md';
+  // Security: only allow relative paths within portal-docs
+  src = src.replace(/\.\.\//g, '').replace(/^\//, '');
+
+  _buildBreadcrumb(src);
+
+  fetch(src)
+    .then(function(r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status + ' — ' + src);
+      return r.text();
+    })
+    .then(function(md) {
+      var renderer = new marked.Renderer();
+      renderer.link = function(href, title, text) {
+        var resolved = _mdLinkHref(href, src);
+        var ext = href && (href.startsWith('http') || href.startsWith('//'));
+        return '<a href="' + resolved + '"' + (ext ? ' target="_blank" rel="noopener"' : '') + (title ? ' title="' + title + '"' : '') + '>' + text + '</a>';
+      };
+      // Wrap mermaid code blocks
+      renderer.code = function(code, lang) {
+        if (lang === 'mermaid') {
+          return '<div class="mermaid">' + code + '</div>';
+        }
+        var highlighted = lang && hljs.getLanguage(lang)
+          ? hljs.highlight(code, { language: lang }).value
+          : hljs.highlightAuto(code).value;
+        return '<pre><code class="hljs">' + highlighted + '</code></pre>';
+      };
+      marked.use({ renderer: renderer, breaks: false, gfm: true });
+      document.getElementById('content').innerHTML = marked.parse(md);
+      _buildToc();
+      return mermaid.run({ querySelector: '.mermaid' });
+    })
+    .catch(function(err) {
+      document.getElementById('content').innerHTML =
+        '<div class="error-msg"><strong>Could not load page</strong><br>' + err.message + '</div>' +
+        '<p style="color:var(--muted);margin-top:12px">The page <code>' + src + '</code> may not exist yet. <a href="/docs/">Return to documentation hub →</a></p>';
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
  Summary

  - Obsidian session lock — a full acquire/release/keepalive/extend lock system for the shared containerised Obsidian instance, preventing concurrent access collisions in multi-user demo mode. Includes a background cleanup task, file-based state persistence, and admin override endpoints (evict with configurable
  grace period, force unlock). On acquire, the current persona's Egeria credentials are injected directly into the Call Dr. Egeria plugin's data.json via the shared vault volume; the plugin's file-watcher picks up the change automatically.
  - Obsidian admin panel tab — new Obsidian tab in the demo admin page with live lock status, evict/force-unlock actions, reservation calendar (create/delete future reserved blocks with conflict detection), and a 50-entry audit log. Auto-polls every 15 s while a session is active.
  - Live Obsidian tile in the portal — the portal Obsidian tile now polls /api/obsidian/status every 30 s and renders one of four live states: Available (green), In Use by you (timer + extend/release), In Use by someone else (red + GitHub fallback), or Stuck. Eviction warning banner shown to current holder during
  grace period. Keepalive pings run every 60 s; session token persisted in sessionStorage across page reloads.
  - OBSIDIAN_LOCK_ENABLED flag — set to false to disable locking entirely for single-user local or freshstart deployments; tile renders a direct link with no acquire/release flow.
  - Startup stale-lock fix — in local mode, any lock left from a previous server run is cleared immediately on startup rather than waiting for the 60-second cleanup cycle.
  - portal-docs/ documentation hub — a new client-side-rendered documentation site (marked.js + mermaid.js + highlight.js) served at /docs/ on both quickstart (8085) and freshstart (8086). Covers: Egeria Explorer, Obsidian, Dr. Egeria (overview + basic + advanced templates), Egeria Advisor, Jupyter, Quickstart
  local/demo/admin guides, Obsidian session management, Coco Pharmaceuticals background, 11 personas, 5 guided demo scenarios, and Freshstart getting-started. Internal .md links stay in the viewer; auto-TOC builds from headings; dark theme matches the portal.
  - Portal UX — "Coco Web" tile replaced by "Documentation" row (three tiles: Egeria Workspaces Documentation, Egeria Documentation, JavaDocs) with its own section label. Coco Pharmaceuticals intro paragraph added above the persona picker, visible in all modes.

  Test plan

  - [ ] localhost:8085/ loads the portal; Coco intro visible above persona picker
  - [ ] Obsidian tile shows green "● Available"; clicking acquires lock and opens port 3000
  - [ ] Second browser shows red "In use by X · N min remaining" + GitHub fallback
  - [ ] Admin → Obsidian tab: status cards update, eviction countdown appears in holder's tile, force unlock clears the lock
  - [ ] Create a reservation; confirm regular users blocked within buffer window
  - [ ] Restart pyegeria-web in local mode; tile shows Available immediately (no stale lock)
  - [ ] localhost:8085/docs/ loads the hub; clicking a card renders the markdown page with Mermaid diagrams
  - [ ] OBSIDIAN_LOCK_ENABLED=false in .env → tile shows direct Open link, no acquire flow
  - [ ] localhost:8086/docs/ works on freshstart stack
