### PR TITLE
feat(tech-catalog): Glossary card, cross-navigation, endpoint fix, re…

### DIFF
--- a/CATALOG_ISSUES.md
+++ b/CATALOG_ISSUES.md
@@ -1,0 +1,107 @@
+# Tech Catalog — Issues & Lessons Learned
+
+Tracks outstanding work, known bugs, and pyegeria API lessons discovered while building The Catalog (`tech_catalog_handler.py` + `tech-catalog.html`).
+
+---
+
+## Lessons Learned — pyegeria API defaults
+
+Every `find_*` method in pyegeria has a status-list parameter that **defaults to a single active state**, silently filtering out any element that hasn't had that status explicitly set. In the Coco Pharma demo data, almost nothing has an explicit status, so everything was invisible until these were overridden to `[]`.
+
+| pyegeria method | Status param | Default | Fix applied |
+|---|---|---|---|
+| `find_infrastructure` | `deployment_status_list` | `["ACTIVE"]` | `deployment_status_list=[]` |
+| `find_data_assets` | `content_status_list` | `["ACTIVE"]` | `content_status_list=[]` |
+| `find_processes` | `activity_status_list` | `["IN_PROGRESS"]` | `activity_status_list=[]` |
+
+**Rule:** Always pass `<status_param>=[]` on any `find_*` call unless the user has explicitly requested status filtering.
+
+**Also:** All list calls now use `graph_query_depth=0` (performance); all detail calls use `graph_query_depth=3` (full property/relationship data for display).
+
+---
+
+## Lessons Learned — Endpoints
+
+`Endpoint` is NOT an Asset subtype — `AssetMaker.find_assets(metadata_element_type="Endpoint")` returns nothing. Must use `ConnectionMaker.find_endpoints()` and `ConnectionMaker.get_endpoint_by_guid()`.
+
+`ConnectionMaker.__init__` takes `server_name` (positional), not `view_server` like `AssetMaker`.
+
+---
+
+## Lessons Learned — Mermaid diagrams
+
+Two separate diagram paths exist in the detail pane:
+
+1. **`AvailableMermaidDiagrams`** — renders mermaid fields embedded in the element response (`edgeMermaidGraph`, `localLineageGraph`, etc.). These require `graph_query_depth > 0`. Now passed through by `_serialize()` via `_MERMAID_FIELDS` set. `mermaidGraph` and `anchorMermaidGraph` are intentionally excluded from this path (handled by buttons below).
+
+2. **`MermaidSection` buttons** — "Load Context Diagram" / "Load Anchored Graph" fetch from `mermaid_handler.py` via `ClassificationExplorer.get_element_by_guid` and `MetadataExpert.get_anchored_element_graph`. These are on-demand, separate from the detail fetch.
+
+**Bug fixed:** `DiagramPanel` was calling `.text()` on the JSON response and passing the raw JSON string to Mermaid.js. Fixed to `.json()` + extract `data.mermaidGraph`.
+
+**Bug fixed:** Mermaid fields were stripped by `_serialize()`. Now passed through for all `_MERMAID_FIELDS`.
+
+**Bug fixed:** Mermaid field names were appearing in the Properties table. Fixed by adding `_ALL_MERMAID_FIELDS` to `skipKeys` in `AssetDetail`.
+
+**Credentials note:** `MermaidSection` fetch URLs don't include credentials — the mermaid handler uses env var defaults. If a user authenticates with non-default credentials, diagram fetches use the wrong identity. This is a known limitation.
+
+---
+
+## Outstanding Issues
+
+### O-1: List-level mermaid graph discarded
+`find_*` calls may return a result-set-level `mermaidGraph` at the response root alongside the elements. `_safe_list()` only extracts the elements list and discards any top-level fields. If Egeria generates a diagram of all found elements, it never reaches the frontend.
+
+**Status:** Not yet fixed. Needs a live test to confirm whether the response root actually contains a mermaid graph.
+
+### O-2: `_safe_list` only handles `"items"` key
+```python
+if isinstance(raw, dict) and "items" in raw:
+    return raw["items"]
+```
+pyegeria may use `"elements"` or `"elementList"` as the list key in some response formats. If so, the handler silently returns `[]`. Needs a live response inspection to confirm.
+
+**Status:** Not yet fixed. Confirm response key with a live test.
+
+### O-3: `AvailableMermaidDiagrams` skips `mermaidGraph`
+`mermaidGraph` is in `_MERMAID_SECTION_FIELDS` and excluded from inline rendering — it's expected from the `MermaidSection` on-demand button. But `MermaidSection` re-fetches via a separate API call even when `_serialize()` already passed the embedded `mermaidGraph` through. Wasted fetch.
+
+**Fix options:**
+- (a) Pre-populate the "Context Diagram" button state from the embedded `mermaidGraph` (avoids second fetch)
+- (b) Remove `mermaidGraph` from `_MERMAID_SECTION_FIELDS` so it renders inline immediately
+
+**Status:** Not yet fixed.
+
+### O-4: `DeployedSoftwareComponent` results — needs live retest
+Added `activity_status_list=[]` — previously returned 0. Now should return connectors catalogued in the Egeria runtime.
+
+**Status:** Fixed in code, needs live test confirmation.
+
+### O-5: Data assets (DataStore / DataFeed / DataSet) — needs live retest
+Added `content_status_list=[]` — previously returned 0.
+
+**Status:** Fixed in code, needs live test confirmation.
+
+### O-6: ITInfrastructure — needs live retest
+Added `deployment_status_list=[]` — previously returned 0.
+
+**Status:** Fixed in code, needs live test confirmation.
+
+### O-7: Endpoints — needs live retest
+Switched from `AssetMaker.find_assets(metadata_element_type="Endpoint")` to `ConnectionMaker.find_endpoints()`. Previously returned wrong/empty results.
+
+**Status:** Fixed in code, needs live test confirmation.
+
+### O-8: `get_software_capability_by_guid` optimisation
+The detail pane for Software Capabilities does an O(n) scan (`find_software_capabilities(search_string="*")` then filter by GUID). `get_software_capability_by_guid(guid)` exists on `AssetMaker` in 6.0.13.6 and could replace this with a direct lookup.
+
+**Status:** Not yet implemented. Low priority (50 items is fast).
+
+### O-9: Mermaid diagram credentials not forwarded
+`MermaidSection` fetches `/api/mermaid/{guid}` without passing the user's credentials as query params. `mermaid_handler.py` falls back to env var defaults. Portal-authenticated users with non-default credentials get diagrams from the wrong identity.
+
+**Status:** Not yet fixed.
+
+### O-10: DeployedAPI mermaid diagrams
+APIs section shows no diagrams. Likely because `get_element_by_guid` (ClassificationExplorer) returns no `mermaidGraph` for `DeployedAPI` elements in Coco data. Needs live test of `/api/mermaid/{guid}` with a real API GUID to confirm data vs display issue.
+
+**Status:** Under investigation.

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/tech-catalog.html
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/tech-catalog.html
@@ -584,6 +584,7 @@ var useState    = React.useState;
 var useEffect   = React.useEffect;
 var useRef      = React.useRef;
 var useCallback = React.useCallback;
+var useMemo     = React.useMemo;
 
 // ── Session ID ────────────────────────────────────────────────────────────────
 var _SESSION_ID = (function() {
@@ -606,6 +607,74 @@ function credAppend(url, creds) {
   if (creds.userId)   p.set('user_id',  creds.userId);
   if (creds.password) p.set('user_pwd', creds.password);
   return url + '?' + p.toString();
+}
+
+// ── Markdown renderer (shared with type-explorer.html) ───────────────────────
+function _renderMdHtml(rawText) {
+  if (!rawText || !rawText.trim()) return '';
+  var esc = function(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); };
+  var inlineMarkup = function(s) { return s
+    .replace(/\*\*\*(.+?)\*\*\*/g,'<strong><em>$1</em></strong>')
+    .replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>')
+    .replace(/\*([^*\n]+?)\*/g,'<em>$1</em>')
+    .replace(/`([^`\n]+)`/g,'<code style="background:rgba(0,0,0,.06);padding:1px 4px;border-radius:3px;font-size:.9em">$1</code>'); };
+  var lines = rawText.split('\n'), parts = [], i = 0;
+  while (i < lines.length) {
+    if (i+1 < lines.length && /^\|.+\|/.test(lines[i]) && /^\|[\s\-:|]+\|/.test(lines[i+1])) {
+      var tlines = [];
+      while (i < lines.length && /^\|/.test(lines[i].trim())) { tlines.push(lines[i]); i++; }
+      var headers = tlines[0].split('|').slice(1,-1).map(function(h){return h.trim();});
+      var seps = tlines[1].split('|').slice(1,-1).map(function(s){return s.trim();});
+      var aligns = seps.map(function(s){return s.startsWith(':')&&s.endsWith(':')? 'center':s.endsWith(':')? 'right':'left';});
+      var rows = tlines.slice(2).map(function(r){return r.split('|').slice(1,-1).map(function(c){return c.trim();});});
+      var t = '<div style="overflow-x:auto;margin:8px 0"><table style="border-collapse:collapse;font-size:12px"><thead><tr>';
+      headers.forEach(function(h,j){t+='<th style="text-align:'+(aligns[j]||'left')+';padding:5px 8px;border:1px solid var(--border);color:var(--muted)">'+inlineMarkup(esc(h))+'</th>';});
+      t+='</tr></thead><tbody>';
+      rows.forEach(function(row){t+='<tr>';headers.forEach(function(_,j){t+='<td style="text-align:'+(aligns[j]||'left')+';padding:5px 8px;border:1px solid var(--border)">'+inlineMarkup(esc(row[j]||''))+'</td>';});t+='</tr>';});
+      t+='</tbody></table></div>'; parts.push(t);
+    } else {
+      var nonTable = [];
+      while (i < lines.length && !(i+1 < lines.length && /^\|.+\|/.test(lines[i]) && /^\|[\s\-:|]+\|/.test(lines[i+1]))) { nonTable.push(lines[i]); i++; }
+      if (nonTable.length > 0) parts.push(inlineMarkup(esc(nonTable.join('\n')))
+        .replace(/^### (.+)$/gm,'<b style="font-size:12px;display:block;margin:8px 0 2px;color:var(--accent)">$1</b>')
+        .replace(/^## (.+)$/gm, '<b style="font-size:13px;display:block;margin:10px 0 2px;color:var(--accent)">$1</b>')
+        .replace(/^# (.+)$/gm,  '<b style="font-size:14px;display:block;margin:12px 0 4px;color:var(--accent)">$1</b>')
+        .replace(/^[-*] (.+)$/gm,'<span style="display:block;padding-left:12px">• $1</span>')
+        .replace(/^(\d+)\. (.+)$/gm,'<span style="display:block;padding-left:12px">$1. $2</span>')
+        .replace(/\n\n/g,'<br><br>').replace(/\n/g,'<br>'));
+    }
+  }
+  return parts.join('');
+}
+function renderMd(text) {
+  if (!text || !text.trim()) return null;
+  var html = _renderMdHtml(text);
+  if (!html) return null;
+  return React.createElement('div', { dangerouslySetInnerHTML: { __html: html }, style: { lineHeight: 1.6, wordBreak: 'break-word' } });
+}
+
+// ── Resizable divider (shared with type-explorer.html) ────────────────────────
+function useResizable(initialPx, min, max) {
+  min = (min === undefined) ? 100 : min;
+  max = (max === undefined) ? 900 : max;
+  var _w = useState(initialPx), width = _w[0], setWidth = _w[1];
+  var widthRef = useRef(width);
+  widthRef.current = width;
+  var onMouseDown = useCallback(function(e) {
+    e.preventDefault();
+    var startX = e.clientX, startW = widthRef.current;
+    function onMove(mv) { setWidth(Math.max(min, Math.min(max, startW + mv.clientX - startX))); }
+    function onUp() { document.removeEventListener('mousemove', onMove); document.removeEventListener('mouseup', onUp); }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [min, max]);
+  return [width, onMouseDown];
+}
+function ResizeDivider({ onMouseDown }) {
+  return React.createElement('div', {
+    onMouseDown: onMouseDown,
+    style: { width: 5, flexShrink: 0, cursor: 'col-resize', background: 'transparent', position: 'relative' }
+  });
 }
 
 // ── SHARED — Mermaid diagram components ──────────────────────────────────────
@@ -633,8 +702,9 @@ function DiagramPanel({ fetchUrl, label, buttonLabel }) {
   function load() {
     if (visible) { setVisible(false); return; }
     setVisible(true); setLoading(true);
-    fetch(fetchUrl).then(function(r) { return r.text(); }).then(function(t) {
-      setCode(t); setLoading(false);
+    fetch(fetchUrl).then(function(r) { return r.json(); }).then(function(data) {
+      var graph = (data && data.mermaidGraph) ? data.mermaidGraph : '';
+      setCode(graph); setLoading(false);
     }).catch(function(e) { setErrMsg(String(e)); setLoading(false); });
   }
   return React.createElement('div', { style: { margin: '6px 0' } },
@@ -645,7 +715,8 @@ function DiagramPanel({ fetchUrl, label, buttonLabel }) {
     }, visible ? '▾ Hide ' + label : (buttonLabel || '▦ Load ' + label)),
     visible && loading && React.createElement('div', { style: { fontSize: 11, color: 'var(--dim)', padding: 8 } }, 'Loading diagram…'),
     visible && errMsg  && React.createElement('div', { style: { fontSize: 11, color: '#f87171', padding: 8 } }, errMsg),
-    visible && !loading && code && React.createElement(MermaidDiagram, { code: code })
+    visible && !loading && code && React.createElement(MermaidDiagram, { code: code }),
+    visible && !loading && !code && !errMsg && React.createElement('div', { style: { fontSize: 11, color: 'var(--dim)', padding: 8 } }, 'No diagram available for this element.')
   );
 }
 
@@ -875,12 +946,394 @@ function SidebarDetail({ items, loading, error, selected, onSelect, renderDetail
   );
 }
 
+// ── Glossary components (ported from type-explorer.html) ─────────────────────
+
+var _glsItemStyle    = { display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px', fontSize: 12, cursor: 'pointer', borderLeft: '2px solid transparent', userSelect: 'none' };
+var _glsItemSelStyle = Object.assign({}, _glsItemStyle, { background: 'rgba(96,165,250,.1)', borderLeftColor: 'var(--accent)', color: 'var(--text)' });
+var _glsBadge        = { display: 'inline-block', fontSize: 10, fontWeight: 600, padding: '1px 7px', borderRadius: 10, border: '0.5px solid rgba(96,165,250,.3)', background: 'rgba(96,165,250,.1)', color: 'var(--accent)' };
+
+function GlossaryFolderDetail({ folder }) {
+  if (!folder) return null;
+  var fields = [['Qualified Name', folder.qualifiedName],['Type', folder.typeName],['Status', folder.status],['Description', folder.description]].filter(function(r){return r[1]&&String(r[1]).trim();});
+  var sHdr = { fontSize: 11, fontWeight: 700, letterSpacing: '0.07em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 8, marginTop: 20 };
+  return React.createElement('div', { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 } },
+      React.createElement('div', { style: { fontSize: 18, fontWeight: 700, color: 'var(--text)' } }, folder.displayName || folder.qualifiedName),
+      React.createElement('span', { style: _glsBadge }, 'Folder')
+    ),
+    React.createElement('code', { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 16 } }, folder.guid),
+    folder.description && React.createElement('p', { style: { fontSize: 13, lineHeight: 1.6, marginBottom: 16, color: 'var(--muted)' } }, folder.description),
+    fields.length > 0 && React.createElement('div', null,
+      React.createElement('div', { style: sHdr }, 'Properties'),
+      React.createElement('table', { style: { width: '100%', borderCollapse: 'collapse', fontSize: 12 } },
+        React.createElement('tbody', null,
+          fields.map(function(r) { return React.createElement('tr', { key: r[0], style: { borderTop: '1px solid var(--border)' } },
+            React.createElement('td', { style: { padding: '5px 12px 5px 0', color: 'var(--dim)', width: 140, verticalAlign: 'top', whiteSpace: 'nowrap' } }, r[0]),
+            React.createElement('td', { style: { padding: '5px 0', color: 'var(--text)', wordBreak: 'break-word' } }, r[1])); })
+        )
+      )
+    )
+  );
+}
+
+function GlossaryDetail({ glossary }) {
+  if (!glossary) return null;
+  var sHdr   = { fontSize: 11, fontWeight: 700, letterSpacing: '0.07em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 8, marginTop: 20 };
+  var fields = [['Qualified Name', glossary.qualifiedName],['Language', glossary.language],['Usage', glossary.usage],['Status', glossary.status]].filter(function(r){return r[1];});
+  return React.createElement('div', { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 } },
+      React.createElement('h2', { style: { fontSize: 18, fontWeight: 700, margin: 0, color: 'var(--text)', flex: 1 } }, glossary.displayName || glossary.qualifiedName || glossary.guid),
+      React.createElement('span', { style: _glsBadge }, 'Glossary')
+    ),
+    glossary.description && React.createElement('p', { style: { fontSize: 13, color: 'var(--muted)', lineHeight: 1.6, margin: '0 0 16px' } }, glossary.description),
+    fields.length > 0 && React.createElement('div', null,
+      React.createElement('div', { style: sHdr }, 'Properties'),
+      React.createElement('table', { style: { width: '100%', borderCollapse: 'collapse', fontSize: 12 } },
+        React.createElement('tbody', null,
+          fields.map(function(r) { return React.createElement('tr', { key: r[0], style: { borderTop: '1px solid var(--border)' } },
+            React.createElement('td', { style: { padding: '5px 12px 5px 0', color: 'var(--dim)', width: 140, verticalAlign: 'top' } }, r[0]),
+            React.createElement('td', { style: { padding: '5px 0', color: 'var(--text)' } }, r[1])); })
+        )
+      )
+    ),
+    React.createElement(MermaidSection, { guid: glossary.guid })
+  );
+}
+
+function GlossaryTermDetail({ term, onNavigateToTerm }) {
+  if (!term) return null;
+  var sHdr   = { fontSize: 11, fontWeight: 700, letterSpacing: '0.07em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 8, marginTop: 20 };
+  var fields = [['Qualified Name', term.qualifiedName],['Abbreviation', term.abbreviation],['Summary', term.summary],['Examples', term.examples],['Usage', term.usage],['Status', term.status],['Content Status', term.contentStatus],['Activity Status', term.activityStatus]].filter(function(r){return r[1]&&r[1].trim();});
+  var folderList = term.folders || [];
+  var relGroups  = Object.entries(term.relationships || {}).filter(function(e) { return e[1].length > 0; });
+  var relBtnStyle = { fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid rgba(96,165,250,.4)', background: 'rgba(96,165,250,.08)', color: 'var(--accent)', cursor: 'pointer' };
+  return React.createElement('div', { style: { padding: '20px 24px', overflowY: 'auto', height: '100%' } },
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' } },
+      React.createElement('div', { style: { fontSize: 18, fontWeight: 700, color: 'var(--text)' } }, term.displayName),
+      term.isTemplateSubstitute && React.createElement('span', { style: Object.assign({}, _glsBadge, { background: 'rgba(245,158,11,.15)', color: '#fbbf24', border: '0.5px solid rgba(245,158,11,.4)' }) }, 'Template Substitute'),
+      React.createElement('div', { style: { marginLeft: 'auto' } }, React.createElement(EgeriaFeedbackWidget, { guid: term.guid }))
+    ),
+    React.createElement('code', { style: { fontSize: 11, color: 'var(--dim)', display: 'block', marginBottom: 4 } }, term.guid),
+    folderList.length > 0 && React.createElement('div', { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8, marginTop: 6 } },
+      React.createElement('span', { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, 'Folders:'),
+      folderList.map(function(f) { return React.createElement('span', { key: f.guid, style: Object.assign({}, _glsBadge, { background: 'rgba(99,102,241,.1)', color: '#818cf8', border: '0.5px solid rgba(99,102,241,.25)' }) }, f.displayName || f.guid); })
+    ),
+    (term.classifications || []).length > 0 && React.createElement('div', { style: { display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 12 } },
+      React.createElement('span', { style: { fontSize: 11, color: 'var(--dim)', marginRight: 4 } }, 'Classifications:'),
+      term.classifications.map(function(c) { return React.createElement('span', { key: c.typeName, style: Object.assign({}, _glsBadge, { background: 'rgba(168,85,247,.1)', color: '#c084fc', border: '0.5px solid rgba(168,85,247,.25)' }) }, c.typeName); })
+    ),
+    term.description && React.createElement('div', { style: { fontSize: 13, marginBottom: 16, color: 'var(--text)' } }, renderMd(term.description)),
+    React.createElement(MermaidSection, { guid: term.guid }),
+    fields.length > 0 && React.createElement('div', null,
+      React.createElement('div', { style: sHdr }, 'Properties'),
+      React.createElement('table', { style: { width: '100%', borderCollapse: 'collapse', fontSize: 12 } },
+        React.createElement('tbody', null,
+          fields.map(function(r) { return React.createElement('tr', { key: r[0], style: { borderTop: '1px solid var(--border)' } },
+            React.createElement('td', { style: { padding: '5px 12px 5px 0', color: 'var(--dim)', width: 140, verticalAlign: 'top' } }, r[0]),
+            React.createElement('td', { style: { padding: '5px 0', color: 'var(--text)' } }, renderMd(r[1]))); })
+        )
+      )
+    ),
+    relGroups.length > 0 && React.createElement('div', { style: { marginTop: 16, paddingTop: 12, borderTop: '1px solid var(--border)' } },
+      React.createElement('div', { style: sHdr }, 'Relationships'),
+      relGroups.map(function(entry) {
+        var label = entry[0], items = entry[1];
+        return React.createElement('div', { key: label, style: { marginBottom: 12 } },
+          React.createElement('div', { style: { fontSize: 11, color: 'var(--muted)', fontWeight: 600, marginBottom: 4 } }, label),
+          items.map(function(item) {
+            var isTerm = !item.typeName || item.typeName === 'GlossaryTerm';
+            return React.createElement('div', { key: item.guid, style: { display: 'flex', alignItems: 'center', gap: 6, padding: '3px 0', borderTop: '1px solid var(--border)' } },
+              React.createElement('span', { style: { flex: 1, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }, title: item.qualifiedName || item.guid }, item.displayName || item.qualifiedName || item.guid),
+              item.typeName && !isTerm && React.createElement('span', { style: { fontSize: 10, color: 'var(--dim)', flexShrink: 0 } }, item.typeName),
+              isTerm && onNavigateToTerm && React.createElement('button', { onClick: function() { onNavigateToTerm(item.guid); }, style: relBtnStyle }, 'View →')
+            );
+          })
+        );
+      })
+    ),
+    React.createElement(EgeriaCommentsSection, { guid: term.guid })
+  );
+}
+
+function GlossaryView({ creds }) {
+  var _sideW = useResizable(220), sideW = _sideW[0], onDivDown = _sideW[1];
+  var _gs = useState('loading'), glossaryState = _gs[0], setGlossaryState = _gs[1];
+  var _ga = useState(0),         glossaryAttempt = _ga[0], setGlossaryAttempt = _ga[1];
+  var _gl = useState([]),         glossaries = _gl[0], setGlossaries = _gl[1];
+  var _sg = useState(null),       selectedGlossary = _sg[0], setSelectedGlossary = _sg[1];
+  var _fs = useState([]),         folderStack = _fs[0], setFolderStack = _fs[1];
+  var _fo = useState([]),         folders = _fo[0], setFolders = _fo[1];
+  var _te = useState([]),         terms = _te[0], setTerms = _te[1];
+  var _ss = useState('idle'),     scopeState = _ss[0], setScopeState = _ss[1];
+  var _se = useState(''),         scopeError = _se[0], setScopeError = _se[1];
+  var _sq = useState(''),         searchQuery = _sq[0], setSearchQuery = _sq[1];
+  var _si = useState(''),         searchInputValue = _si[0], setSearchInputValue = _si[1];
+  var _st = useState([]),         searchTerms = _st[0], setSearchTerms = _st[1];
+  var _ss2 = useState('idle'),    searchState = _ss2[0], setSearchState = _ss2[1];
+  var _se2 = useState(''),        searchError = _se2[0], setSearchError = _se2[1];
+  var _sel = useState(null),      selectedItem = _sel[0], setSelectedItem = _sel[1];
+  var _td = useState(null),       termDetail = _td[0], setTermDetail = _td[1];
+  var _tds = useState('idle'),    termDetailState = _tds[0], setTermDetailState = _tds[1];
+  var _ft = useState(''),         filterText = _ft[0], setFilterText = _ft[1];
+  var _sht = useState(false),     showTemplates = _sht[0], setShowTemplates = _sht[1];
+  var _ge = useState(''),         glossaryError = _ge[0], setGlossaryError = _ge[1];
+
+  // Load glossary list
+  useEffect(function() {
+    setGlossaryState('loading'); setGlossaryError('');
+    fetch(credAppend('/api/glossary', creds))
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function(data) {
+        var list = (data.glossaries || []).slice().sort(function(a,b){return (a.displayName||'').localeCompare(b.displayName||'');});
+        setGlossaries(list); setGlossaryState('ready');
+        if (list.length > 0) setSelectedGlossary(list[0].guid);
+      })
+      .catch(function(err) { setGlossaryError(err.message); setGlossaryState('error'); });
+  }, [glossaryAttempt]);
+
+  var currentScopeGuid = useMemo(function() {
+    if (!selectedGlossary) return null;
+    return folderStack.length > 0 ? folderStack[folderStack.length - 1].guid : selectedGlossary;
+  }, [selectedGlossary, folderStack]);
+
+  // Load folders + terms for current scope
+  useEffect(function() {
+    if (!currentScopeGuid) return;
+    setScopeState('loading'); setScopeError(''); setFolders([]); setTerms([]);
+    setSelectedItem(null); setTermDetail(null); setTermDetailState('idle'); setFilterText('');
+    Promise.all([
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/folders', creds)).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();}),
+      fetch(credAppend('/api/glossary/' + encodeURIComponent(currentScopeGuid) + '/terms',   creds)).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+    ])
+    .then(function(res) { setFolders(res[0].folders||[]); setTerms(res[1].terms||[]); setScopeState('ready'); })
+    .catch(function(err){ setScopeError(err.message); setScopeState('error'); });
+  }, [currentScopeGuid]);
+
+  var runSearch = useCallback(function(q) {
+    var sq = (q||'').trim() || '*';
+    setSearchQuery(sq); setSearchInputValue(sq === '*' ? '' : sq);
+    setSearchState('loading'); setSearchError(''); setSearchTerms([]); setSelectedItem(null); setTermDetail(null); setTermDetailState('idle');
+    fetch(credAppend('/api/glossary-terms?q=' + encodeURIComponent(sq), creds))
+      .then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+      .then(function(data){setSearchTerms(data.terms||[]);setSearchState('ready');})
+      .catch(function(err){setSearchError(err.message);setSearchState('idle');});
+  }, []);
+
+  var openFolder = useCallback(function(folder){ setFolderStack(function(s){return s.concat([{guid:folder.guid,displayName:folder.displayName}]);}); }, []);
+  var navigateTo = useCallback(function(idx){ if(idx<0){setFolderStack([]);}else{setFolderStack(function(s){return s.slice(0,idx+1);});} }, []);
+  var navigateToTerm = useCallback(function(guid){ setSelectedItem(guid); }, []);
+
+  var isSearchMode = selectedGlossary === null;
+
+  var filteredTerms = useMemo(function() {
+    var q = filterText.trim().toLowerCase();
+    return terms.filter(function(t){
+      if (!showTemplates && t.isTemplateSubstitute) return false;
+      if (!q) return true;
+      return (t.displayName||'').toLowerCase().includes(q)||(t.description||'').toLowerCase().includes(q)||(t.abbreviation||'').toLowerCase().includes(q);
+    }).slice().sort(function(a,b){return (a.displayName||'').localeCompare(b.displayName||'');});
+  }, [terms, filterText, showTemplates]);
+
+  var templateTermCount = useMemo(function(){ return terms.filter(function(t){return t.isTemplateSubstitute;}).length; }, [terms]);
+
+  var filteredSearchTerms = useMemo(function() {
+    var q = filterText.trim().toLowerCase();
+    return searchTerms.filter(function(t){
+      if (!showTemplates && t.isTemplateSubstitute) return false;
+      if (!q) return true;
+      return (t.displayName||'').toLowerCase().includes(q)||(t.description||'').toLowerCase().includes(q);
+    }).slice().sort(function(a,b){return (a.displayName||'').localeCompare(b.displayName||'');});
+  }, [searchTerms, filterText, showTemplates]);
+
+  // Lazy-fetch full term detail when a term is selected
+  useEffect(function() {
+    if (!selectedItem) { setTermDetail(null); setTermDetailState('idle'); return; }
+    if (folders.find(function(f){return f.guid===selectedItem;})) { setTermDetail(null); setTermDetailState('idle'); return; }
+    setTermDetail(null); setTermDetailState('loading');
+    fetch(credAppend('/api/glossary/term/' + encodeURIComponent(selectedItem), creds))
+      .then(function(r){return r.ok?r.json():null;})
+      .then(function(data){setTermDetail(data||null);setTermDetailState(data?'ready':'error');})
+      .catch(function(){setTermDetailState('error');});
+  }, [selectedItem, folders]);
+
+  var selectedObj = useMemo(function() {
+    var pool = isSearchMode ? filteredSearchTerms : folders.map(function(f){return Object.assign({},f,{isFolder:true});}).concat(filteredTerms);
+    return selectedItem ? (pool.find(function(x){return x.guid===selectedItem;})||null) : null;
+  }, [selectedItem, isSearchMode, filteredSearchTerms, folders, filteredTerms]);
+
+  var selectedGlossaryName = selectedGlossary ? ((glossaries.find(function(g){return g.guid===selectedGlossary;})||{}).displayName||'') : '';
+  var middleLoading = isSearchMode ? searchState==='loading' : scopeState==='loading';
+  var middleError   = isSearchMode ? searchError : scopeError;
+  var templateHidden = !showTemplates && templateTermCount > 0 ? ' · ' + templateTermCount + ' template' + (templateTermCount!==1?'s':'')+' hidden' : '';
+  var middleCounts  = isSearchMode
+    ? 'Terms (' + filteredSearchTerms.length + (filteredSearchTerms.length!==searchTerms.length?'/'+searchTerms.length:'') + ')' + (searchTerms.length>=200?' ⚠ first 200 shown':'')
+    : (scopeState==='loading' ? 'Loading…' : folders.length+' folder'+(folders.length!==1?'s':'')+', '+filteredTerms.length+(filteredTerms.length!==(terms.length-templateTermCount)?'/'+(terms.length-templateTermCount):'')+' term'+((terms.length-templateTermCount)!==1?'s':'')+templateHidden+(terms.length>=500?' ⚠ first 500 shown':''));
+
+  var sidebarStyle  = { width: sideW, flexShrink: 0, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--panel)' };
+  var treeScrollSt  = { flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '4px 0' };
+  var mainStyle     = { flex: 1, overflowY: 'auto', background: 'var(--bg)' };
+
+  function treeItemSt(active) { return active ? _glsItemSelStyle : _glsItemStyle; }
+
+  if (glossaryState==='loading') return React.createElement('div', {style:{flex:1,display:'flex',alignItems:'center',justifyContent:'center',color:'var(--muted)'}}, 'Loading glossaries…');
+  if (glossaryState==='error')   return React.createElement('div', {style:{flex:1,display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',gap:12,color:'var(--muted)'}},
+    React.createElement('div', null, 'Error: ' + glossaryError),
+    React.createElement('button', {style:{fontSize:12,padding:'4px 12px',borderRadius:4,border:'1px solid var(--border)',background:'transparent',color:'var(--accent)',cursor:'pointer'},onClick:function(){setGlossaryAttempt(function(a){return a+1;});}}, 'Retry')
+  );
+
+  return React.createElement('div', { style: { display: 'flex', flex: 1, overflow: 'hidden' } },
+    // Left: glossary list
+    React.createElement('div', { style: sidebarStyle },
+      React.createElement('div', { style: { padding: '8px 10px', fontWeight: 700, fontSize: 11, color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '0.06em', borderBottom: '1px solid var(--border)' } }, 'Glossaries (' + glossaries.length + ')'),
+      React.createElement('div', { style: treeScrollSt },
+        React.createElement('div', { style: treeItemSt(isSearchMode), onClick: function(){setSelectedGlossary(null);setFolderStack([]);runSearch('*');}, title: 'Search terms across all glossaries' },
+          React.createElement('span', { style: { fontStyle: 'italic', color: 'var(--dim)', fontSize: 12 } }, 'All Terms (search)')
+        ),
+        glossaries.map(function(g) {
+          return React.createElement('div', { key: g.guid, style: treeItemSt(selectedGlossary===g.guid), onClick: function(){setSelectedGlossary(g.guid);setFolderStack([]);}, title: g.description||g.qualifiedName },
+            React.createElement('span', { style: { fontSize: 12, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, g.displayName||g.qualifiedName||g.guid)
+          );
+        })
+      )
+    ),
+    React.createElement(ResizeDivider, { onMouseDown: onDivDown }),
+    // Middle: folders + terms / search results
+    React.createElement('div', { style: { width: 280, flexShrink: 0, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column', overflow: 'hidden' } },
+      React.createElement('div', { style: { padding: '8px 10px', borderBottom: '1px solid var(--border)', display: 'flex', flexDirection: 'column', gap: 5 } },
+        // Breadcrumb
+        !isSearchMode && React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', fontSize: 11 } },
+          React.createElement('span', { style: { cursor: 'pointer', color: folderStack.length>0?'var(--accent)':'var(--dim)', fontWeight: 600 }, onClick: function(){navigateTo(-1);} }, selectedGlossaryName||'Glossary'),
+          folderStack.map(function(f,i) { return [
+            React.createElement('span', { key: 'sep'+i, style: { color: 'var(--dim)' } }, '›'),
+            React.createElement('span', { key: 'f'+i, style: { cursor: 'pointer', color: i===folderStack.length-1?'var(--dim)':'var(--accent)', fontWeight: i===folderStack.length-1?600:400 }, onClick: function(){navigateTo(i);} }, f.displayName)
+          ]; })
+        ),
+        React.createElement('div', { style: { fontWeight: 600, fontSize: 11, color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '0.05em' } }, middleCounts),
+        isSearchMode
+          ? React.createElement('form', { onSubmit: function(e){e.preventDefault();runSearch(searchInputValue);}, style: { display: 'flex', gap: 4 } },
+              React.createElement('input', { type: 'text', placeholder: 'Search all terms…', value: searchInputValue, onChange: function(e){setSearchInputValue(e.target.value);}, style: { flex: 1, fontSize: 12, padding: '3px 7px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit' } }),
+              React.createElement('button', { type: 'submit', style: { padding: '3px 8px', borderRadius: 4, border: '1px solid var(--border)', background: 'transparent', color: 'inherit', cursor: 'pointer', fontSize: 12 } }, 'Go')
+            )
+          : React.createElement('input', { type: 'search', placeholder: 'Filter terms…', value: filterText, onChange: function(e){setFilterText(e.target.value);}, style: { width: '100%', boxSizing: 'border-box', fontSize: 12, padding: '3px 7px', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg)', color: 'inherit' } }),
+        React.createElement('label', { style: { display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, color: 'var(--dim)', cursor: 'pointer', userSelect: 'none' } },
+          React.createElement('input', { type: 'checkbox', checked: showTemplates, onChange: function(e){setShowTemplates(e.target.checked);}, style: { margin: 0, cursor: 'pointer' } }),
+          'Show template substitutes'
+        )
+      ),
+      middleError && React.createElement('div', { style: { padding: 10, color: 'var(--muted)', fontSize: 12 } }, 'Error: ' + middleError),
+      React.createElement('div', { style: treeScrollSt },
+        isSearchMode
+          ? filteredSearchTerms.map(function(t) {
+              return React.createElement('div', { key: t.guid, style: treeItemSt(selectedItem===t.guid), onClick: function(){setSelectedItem(t.guid);}, title: t.qualifiedName||t.guid },
+                React.createElement('div', { style: { flex: 1, minWidth: 0 } },
+                  React.createElement('div', { style: { fontSize: 12, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, t.displayName||t.qualifiedName||t.guid),
+                  t.qualifiedName && React.createElement('div', { style: { fontSize: 10, color: 'var(--dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, t.qualifiedName)
+                )
+              );
+            })
+          : [
+              folders.map(function(f) {
+                return React.createElement('div', { key: f.guid, style: Object.assign({}, treeItemSt(selectedItem===f.guid), { cursor: 'pointer' }), title: f.description||f.qualifiedName },
+                  React.createElement('span', { style: { fontSize: 12, cursor: 'pointer', color: 'var(--dim)' }, onClick: function(){openFolder(f);} }, '📁'),
+                  React.createElement('span', { style: { flex: 1, fontSize: 12, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }, onClick: function(){setSelectedItem(f.guid);} }, f.displayName||f.qualifiedName||f.guid),
+                  React.createElement('span', { style: { fontSize: 16, padding: '0 4px', cursor: 'pointer', color: 'var(--accent)', lineHeight: 1 }, title: 'Open folder', onClick: function(){openFolder(f);} }, '›')
+                );
+              }),
+              filteredTerms.map(function(t) {
+                return React.createElement('div', { key: t.guid, style: treeItemSt(selectedItem===t.guid), onClick: function(){setSelectedItem(t.guid);}, title: t.qualifiedName||t.guid },
+                  React.createElement('div', { style: { flex: 1, minWidth: 0 } },
+                    React.createElement('div', { style: { fontSize: 12, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, t.displayName||t.qualifiedName||t.guid),
+                    t.qualifiedName && React.createElement('div', { style: { fontSize: 10, color: 'var(--dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } }, t.qualifiedName)
+                  )
+                );
+              })
+            ]
+      )
+    ),
+    // Right: detail
+    React.createElement('div', { style: mainStyle },
+      selectedObj && selectedObj.isFolder
+        ? React.createElement(GlossaryFolderDetail, { folder: selectedObj })
+        : termDetailState==='loading'
+          ? React.createElement('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--muted)', fontSize: 13 } }, 'Loading term…')
+          : termDetail
+            ? React.createElement(GlossaryTermDetail, { term: termDetail, onNavigateToTerm: navigateToTerm })
+            : !isSearchMode && selectedGlossary && !selectedItem
+              ? React.createElement(GlossaryDetail, { glossary: glossaries.find(function(g){return g.guid===selectedGlossary;})||null })
+              : React.createElement('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--dim)', fontSize: 13 } },
+                  middleLoading ? 'Loading…' : 'Select a term or folder to view details'
+                )
+    )
+  );
+}
+
+// ── Type → section/tab mapping for cross-navigation ──────────────────────────
+// Maps an Egeria typeName to the catalog section+tab that hosts it.
+// Subtypes not listed here won't get a "View →" button in the Relationships panel.
+var TYPE_TO_NAV = (function() {
+  var m = {};
+  // ITInfrastructure hierarchy
+  ['ITInfrastructure','SoftwareServer','SoftwareServerPlatform','Host',
+   'VirtualMachine','VirtualContainer','DockerContainer','HostCluster',
+   'BareMetalComputer','OperatingPlatform','StorageArray','StorageVolume',
+   'StorageVolumePair','SwitchFabric','NetworkGateway'].forEach(function(t) {
+    m[t] = { section: 'infrastructure', tab: 'infrastructure' };
+  });
+  // SoftwareCapability hierarchy
+  ['SoftwareCapability','APIManager','EventBroker','DatabaseManager','MetadataServer',
+   'GovernanceEngine','DataProcessingEngine','DataStoreManager','FileSystem',
+   'NetworkGateway','EnterpriseAccessLayer','CohortMember','CloudService',
+   'ContentManager','DirectoryService','InformationView','FormManager',
+   'RelationalDatabaseManager','WorkflowEngine','ReportingEngine',
+   'AnalyticsEngine','DataQualityEngine','MasterDataManager',
+   'NotificationManager','SearchEngine','GovernanceProgram',
+   'SecurityManager','AuthorizationManager','ReferenceDataManager',
+   'DigitalServiceManager'].forEach(function(t) {
+    m[t] = { section: 'infrastructure', tab: 'software-capabilities' };
+  });
+  // Endpoints
+  ['Endpoint'].forEach(function(t) {
+    m[t] = { section: 'infrastructure', tab: 'endpoints' };
+  });
+  // DataStore hierarchy
+  ['DataStore','Database','RelationalDatabase','ObjectStore','DocumentStore',
+   'GraphStore','DataFile','CSVFile','SpreadsheetFile','MediaFile','MediaCollection',
+   'DataFolder','FileFolder','DataObjectStore','KeyValueStore','GraphDatabase',
+   'DocumentDatabase','RelationalDatabaseSchema','DataStoreEncoding'].forEach(function(t) {
+    m[t] = { section: 'data-assets', tab: 'data-stores' };
+  });
+  // DataFeed hierarchy
+  ['DataFeed','Topic','KafkaTopic','SubscriberList','EventType','EventSet'].forEach(function(t) {
+    m[t] = { section: 'data-assets', tab: 'data-feeds' };
+  });
+  // DataSet hierarchy
+  ['DataSet','VirtualRelationalTable','DataCatalog','DataDesignArtifact',
+   'DataTable','DataSchemaAttribute'].forEach(function(t) {
+    m[t] = { section: 'data-assets', tab: 'data-sets' };
+  });
+  // APIs
+  ['DeployedAPI','APIOperation','APISchemaType'].forEach(function(t) {
+    m[t] = { section: 'apis', tab: 'apis' };
+  });
+  // Processes / software components
+  ['DeployedSoftwareComponent','DataMovementEngine','DataVirtualizationEngine',
+   'AnalyticsComponent','ReportingComponent','DashboardComponent',
+   'MLModel','MLModelDeployment'].forEach(function(t) {
+    m[t] = { section: 'processes', tab: 'software-components' };
+  });
+  // Glossary
+  ['GlossaryTerm','Glossary','GlossaryCategory'].forEach(function(t) {
+    m[t] = { section: 'glossary', tab: 'glossary' };
+  });
+  return m;
+}());
+
 // ── Generic detail panel ──────────────────────────────────────────────────────
-function AssetDetail({ item, detailLoading }) {
+function AssetDetail({ item, detailLoading, onNavigate }) {
   if (!item) return null;
   var sectionHdr = { fontSize: 11, fontWeight: 700, letterSpacing: '0.07em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 8, marginTop: 20 };
   var cardStyle  = { background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 6, padding: '8px 12px', marginBottom: 6 };
-  var skipKeys   = new Set(['guid','typeName','displayName','qualifiedName','description','classifications','relationships']);
+  var skipKeys   = new Set(['guid','typeName','displayName','qualifiedName','description','classifications','relationships'].concat(_ALL_MERMAID_FIELDS));
   var extraProps = Object.entries(item).filter(function(e) {
     return !skipKeys.has(e[0]) && e[1] && typeof e[1] === 'string';
   });
@@ -926,17 +1379,36 @@ function AssetDetail({ item, detailLoading }) {
       })
     ),
 
+    // Mermaid diagrams — between Properties and Relationships
+    React.createElement(AvailableMermaidDiagrams, { data: item }),
+    React.createElement(MermaidSection, { guid: item.guid }),
+
     // Relationships
     rels.length > 0 && React.createElement('div', null,
       React.createElement('div', { style: sectionHdr }, 'Relationships'),
       rels.map(function(r, i) {
         var el = r.relatedElement || {};
         var relProps = Object.entries(r.relationshipProperties || {});
+        // Resolve nav target: try exact typeName first, then walk superTypes
+        var nav = null;
+        if (el.guid) {
+          nav = el.typeName ? TYPE_TO_NAV[el.typeName] : null;
+          if (!nav && el.superTypes) {
+            for (var si = 0; si < el.superTypes.length; si++) {
+              nav = TYPE_TO_NAV[el.superTypes[si]];
+              if (nav) break;
+            }
+          }
+        }
         return React.createElement('div', { key: i, style: Object.assign({}, cardStyle, { borderLeft: '3px solid var(--rel)' }) },
           React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: relProps.length ? 4 : 0 } },
             React.createElement('span', { style: { fontSize: 10, fontWeight: 700, color: 'var(--rel)', letterSpacing: '0.05em' } }, r.relationshipType),
-            React.createElement('span', { style: { fontSize: 12, color: 'var(--text)' } }, el.displayName || el.guid || ''),
-            el.typeName && React.createElement('span', { style: { fontSize: 10, color: 'var(--dim)' } }, '· ' + el.typeName)
+            React.createElement('span', { style: { fontSize: 12, color: 'var(--text)', flex: 1 } }, el.displayName || el.guid || ''),
+            el.typeName && React.createElement('span', { style: { fontSize: 10, color: 'var(--dim)' } }, '· ' + el.typeName),
+            nav && onNavigate && React.createElement('button', {
+              onClick: function() { onNavigate({ guid: el.guid, section: nav.section, tab: nav.tab, displayName: el.displayName || el.guid }); },
+              style: { fontSize: 10, padding: '2px 7px', borderRadius: 4, border: '1px solid rgba(96,165,250,.4)', background: 'rgba(96,165,250,.08)', color: 'var(--accent)', cursor: 'pointer', flexShrink: 0 }
+            }, 'View →')
           ),
           el.description && React.createElement('div', { style: { fontSize: 11, color: 'var(--muted)', marginBottom: relProps.length ? 4 : 0 } }, el.description),
           relProps.map(function(e) {
@@ -947,17 +1419,13 @@ function AssetDetail({ item, detailLoading }) {
       })
     ),
 
-    // Mermaid diagrams
-    React.createElement(AvailableMermaidDiagrams, { data: item }),
-    React.createElement(MermaidSection, { guid: item.guid }),
-
     // Comments
     React.createElement(EgeriaCommentsSection, { guid: item.guid })
   );
 }
 
 // ── Generic tab view ──────────────────────────────────────────────────────────
-function AssetTabView({ endpoint, sectionId, creds }) {
+function AssetTabView({ endpoint, sectionId, creds, navTarget, onNavigate }) {
   var _items      = useState([]),    items      = _items[0],      setItems      = _items[1];
   var _loading    = useState(true),  loading    = _loading[0],    setLoading    = _loading[1];
   var _error      = useState(''),    error      = _error[0],      setError      = _error[1];
@@ -987,6 +1455,15 @@ function AssetTabView({ endpoint, sectionId, creds }) {
       .catch(function() { setDetailLoad(false); }); // fall back to summary on error
   }
 
+  // Cross-navigation: when a navTarget arrives for this tab, fetch its detail directly
+  var _lastNavGuid = useRef(null);
+  useEffect(function() {
+    if (!navTarget || !navTarget.guid) return;
+    if (navTarget.guid === _lastNavGuid.current) return; // already handled
+    _lastNavGuid.current = navTarget.guid;
+    handleSelect({ guid: navTarget.guid, displayName: navTarget.displayName || navTarget.guid });
+  }, [navTarget]);
+
   var filtered = items.filter(function(item) {
     var matchQ = !q.trim() || (item.displayName || item.qualifiedName || '').toLowerCase().includes(q.trim().toLowerCase());
     var matchT = typeFilter === 'all' || item.deployedImplementationType === typeFilter || item.typeName === typeFilter;
@@ -1009,7 +1486,7 @@ function AssetTabView({ endpoint, sectionId, creds }) {
   return React.createElement(SidebarDetail, {
     items: filtered, loading: loading, error: error, selected: selected, onSelect: handleSelect,
     filterBar: filterBar,
-    renderDetail: function() { return React.createElement(AssetDetail, { item: detail, detailLoading: detailLoad }); },
+    renderDetail: function() { return React.createElement(AssetDetail, { item: detail, detailLoading: detailLoad, onNavigate: onNavigate }); },
   });
 }
 
@@ -1035,9 +1512,22 @@ var SECTION_TABS = {
   ],
 };
 
-function SectionView({ sectionId, creds }) {
+function SectionView({ sectionId, creds, navTarget, onNavigate }) {
+  if (sectionId === 'glossary') {
+    return React.createElement('div', { style: { display: 'flex', flex: 1, overflow: 'hidden' } },
+      React.createElement(GlossaryView, { creds: creds })
+    );
+  }
   var tabs = SECTION_TABS[sectionId] || [];
   var _tab = useState(tabs[0] ? tabs[0].id : ''), activeTab = _tab[0], setActiveTab = _tab[1];
+
+  // When a cross-nav target arrives for this section, switch to the right sub-tab
+  useEffect(function() {
+    if (navTarget && navTarget.section === sectionId && navTarget.tab) {
+      setActiveTab(navTarget.tab);
+    }
+  }, [navTarget]);
+
   var currentTab = tabs.find(function(t) { return t.id === activeTab; }) || tabs[0];
   return React.createElement('div', { style: { display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' } },
     // Sub-tab bar
@@ -1050,12 +1540,20 @@ function SectionView({ sectionId, creds }) {
           t.label);
       })
     ),
-    currentTab && React.createElement(AssetTabView, { key: currentTab.id, endpoint: currentTab.endpoint, sectionId: currentTab.id, creds: creds })
+    currentTab && React.createElement(AssetTabView, {
+      key: currentTab.id,
+      endpoint: currentTab.endpoint,
+      sectionId: currentTab.id,
+      creds: creds,
+      navTarget: navTarget && navTarget.section === sectionId && navTarget.tab === currentTab.id ? navTarget : null,
+      onNavigate: onNavigate,
+    })
   );
 }
 
 // ── Splash / top-level tile selector ─────────────────────────────────────────
 var SECTIONS = [
+  { id: 'glossary',       icon: '📖', label: 'Glossary',               desc: 'Browse glossaries, categories, and terms.' },
   { id: 'infrastructure', icon: '🖧', label: 'Infrastructure Assets', desc: 'Servers, storage, networks, software capabilities, and endpoints.' },
   { id: 'data-assets',    icon: '🗄️', label: 'Data Assets',          desc: 'Data stores, data feeds, and data sets.' },
   { id: 'apis',           icon: '🔗', label: 'APIs',                   desc: 'Deployed APIs and their endpoints.' },
@@ -1088,14 +1586,21 @@ function Splash({ onSelect }) {
 function App() {
   var _section   = useState(function() {
     var hash  = window.location.hash.slice(1);
-    var valid = new Set(['infrastructure','data-assets','apis','processes']);
+    var valid = new Set(['glossary','infrastructure','data-assets','apis','processes']);
     return valid.has(hash) ? hash : '';
   }), section = _section[0], setSection = _section[1];
 
-  var _creds   = useState(null), creds = _creds[0], setCreds = _creds[1];
-  var _srvMgd  = useState(false), srvManaged = _srvMgd[0], setSrvManaged = _srvMgd[1];
-  var _demoMode = useState(false), demoMode = _demoMode[0], setDemoMode = _demoMode[1];
-  var _ready   = useState(false), ready = _ready[0], setReady = _ready[1];
+  var _creds     = useState(null),  creds      = _creds[0],     setCreds      = _creds[1];
+  var _srvMgd    = useState(false), srvManaged = _srvMgd[0],    setSrvManaged = _srvMgd[1];
+  var _demoMode  = useState(false), demoMode   = _demoMode[0],  setDemoMode   = _demoMode[1];
+  var _ready     = useState(false), ready      = _ready[0],     setReady      = _ready[1];
+  var _navTarget = useState(null),  navTarget  = _navTarget[0], setNavTarget  = _navTarget[1];
+
+  function handleNavigate(nav) {
+    // nav = { guid, section, tab, displayName }
+    setNavTarget(nav);
+    setSection(nav.section);
+  }
 
   useEffect(function() {
     fetch('/api/auth/me').then(function(r) { return r.json(); }).then(function(d) {
@@ -1145,7 +1650,7 @@ function App() {
       ? React.createElement('div', { style: { flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' } },
           React.createElement(ConnectionForm, { saveCreds: setCreds }))
       : section
-        ? React.createElement(SectionView, { sectionId: section, creds: creds })
+        ? React.createElement(SectionView, { sectionId: section, creds: creds, navTarget: navTarget, onNavigate: handleNavigate })
         : React.createElement(Splash, { onSelect: setSection }),
     React.createElement(FeedbackButton, { section: section, persona: null, demoMode: demoMode, srvManaged: srvManaged })
   );

--- a/compose-configs/egeria-quickstart/PyegeriaWebHandler/tech_catalog_handler.py
+++ b/compose-configs/egeria-quickstart/PyegeriaWebHandler/tech_catalog_handler.py
@@ -37,6 +37,18 @@ _HTML = _HERE / "tech-catalog.html"
 _SEQ_ORDER = "PROPERTY_ASCENDING"
 _SEQ_PROP  = "displayName"
 
+# Mermaid graph fields Egeria may embed in an element response.
+# Must stay in sync with _ALL_MERMAID_FIELDS in tech-catalog.html and mermaid_handler.py.
+_MERMAID_FIELDS = {
+    "mermaidGraph", "anchorMermaidGraph", "edgeMermaidGraph",
+    "localLineageGraph", "fieldLevelLineageGraph",
+    "informationSupplyChainMermaidGraph", "iscImplementationMermaidGraph",
+    "actionMermaidGraph", "specificationMermaidGraph",
+    "solutionBlueprintMermaidGraph", "solutionSubcomponentMermaidGraph",
+    "governanceActionProcessMermaidGraph", "organizationTreeMermaidGraph",
+    "collectionMermaidMindMap",
+}
+
 
 # ── Credential helpers ────────────────────────────────────────────────────────
 
@@ -53,6 +65,14 @@ def _asset_maker(url, server, user_id, user_pwd):
     from pyegeria import AssetMaker
     u, s, uid, pwd = _creds(url, server, user_id, user_pwd)
     mgr = AssetMaker(view_server=s, platform_url=u, user_id=uid, user_pwd=pwd)
+    mgr.create_egeria_bearer_token()
+    return mgr
+
+
+def _connection_maker(url, server, user_id, user_pwd):
+    from pyegeria import ConnectionMaker
+    u, s, uid, pwd = _creds(url, server, user_id, user_pwd)
+    mgr = ConnectionMaker(server_name=s, platform_url=u, user_id=uid, user_pwd=pwd)
     mgr.create_egeria_bearer_token()
     return mgr
 
@@ -108,10 +128,16 @@ def _flat_props(props_dict: dict) -> dict:
 def _extract_relationships(el: dict) -> list:
     """
     Extract peer relationships from a graph-queried element.
-    Egeria embeds related elements as list-valued keys where each item
-    carries a 'relationshipHeader' dict describing the link type.
+
+    pyegeria wraps the related element in a nested 'relatedElement' sub-dict
+    (class RelatedMetadataElementSummary). The top-level item only contains
+    'relationshipHeader', 'relationshipProperties', 'relatedElement', and
+    optionally 'relatedElementAtEnd1'. We must unwrap 'relatedElement' to
+    reach the actual elementHeader / properties.
     """
     _SKIP_KEYS = {"elementHeader", "properties", "classifications", "class"}
+    _ITEM_META  = {"relationshipHeader", "relationshipProperties",
+                   "relatedElement", "relatedElementAtEnd1", "class"}
     result = []
     for key, val in el.items():
         if key in _SKIP_KEYS or not isinstance(val, list):
@@ -123,19 +149,31 @@ def _extract_relationships(el: dict) -> list:
             if not isinstance(rel_hdr, dict):
                 continue
             rel_type = (rel_hdr.get("type") or {}).get("typeName") or key
-            rel_props_raw = item.get("relationshipProperties") or item.get("properties") or {}
+            rel_props_raw = item.get("relationshipProperties") or {}
             rel_props = _flat_props(rel_props_raw) if rel_props_raw else {}
-            # Related element is the remainder of the item dict
-            elem = {k: v for k, v in item.items()
-                    if k not in ("relationshipHeader", "relationshipProperties")}
+
+            # Prefer the nested 'relatedElement' wrapper (standard pyegeria format).
+            nested = item.get("relatedElement")
+            if isinstance(nested, dict) and "elementHeader" in nested:
+                elem = nested
+            else:
+                # Fallback for older / flat formats
+                elem = {k: v for k, v in item.items() if k not in _ITEM_META}
+
             elem_hdr   = _header(elem)
             elem_props = _props(elem)
+            type_info  = elem_hdr.get("type") or {}
+            type_name  = type_info.get("typeName", "")
+            # superTypeNames lets the frontend find a nav target for subtypes
+            super_types = type_info.get("superTypeNames") or []
+
             result.append({
                 "relationshipType": rel_type,
                 "relationshipProperties": rel_props,
                 "relatedElement": {
                     "guid":        elem_hdr.get("guid", ""),
-                    "typeName":    _type_name(elem),
+                    "typeName":    type_name,
+                    "superTypes":  super_types,
                     "displayName": elem_props.get("displayName") or elem_props.get("name") or elem_hdr.get("guid", ""),
                     "description": elem_props.get("description") or "",
                 },
@@ -161,6 +199,12 @@ def _serialize(el, include_relationships: bool = False):
     }
     if include_relationships:
         out["relationships"] = _extract_relationships(el)
+    # Pass through any mermaid graph fields present in the element or its properties.
+    # These are only populated when graph_query_depth > 0 and Egeria has diagram data.
+    for field in _MERMAID_FIELDS:
+        val = el.get(field) or props.get(field)
+        if val and isinstance(val, str) and not val.lower().startswith("no "):
+            out[field] = val
     return out
 
 
@@ -210,11 +254,13 @@ def list_infrastructure(
         raw = mgr.find_infrastructure(
             search_string=q or "*",
             metadata_element_type="ITInfrastructure",
+            deployment_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -242,6 +288,7 @@ def list_software_capabilities(
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -259,18 +306,16 @@ def list_endpoints(
     user_id: Optional[str] = Query(None), user_pwd: Optional[str] = Query(None),
 ):
     try:
-        mgr = _asset_maker(url, server, user_id, user_pwd)
+        mgr = _connection_maker(url, server, user_id, user_pwd)
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
     try:
-        raw = mgr.find_assets(
+        raw = mgr.find_endpoints(
             search_string=q or "*",
-            metadata_element_type="Endpoint",
+            output_format="JSON",
             start_from=start_from,
             page_size=page_size,
-            output_format="JSON",
-            sequencing_order=_SEQ_ORDER,
-            sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -295,11 +340,13 @@ def list_data_stores(
         raw = mgr.find_data_assets(
             search_string=q or "*",
             metadata_element_type="DataStore",
+            content_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -324,11 +371,13 @@ def list_data_feeds(
         raw = mgr.find_data_assets(
             search_string=q or "*",
             metadata_element_type="DataFeed",
+            content_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -353,11 +402,13 @@ def list_data_sets(
         raw = mgr.find_data_assets(
             search_string=q or "*",
             metadata_element_type="DataSet",
+            content_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -387,6 +438,7 @@ def list_apis(
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -411,11 +463,13 @@ def list_software_components(
         raw = mgr.find_processes(
             search_string=q or "*",
             metadata_element_type="DeployedSoftwareComponent",
+            activity_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -440,11 +494,13 @@ def list_actions(
         raw = mgr.find_processes(
             search_string=q or "*",
             metadata_element_type="Action",
+            activity_status_list=[],
             start_from=start_from,
             page_size=page_size,
             output_format="JSON",
             sequencing_order=_SEQ_ORDER,
             sequencing_property=_SEQ_PROP,
+            graph_query_depth=0,
         )
         items = [_serialize(e) for e in _safe_list(raw)]
         return JSONResponse({"items": items, "total": len(items)})
@@ -478,26 +534,40 @@ def get_asset_detail(
         raise HTTPException(status_code=500, detail=str(exc))
 
 
-# Map from section id → targeted find_* with graph_query_depth=1
+# Map from section id → targeted find_* with graph_query_depth=3 for full property/relationship detail
 _SECTION_FINDERS = {
     "software-capabilities": lambda m: m.find_software_capabilities(
-        search_string="*", output_format="JSON", graph_query_depth=1),
-    "endpoints": lambda m: m.find_assets(
-        search_string="*", metadata_element_type="Endpoint",
-        output_format="JSON", graph_query_depth=1,
-        sequencing_order=_SEQ_ORDER, sequencing_property=_SEQ_PROP),
+        search_string="*", output_format="JSON", graph_query_depth=3),
     "infrastructure": lambda m: m.find_infrastructure(
-        search_string="*", output_format="JSON", graph_query_depth=1,
+        search_string="*", output_format="JSON", graph_query_depth=3,
+        deployment_status_list=[],
         sequencing_order=_SEQ_ORDER, sequencing_property=_SEQ_PROP),
 }
 
 
 def _fetch_detail(mgr, guid: str, section: Optional[str]):
     """
-    Fetch a single element with graph_query_depth=1.
-    If section is known we use the targeted finder directly.
-    Otherwise tries get_asset_by_guid first, then find_software_capabilities.
+    Fetch a single element with graph_query_depth=3 to expose full property/relationship detail.
+    Endpoints use ConnectionMaker.get_endpoint_by_guid (not an Asset subtype).
+    Other non-Asset sections use the targeted finder.
+    Asset subtypes fall through to get_asset_by_guid.
     """
+    # Endpoints: direct GUID lookup via ConnectionMaker
+    if section == "endpoints":
+        try:
+            cm = _connection_maker_from_asset_maker(mgr)
+            raw = cm.get_endpoint_by_guid(
+                endpoint_guid=guid,
+                output_format="JSON",
+                body={"class": "GetRequestBody", "graphQueryDepth": 3},
+            )
+            el = raw[0] if isinstance(raw, list) else raw
+            if el:
+                return el
+        except Exception:
+            pass
+        return None
+
     # Known non-Asset section — use targeted find and filter by GUID
     finder = _SECTION_FINDERS.get(section or "")
     if finder:
@@ -511,7 +581,7 @@ def _fetch_detail(mgr, guid: str, section: Optional[str]):
         raw = mgr.get_asset_by_guid(
             asset_guid=guid,
             output_format="JSON",
-            body={"class": "GetRequestBody", "graphQueryDepth": 1, "relationshipsPageSize": 50},
+            body={"class": "GetRequestBody", "graphQueryDepth": 3, "relationshipsPageSize": 50},
         )
         el = raw[0] if isinstance(raw, list) else raw
         if el:
@@ -522,12 +592,30 @@ def _fetch_detail(mgr, guid: str, section: Optional[str]):
     # Fallback: SoftwareCapability subtypes (catches any missed non-Asset type)
     try:
         return _find_by_guid(
-            mgr.find_software_capabilities(search_string="*", output_format="JSON", graph_query_depth=1),
+            mgr.find_software_capabilities(search_string="*", output_format="JSON", graph_query_depth=3),
             guid)
     except Exception:
         pass
 
     return None
+
+
+def _connection_maker_from_asset_maker(mgr):
+    """Create a ConnectionMaker sharing credentials from an existing AssetMaker.
+
+    NOTE: Do NOT pass token= here. ConnectionMaker.__init__ calls check_connection()
+    immediately, and the Bearer token format from AssetMaker causes a 401 on that
+    handshake. A fresh create_egeria_bearer_token() call is required instead.
+    """
+    from pyegeria import ConnectionMaker
+    cm = ConnectionMaker(
+        server_name=mgr.server_name,
+        platform_url=mgr.platform_url,
+        user_id=mgr.user_id,
+        user_pwd=mgr.user_pwd,
+    )
+    cm.create_egeria_bearer_token()
+    return cm
 
 
 def _find_by_guid(raw, guid: str):


### PR DESCRIPTION
…lationship data fix

Glossary:
- Add GlossaryView, GlossaryFolderDetail, GlossaryDetail, GlossaryTermDetail components ported from Egeria Explorer with inline styles and creds prop
- Add /api/glossary* routes consumed by the new components
- Move Glossary to first card and first nav item

Cross-relationship navigation:
- Add TYPE_TO_NAV mapping (~60 Egeria types → section/tab)
- Add "View →" buttons on relationship cards for known/navigable types
- Walk superTypeNames as fallback so subtypes (e.g. SecretsCollection → DataSet) resolve to the correct tab
- Thread onNavigate / navTarget from App → SectionView → AssetTabView → AssetDetail so clicking View → switches section, selects sub-tab, and fetches detail

Fix: Endpoint detail returning 404 (ConnectionMaker token conflict):
- ConnectionMaker.__init__ calls check_connection() immediately; passing the Bearer token from AssetMaker caused a 401 on that handshake
- _connection_maker_from_asset_maker now omits token= and calls create_egeria_bearer_token() after construction

Fix: _extract_relationships discarding all related-element data:
- pyegeria wraps related elements in a nested 'relatedElement' sub-dict (RelatedMetadataElementSummary); the old code stripped it, leaving every relationship with an empty typeName, displayName, and guid
- Now unwraps 'relatedElement' correctly and also extracts superTypeNames so the frontend can resolve subtype nav targets