### PR TITLE
docs(tech-catalog): update spec, API reference, and issues log to cur…

### DIFF
--- a/CATALOG_ISSUES.md
+++ b/CATALOG_ISSUES.md
@@ -1,14 +1,16 @@
 # Tech Catalog — Issues & Lessons Learned
 
-Tracks outstanding work, known bugs, and pyegeria API lessons discovered while building The Catalog (`tech_catalog_handler.py` + `tech-catalog.html`).
+Tracks bugs fixed, lessons learned, and outstanding work for The Catalog (`tech_catalog_handler.py` + `tech-catalog.html`). Updated as of **2026-06-08**.
 
 ---
 
-## Lessons Learned — pyegeria API defaults
+## Lessons Learned
 
-Every `find_*` method in pyegeria has a status-list parameter that **defaults to a single active state**, silently filtering out any element that hasn't had that status explicitly set. In the Coco Pharma demo data, almost nothing has an explicit status, so everything was invisible until these were overridden to `[]`.
+### L-1: pyegeria `find_*` status defaults silently hide most Coco data
 
-| pyegeria method | Status param | Default | Fix applied |
+Every `find_*` method has a status-list parameter that defaults to a single active state. In Coco Pharma demo data, almost nothing has an explicit status set, so everything was invisible until these were overridden to `[]`.
+
+| pyegeria method | Status param | Default | Fix |
 |---|---|---|---|
 | `find_infrastructure` | `deployment_status_list` | `["ACTIVE"]` | `deployment_status_list=[]` |
 | `find_data_assets` | `content_status_list` | `["ACTIVE"]` | `content_status_list=[]` |
@@ -16,92 +18,104 @@ Every `find_*` method in pyegeria has a status-list parameter that **defaults to
 
 **Rule:** Always pass `<status_param>=[]` on any `find_*` call unless the user has explicitly requested status filtering.
 
-**Also:** All list calls now use `graph_query_depth=0` (performance); all detail calls use `graph_query_depth=3` (full property/relationship data for display).
+**Depth rule:** List calls use `graph_query_depth=0` (performance); detail calls use `graph_query_depth=3` (full property/relationship graph for display).
 
 ---
 
-## Lessons Learned — Endpoints
+### L-2: `Endpoint` is not an Asset — requires `ConnectionMaker`
 
-`Endpoint` is NOT an Asset subtype — `AssetMaker.find_assets(metadata_element_type="Endpoint")` returns nothing. Must use `ConnectionMaker.find_endpoints()` and `ConnectionMaker.get_endpoint_by_guid()`.
+`AssetMaker.find_assets(metadata_element_type="Endpoint")` returns nothing. `Endpoint` is not in the Asset type hierarchy. Must use `ConnectionMaker.find_endpoints()` and `ConnectionMaker.get_endpoint_by_guid()`.
 
 `ConnectionMaker.__init__` takes `server_name` (positional), not `view_server` like `AssetMaker`.
 
 ---
 
-## Lessons Learned — Mermaid diagrams
+### L-3: `ConnectionMaker` rejects a reused Bearer token in its constructor
 
-Two separate diagram paths exist in the detail pane:
+`ConnectionMaker.__init__` calls `check_connection()` immediately. Passing a Bearer token obtained from `AssetMaker.get_token()` causes a 401 on that handshake — the `/api/about` check fails. The symptom was endpoint detail requests returning 404 (the exception was silently swallowed).
 
-1. **`AvailableMermaidDiagrams`** — renders mermaid fields embedded in the element response (`edgeMermaidGraph`, `localLineageGraph`, etc.). These require `graph_query_depth > 0`. Now passed through by `_serialize()` via `_MERMAID_FIELDS` set. `mermaidGraph` and `anchorMermaidGraph` are intentionally excluded from this path (handled by buttons below).
+**Fix:** `_connection_maker_from_asset_maker()` now omits `token=` and calls `cm.create_egeria_bearer_token()` after construction. This adds one extra auth round-trip per endpoint detail request, which is acceptable.
 
-2. **`MermaidSection` buttons** — "Load Context Diagram" / "Load Anchored Graph" fetch from `mermaid_handler.py` via `ClassificationExplorer.get_element_by_guid` and `MetadataExpert.get_anchored_element_graph`. These are on-demand, separate from the detail fetch.
+---
 
-**Bug fixed:** `DiagramPanel` was calling `.text()` on the JSON response and passing the raw JSON string to Mermaid.js. Fixed to `.json()` + extract `data.mermaidGraph`.
+### L-4: pyegeria relationship items nest the related element under `relatedElement`
 
-**Bug fixed:** Mermaid fields were stripped by `_serialize()`. Now passed through for all `_MERMAID_FIELDS`.
+`_extract_relationships()` originally stripped the outer item wrapper by doing:
+```python
+elem = {k: v for k, v in item.items() if k not in ("relationshipHeader", "relationshipProperties")}
+```
+This left an empty dict because pyegeria's `RelatedMetadataElementSummary` puts the actual element inside a nested `relatedElement` key:
+```json
+{
+  "relationshipHeader": {...},
+  "relationshipProperties": {...},
+  "relatedElement": {
+    "elementHeader": { "guid": "...", "type": { "typeName": "SecretsCollection", "superTypeNames": ["DataSet", ...] } },
+    "properties": { "displayName": "cocoUserDirectory" }
+  }
+}
+```
+Every relationship was showing an empty `typeName`, empty `displayName`, and no GUID. This also prevented all "View →" navigation buttons from appearing.
 
-**Bug fixed:** Mermaid field names were appearing in the Properties table. Fixed by adding `_ALL_MERMAID_FIELDS` to `skipKeys` in `AssetDetail`.
+**Fix:** `_extract_relationships()` now checks for a nested `relatedElement` with an `elementHeader` and unwraps it. It also extracts `superTypeNames` and passes them as `superTypes` in the serialized output so the frontend can resolve subtype navigation targets.
 
-**Credentials note:** `MermaidSection` fetch URLs don't include credentials — the mermaid handler uses env var defaults. If a user authenticates with non-default credentials, diagram fetches use the wrong identity. This is a known limitation.
+---
+
+### L-5: Mermaid diagrams had two independent bugs
+
+**Bug 1 — `_serialize()` stripped all mermaid fields (FIXED)**
+`_serialize()` only extracted a fixed list of scalar properties and silently discarded everything else. A `_MERMAID_FIELDS` set was added; `_serialize()` now passes through any non-empty mermaid field.
+
+**Bug 2 — `DiagramPanel` called `.text()` on a JSON response (FIXED)**
+`DiagramPanel` was calling `.text()` then passing the raw JSON string to Mermaid.js, which failed to parse it. Fixed to `.json()` + extract `data.mermaidGraph`.
+
+**Bug 3 — Mermaid field names appeared in Properties table (FIXED)**
+`AssetDetail.skipKeys` didn't include mermaid field names. Fixed by concatenating `_ALL_MERMAID_FIELDS`.
+
+---
+
+### L-6: Cross-navigation requires threading nav state through three component levels
+
+App → SectionView → AssetTabView → AssetDetail is a four-level prop chain. Implemented using a `navTarget` state in App: clicking "View →" calls `onNavigate({guid, section, tab, displayName})`, which sets the section, switches the sub-tab via `useEffect` in SectionView, and triggers a direct detail fetch in AssetTabView via a `useRef` deduplication guard.
+
+Frontend `TYPE_TO_NAV` resolves Egeria types to `{ section, tab }`. A supertype fallback walk handles subtypes not explicitly listed (e.g., `SecretsCollection` → `DataSet` → `data-sets` tab).
 
 ---
 
 ## Outstanding Issues
 
 ### O-1: List-level mermaid graph discarded
-`find_*` calls may return a result-set-level `mermaidGraph` at the response root alongside the elements. `_safe_list()` only extracts the elements list and discards any top-level fields. If Egeria generates a diagram of all found elements, it never reaches the frontend.
+`find_*` responses may include a top-level `mermaidGraph` field for the whole result set. `_safe_list()` only extracts the `items` list and discards anything else. Unconfirmed whether Egeria actually returns this in practice.
 
-**Status:** Not yet fixed. Needs a live test to confirm whether the response root actually contains a mermaid graph.
+**Status:** Needs live response inspection to confirm.
 
 ### O-2: `_safe_list` only handles `"items"` key
 ```python
 if isinstance(raw, dict) and "items" in raw:
     return raw["items"]
 ```
-pyegeria may use `"elements"` or `"elementList"` as the list key in some response formats. If so, the handler silently returns `[]`. Needs a live response inspection to confirm.
+Some pyegeria responses may use `"elements"` or `"elementList"`. Unconfirmed.
 
-**Status:** Not yet fixed. Confirm response key with a live test.
+**Status:** Needs live response inspection to confirm.
 
-### O-3: `AvailableMermaidDiagrams` skips `mermaidGraph`
-`mermaidGraph` is in `_MERMAID_SECTION_FIELDS` and excluded from inline rendering — it's expected from the `MermaidSection` on-demand button. But `MermaidSection` re-fetches via a separate API call even when `_serialize()` already passed the embedded `mermaidGraph` through. Wasted fetch.
+### O-3: Redundant mermaid fetch when embedded graph already present
+`mermaidGraph` is in `_MERMAID_SECTION_FIELDS` so it's excluded from inline rendering and reserved for the "Load Context Diagram" button. But `_serialize()` already passes through the embedded `mermaidGraph` from the detail response. The button triggers a second fetch to `/api/mermaid/{guid}` even when the data is already available.
 
-**Fix options:**
-- (a) Pre-populate the "Context Diagram" button state from the embedded `mermaidGraph` (avoids second fetch)
-- (b) Remove `mermaidGraph` from `_MERMAID_SECTION_FIELDS` so it renders inline immediately
+**Fix options:** Pre-populate the button state from the embedded field, or remove `mermaidGraph` from `_MERMAID_SECTION_FIELDS` and render it inline.
 
-**Status:** Not yet fixed.
+**Status:** Low priority.
 
-### O-4: `DeployedSoftwareComponent` results — needs live retest
-Added `activity_status_list=[]` — previously returned 0. Now should return connectors catalogued in the Egeria runtime.
+### O-8: Software Capabilities detail uses O(n) scan
+The detail pane for Software Capabilities calls `find_software_capabilities(search_string="*", graph_query_depth=3)` then filters by GUID. `get_software_capability_by_guid(guid)` exists on `AssetMaker` (confirmed in 6.0.13.6) and could replace this with a direct lookup.
 
-**Status:** Fixed in code, needs live test confirmation.
-
-### O-5: Data assets (DataStore / DataFeed / DataSet) — needs live retest
-Added `content_status_list=[]` — previously returned 0.
-
-**Status:** Fixed in code, needs live test confirmation.
-
-### O-6: ITInfrastructure — needs live retest
-Added `deployment_status_list=[]` — previously returned 0.
-
-**Status:** Fixed in code, needs live test confirmation.
-
-### O-7: Endpoints — needs live retest
-Switched from `AssetMaker.find_assets(metadata_element_type="Endpoint")` to `ConnectionMaker.find_endpoints()`. Previously returned wrong/empty results.
-
-**Status:** Fixed in code, needs live test confirmation.
-
-### O-8: `get_software_capability_by_guid` optimisation
-The detail pane for Software Capabilities does an O(n) scan (`find_software_capabilities(search_string="*")` then filter by GUID). `get_software_capability_by_guid(guid)` exists on `AssetMaker` in 6.0.13.6 and could replace this with a direct lookup.
-
-**Status:** Not yet implemented. Low priority (50 items is fast).
+**Status:** Low priority — list is ~50 items, fast enough today.
 
 ### O-9: Mermaid diagram credentials not forwarded
-`MermaidSection` fetches `/api/mermaid/{guid}` without passing the user's credentials as query params. `mermaid_handler.py` falls back to env var defaults. Portal-authenticated users with non-default credentials get diagrams from the wrong identity.
+`MermaidSection` fetches `/api/mermaid/{guid}` without passing user credentials as query params. `mermaid_handler.py` falls back to env-var defaults. Portal-authenticated users with non-default credentials get diagrams from the wrong identity.
 
-**Status:** Not yet fixed.
+**Status:** Known limitation, not yet fixed.
 
-### O-10: DeployedAPI mermaid diagrams
-APIs section shows no diagrams. Likely because `get_element_by_guid` (ClassificationExplorer) returns no `mermaidGraph` for `DeployedAPI` elements in Coco data. Needs live test of `/api/mermaid/{guid}` with a real API GUID to confirm data vs display issue.
+### O-10: DeployedAPI mermaid diagrams may not exist in Coco data
+APIs section shows no diagrams. Likely because `get_element_by_guid` (ClassificationExplorer) returns no `mermaidGraph` for `DeployedAPI` elements in Coco. Needs live test of `/api/mermaid/{guid}` with a real API GUID to distinguish a data issue from a display issue.
 
 **Status:** Under investigation.

--- a/cat_calls.md
+++ b/cat_calls.md
@@ -1,0 +1,158 @@
+# The Catalog — pyegeria API Call Reference
+
+Documents the pyegeria calls made by `tech_catalog_handler.py` and `glossary_handler.py` for each section of The Catalog. Use this as the authoritative working reference for API call strategy, known quirks, and debugging guidance.
+
+All catalog calls go through `AssetMaker` (imported from `pyegeria`) unless noted. Credential params (`url`, `server`, `user_id`, `user_pwd`) are passed from the SPA via query params; the backend falls back to env vars when absent.
+
+**Container pyegeria version: 6.0.13.6** (installed via `pip install pyegeria --upgrade` in Dockerfile-fast-api)
+
+---
+
+## Key pyegeria quirks (apply everywhere)
+
+> These were discovered by source inspection of pyegeria 6.0.13.6 in the container and confirmed against live Coco data.
+
+| Quirk | Detail |
+|---|---|
+| `find_*` status defaults | Every find method silently applies a status filter. Must pass `[]` to see all elements in Coco (which sets no explicit status). See table below. |
+| `AssetMaker` constructor | Takes `view_server=` (not `server_name=`) |
+| `ConnectionMaker` constructor | Takes `server_name=` (not `view_server=`). Also calls `check_connection()` immediately — do NOT pass a Bearer token; it causes a 401 on the check. Call `create_egeria_bearer_token()` after construction instead. |
+| `Endpoint` is not an Asset | `AssetMaker.find_assets(metadata_element_type="Endpoint")` returns nothing. Must use `ConnectionMaker.find_endpoints()` and `ConnectionMaker.get_endpoint_by_guid()`. |
+| `find_endpoints` kwargs | Signature: `(search_string, output_format, report_spec, body, **kwargs)`. Pass `graph_query_depth`, `start_from`, `page_size` via `**kwargs`. |
+| Relationship data structure | pyegeria wraps related elements in `RelatedMetadataElementSummary` — the related element's header/properties are inside a nested `relatedElement` key, not at the top level of the relationship item. The `elementHeader.type.superTypeNames` list enables subtype nav resolution. |
+
+### Status filter defaults
+
+| pyegeria method | Status param | Default (wrong for Coco) | Fix |
+|---|---|---|---|
+| `find_infrastructure` | `deployment_status_list` | `["ACTIVE"]` | `deployment_status_list=[]` |
+| `find_data_assets` | `content_status_list` | `["ACTIVE"]` | `content_status_list=[]` |
+| `find_processes` | `activity_status_list` | `["IN_PROGRESS"]` | `activity_status_list=[]` |
+| `find_software_capabilities` | _(none)_ | N/A | No change needed |
+| `find_endpoints` | _(none confirmed)_ | Unknown | Monitor; may need `body={"contentStatusList":[]}` |
+
+---
+
+## List endpoints — left-hand navigation
+
+Each called when the user selects a section or sub-tab. Returns `{ items: [...], total: N }`. All use `graph_query_depth=0` for performance.
+
+| Section | Sub-tab | Call | `metadata_element_type` | Status | Coco data |
+|---|---|---|---|---|---|
+| Glossary | _(whole section)_ | `GlossaryManager.get_glossaries()` | N/A | ✅ Working | ✅ Multiple glossaries |
+| Infrastructure | IT Infrastructure | `find_infrastructure(search_string="*", deployment_status_list=[], graph_query_depth=0)` | `"ITInfrastructure"` | ✅ Fixed | ✅ Confirmed |
+| Infrastructure | Software Capabilities | `find_software_capabilities(search_string="*", graph_query_depth=0)` | _(all)_ | ✅ Working | ✅ ~50 items |
+| Infrastructure | Endpoints | `ConnectionMaker.find_endpoints(search_string="*", output_format="JSON", graph_query_depth=0)` | _(all)_ | ✅ Fixed | ✅ ~232 items |
+| Data Assets | Data Stores | `find_data_assets(search_string="*", metadata_element_type="DataStore", content_status_list=[], graph_query_depth=0)` | `"DataStore"` | ✅ Fixed | ✅ ~95 items |
+| Data Assets | Data Feeds | `find_data_assets(search_string="*", metadata_element_type="DataFeed", content_status_list=[], graph_query_depth=0)` | `"DataFeed"` | ✅ Fixed | ✅ Confirmed |
+| Data Assets | Data Sets | `find_data_assets(search_string="*", metadata_element_type="DataSet", content_status_list=[], graph_query_depth=0)` | `"DataSet"` | ✅ Fixed | ✅ Confirmed |
+| APIs | APIs | `find_assets(search_string="*", metadata_element_type="DeployedAPI", graph_query_depth=0)` | `"DeployedAPI"` | ✅ Working | ✅ 58 items |
+| Processes | Software Components | `find_processes(search_string="*", metadata_element_type="DeployedSoftwareComponent", activity_status_list=[], graph_query_depth=0)` | `"DeployedSoftwareComponent"` | ✅ Fixed | ✅ Confirmed |
+| Processes | Actions | `find_processes(search_string="*", metadata_element_type="Action", activity_status_list=[], graph_query_depth=0)` | `"Action"` | ✅ Fixed | ✅ 3+ items |
+
+> **Note on Software Capabilities sorting:** `find_software_capabilities` does not support `sequencing_order` — results are sorted client-side in `AssetTabView`.
+
+> **Note on DeployedAPI:** `find_assets` works because DeployedAPI → DeployedSoftwareComponent → Process → Asset. Switching to `find_processes(activity_status_list=[])` would allow status filtering but isn't needed currently.
+
+---
+
+## Detail endpoint — right-hand panel
+
+Called when a sidebar item is clicked: `GET /api/tech-catalog/assets/{guid}?section={tab-id}`
+
+**`graph_query_depth=3` is used for all detail fetches** to return the full relationship/property graph needed to populate the detail pane. This depth exposes nested schema links, lineage anchors, and multi-hop relationships that depth=1 misses.
+
+| Type family | `section` param | Call | Notes |
+|---|---|---|---|
+| Asset subtypes (DeployedAPI, Action, DataStore, …) | `apis`, `actions`, `data-*` | `AssetMaker.get_asset_by_guid(guid, body={graphQueryDepth:3, relationshipsPageSize:50})` | Direct GUID lookup. |
+| SoftwareCapability subtypes | `software-capabilities` | `find_software_capabilities(search_string="*", graph_query_depth=3)` then filter by GUID | O(n) scan — acceptable for ~50 items. `get_software_capability_by_guid(guid)` exists on `AssetMaker` and could replace this (O-8). |
+| Endpoint | `endpoints` | `ConnectionMaker.get_endpoint_by_guid(guid, body={graphQueryDepth:3})` via `_connection_maker_from_asset_maker()` | Direct GUID lookup. ConnectionMaker is re-authenticated (fresh `create_egeria_bearer_token()`) — passing the token from AssetMaker causes a 401. |
+| ITInfrastructure | `infrastructure` | `find_infrastructure(search_string="*", deployment_status_list=[], graph_query_depth=3)` then filter by GUID | O(n) scan — acceptable given small infrastructure list. |
+
+---
+
+## Glossary endpoints (served by `glossary_handler.py`)
+
+The Glossary section is the first tile in The Catalog. It reuses `glossary_handler.py` which was built for Egeria Explorer.
+
+| Endpoint | Handler call | Notes |
+|---|---|---|
+| `GET /api/glossary` | `GlossaryManager.get_glossaries()` | Returns `{ glossaries: [...] }` |
+| `GET /api/glossary/{guid}/folders` | `GlossaryManager.get_glossary_categories()` | Returns `{ folders: [...] }` |
+| `GET /api/glossary/{guid}/terms` | `GlossaryManager.get_terms_for_glossary()` | Returns `{ terms: [...] }` |
+| `GET /api/glossary-terms?q=` | `GlossaryManager.find_glossary_terms()` | Cross-glossary search, returns `{ terms: [...] }` |
+| `GET /api/glossary/term/{guid}` | `GlossaryManager.get_glossary_term_by_guid()` with depth=3 | Full term detail with relationships and classifications |
+
+---
+
+## Cross-navigation (implemented — TC-8)
+
+Cross-navigation is fully implemented. Relationship cards in the detail pane show a **"View →"** button whenever the related element's type (or any of its `superTypeNames`) maps to a known section/tab. Clicking navigates the SPA: switches section, activates the correct sub-tab, and fetches the target element's detail directly (the list loads in the background).
+
+### TYPE_TO_NAV mapping (frontend `tech-catalog.html`)
+
+| Related element typeName (or supertype) | Navigates to section | Navigates to tab |
+|---|---|---|
+| `ITInfrastructure` and subtypes (SoftwareServer, Host, …) | `infrastructure` | `infrastructure` |
+| `SoftwareCapability` and subtypes (APIManager, DatabaseManager, …) | `infrastructure` | `software-capabilities` |
+| `Endpoint` | `infrastructure` | `endpoints` |
+| `DataStore` and subtypes (Database, CSVFile, DataFile, …) | `data-assets` | `data-stores` |
+| `DataFeed` and subtypes (Topic, KafkaTopic, …) | `data-assets` | `data-feeds` |
+| `DataSet` and subtypes (SecretsCollection, VirtualRelationalTable, …) | `data-assets` | `data-sets` |
+| `DeployedAPI` | `apis` | `apis` |
+| `DeployedSoftwareComponent` and subtypes | `processes` | `software-components` |
+| `GlossaryTerm`, `Glossary`, `GlossaryCategory` | `glossary` | `glossary` |
+
+> **Subtype fallback:** When the exact `typeName` is not in the map (e.g., `SecretsCollection`), the frontend walks `relatedElement.superTypes` (from `elementHeader.type.superTypeNames`) to find the first matching ancestor. This means most Egeria subtypes are automatically navigable without being explicitly listed.
+
+### Known navigable relationships in Coco data
+
+| Viewing | Relationship type | Related element type | Tab navigated to |
+|---|---|---|---|
+| DataStore | `DataSetContent` | DataSet subtypes (SecretsCollection, etc.) | `data-sets` |
+| DataStore | `AssetConnection` | Connection | _(not mapped — no catalog tab for Connections)_ |
+| ITInfrastructure | `SupportedSoftwareCapability` | SoftwareCapability subtypes | `software-capabilities` |
+| SoftwareCapability | `SoftwareCapabilityDependency` | SoftwareCapability subtypes | `software-capabilities` |
+| DeployedAPI | `APIEndpoint` | Endpoint | `endpoints` |
+| DataSet | `DataSetContent` | DataStore subtypes | `data-stores` |
+
+---
+
+## Mermaid diagrams in the detail pane
+
+### Rendering order
+
+> **Properties → Classifications → Diagrams → Relationships → Comments**
+
+### Two diagram paths
+
+| Path | Component | Data source | Trigger |
+|---|---|---|---|
+| Embedded | `AvailableMermaidDiagrams` | Mermaid fields in the serialised `item` (passed through by `_serialize()` via `_MERMAID_FIELDS` set) | Renders immediately when field is present |
+| On-demand | `MermaidSection` → `DiagramPanel` | `GET /api/mermaid/{guid}` → `ClassificationExplorer.get_element_by_guid` | User clicks "Load Context Diagram" |
+| On-demand | `MermaidSection` → `DiagramPanel` | `GET /api/mermaid/{guid}/anchored` → `MetadataExpert.get_anchored_element_graph` | User clicks "Load Anchored Graph" |
+
+The fields `mermaidGraph` and `anchorMermaidGraph` are excluded from inline rendering (`_MERMAID_SECTION_FIELDS`) — they are served by the on-demand buttons.
+
+### Bugs fixed
+
+- **Bug 1 (FIXED):** `_serialize()` stripped all mermaid fields. Now iterates `_MERMAID_FIELDS` and passes through non-empty values.
+- **Bug 2 (FIXED):** `DiagramPanel` called `.text()` on the JSON response and fed raw JSON to Mermaid.js. Now calls `.json()` and extracts `data.mermaidGraph`.
+- **Bug 3 (FIXED):** Mermaid field names appeared in the Properties table. Fixed by adding `_ALL_MERMAID_FIELDS` to `skipKeys` in `AssetDetail`.
+
+### Known limitation
+
+`MermaidSection` fetch URLs don't forward user credentials — `mermaid_handler.py` falls back to env-var defaults. Portal-authenticated users with non-default credentials get diagrams from the wrong identity (O-9).
+
+---
+
+## Open issues
+
+| ID | Description | Status |
+|---|---|---|
+| O-1 | List-level `mermaidGraph` in `find_*` response root discarded by `_safe_list()` | Unconfirmed — needs live response inspection |
+| O-2 | `_safe_list` only handles `"items"` key; may miss `"elements"` or `"elementList"` | Unconfirmed — needs live response inspection |
+| O-3 | `MermaidSection` re-fetches context diagram even when embedded `mermaidGraph` already present in detail response | Low priority |
+| O-8 | Software Capabilities detail: O(n) scan via `find_software_capabilities` instead of `get_software_capability_by_guid` | Low priority — fast at ~50 items |
+| O-9 | `MermaidSection` fetch doesn't forward user credentials | Known limitation |
+| O-10 | `DeployedAPI` elements may have no `mermaidGraph` in Coco data | Under investigation |

--- a/technical_data_catalog_spec.md
+++ b/technical_data_catalog_spec.md
@@ -1,270 +1,222 @@
 # Technical Asset Catalog — Specification
 
-The **The Catalog** is a new tile on the portals for quickstart and freshstart. It is aimed at technical users that are used to working with assets.
+**The Catalog** is a tile on the quickstart (and freshstart) portal. It is aimed at technical users who work directly with assets: infrastructure engineers, data engineers, API developers, and architects browsing the governed vocabulary.
 
-When you launch the **The Catalog**, there are 4 tiles:
+When you launch The Catalog, there are **five tiles** (Glossary is first):
 
-- Infrastructure Assets — For working with servers, storage and networks.
-- Data Assets — For working with your data stores, data feeds and data sets.
-- APIs — For working with your APIs
-- Processes — For working with your software processes and actions
-
----
-
-## General features for each tile/tab
-
-When a tile is selected, it opens up a page with two panels. A left-hand panel for a tree-view of elements and a right-hand detail panel.
-
-The left-hand tree view under each tile should include a search box to restrict the elements listed. The elements displayed are of a specific type (detailed in the description of each tile). They are organized alphabetically unless the description of the tile specifies otherwise.
-
-When an element in the left-hand pane is selected, the details pane is populated.
-On the detail pane, the properties of the element are displayed with a link to display each mermaid graph, along with any classifications and relationships (like egeria explorer).
-
-For each classification displayed, it should be possible to see the properties of the classification.
-
-For each relationship displayed, it should be possible to see the properties of the relationship and the related element.
+| Tile | Description |
+|---|---|
+| **Glossary** | Browse glossaries, categories, and terms; cross-link to data assets |
+| **Infrastructure Assets** | Servers, storage, networks, software capabilities, and endpoints |
+| **Data Assets** | Data stores, data feeds, and data sets |
+| **APIs** | Deployed APIs and their endpoints |
+| **Processes** | Software components and actions |
 
 ---
 
-## Under the Infrastructure Assets tile
+## General features
 
-In the left-hand tree-view, there are 3 tabs:
+When a tile is selected, it opens a page with a left-hand navigation panel and a right-hand detail panel. The Glossary tile has a three-column layout (glossary list → categories/terms → term detail); all other tiles have a two-panel layout (item list → item detail).
 
-1. Infrastructure Assets
-2. Software Capabilities
-3. Endpoints
+**Left-hand panel (all asset tiles):**
+- Search box to filter the displayed elements
+- Type filter dropdown when multiple `deployedImplementationType` values are present
+- Items are sorted alphabetically by display name (client-side)
+- Sub-tabs within a tile (e.g., Data Stores / Data Feeds / Data Sets) are shown as a tab bar above the list
 
-### Infrastructure Assets tab
+**Right-hand detail panel (all asset tiles):**
+- Header: element display name, type badge, Egeria feedback widget
+- Qualified name and description
+- Properties table (all scalar properties not in the header)
+- Classifications with their properties
+- Mermaid diagrams: embedded graphs (rendered immediately) + on-demand "Load Context Diagram" / "Load Anchored Graph" buttons
+- Relationships: each relationship card shows the relationship type, related element name and type, relationship properties, and a **"View →"** button when the related element's type maps to a known catalog tab
+- Egeria comments section
 
-The infrastructure assets are accessed using the Asset Maker API. They inherit from ITInfrastructure (metadataElementTypeName="ITInfrastructure").
-They should be organized by type. It should be possible to filter by deployedImplementationType and deploymentStatus attributes.
+**Cross-navigation (implemented):** The "View →" button in any relationship card navigates the SPA to the appropriate section and tab, auto-fetching the related element's detail. Navigation resolves subtypes via the `superTypeNames` hierarchy (e.g., `SecretsCollection` navigates to the Data Sets tab because it inherits from `DataSet`).
 
-When an asset is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the asset and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related software capabilities (getCapabilities) from the software capabilities tab would be good.
+---
+
+## Glossary tile
+
+The Glossary tile uses a three-column layout:
+
+1. **Left column** — glossary list, plus an "All Terms (search)" entry for cross-glossary search
+2. **Middle column** — folder tree and terms for the selected glossary; or search results in global search mode
+3. **Right column** — term detail, folder detail, or glossary detail
+
+### Glossary detail
+Shows the glossary display name, description, language, usage, and a mermaid context diagram button.
+
+### Folder (GlossaryCategory) detail
+Shows folder name, type, status, description, and property table.
+
+### Term detail
+Shows term display name, abbreviation, summary, examples, usage, status, content status, description (rendered as markdown), classifications (with badges), folder assignments, mermaid diagram, full property table, all relationship types with their related elements, and an Egeria comments section.
+
+**Term cross-navigation:** Related elements in a term's relationship list (e.g., other terms linked via `SynonymRelationship`) show a "View →" button that navigates within the Glossary section. Non-glossary related elements (e.g., `DataAsset` linked via semantic assignment) show "View →" buttons that navigate to the appropriate asset tab.
+
+**Template substitutes:** Template terms are hidden by default. A "Show template substitutes" checkbox is available in the filter bar.
+
+### Backend
+All glossary calls are served by `glossary_handler.py` (shared with Egeria Explorer):
+- `GET /api/glossary` → list of glossaries
+- `GET /api/glossary/{guid}/folders` → categories for a glossary or category
+- `GET /api/glossary/{guid}/terms` → terms for a glossary or category
+- `GET /api/glossary-terms?q=` → cross-glossary term search
+- `GET /api/glossary/term/{guid}` → full term detail (`graph_query_depth=3`)
+
+---
+
+## Infrastructure Assets tile
+
+Three sub-tabs:
+
+### IT Infrastructure tab
+- **API:** `AssetMaker.find_infrastructure(search_string, deployment_status_list=[], graph_query_depth=0)`
+- **Type:** `ITInfrastructure` and all subtypes (SoftwareServer, Host, VirtualMachine, HostCluster, etc.)
+- **Filter:** `deployedImplementationType` (client-side dropdown)
+- **Cross-nav:** `SupportedSoftwareCapability` relationships navigate to the Software Capabilities tab
 
 ### Software Capabilities tab
-
-The software capabilities are accessed using the Asset Maker API. They inherit from SoftwareCapability and have their own methods.
-They should be organized by type. It should be possible to filter by the deployedImplementationType and deploymentStatus attributes.
-
-When a software capability is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the software capability and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related infrastructure asset (getHostedByDeployedITInfrastructure) from the infrastructure assets tab would be good.
+- **API:** `AssetMaker.find_software_capabilities(search_string, graph_query_depth=0)`
+- **Type:** `SoftwareCapability` and all subtypes (APIManager, DatabaseManager, EventBroker, etc.)
+- **Filter:** `deployedImplementationType` (client-side dropdown)
+- **Cross-nav:** `SoftwareCapabilityDependency` relationships navigate within this tab; hosting infrastructure relationships navigate to the IT Infrastructure tab
 
 ### Endpoints tab
-
-The endpoints are accessed using the Connection Maker API. They inherit from Endpoint and there are specialized methods for working with endpoints.
-They should be organized by display name.
-
-When an endpoint is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the endpoint and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related infrastructure asset (getServers) from the infrastructure assets tab would be good.
+- **API:** `ConnectionMaker.find_endpoints(search_string, output_format="JSON", graph_query_depth=0)`
+- **Type:** `Endpoint` (not an Asset subtype — requires `ConnectionMaker`)
+- **Detail:** `ConnectionMaker.get_endpoint_by_guid(guid, body={graphQueryDepth:3})` — a fresh `create_egeria_bearer_token()` call is required (passing a reused token causes a 401 in the constructor)
+- **Cross-nav:** Connected server/asset relationships navigate to the IT Infrastructure tab
 
 ---
 
-## Under the Data Assets tile
+## Data Assets tile
 
-In the left-hand tree-view, there are 3 tabs:
-
-1. Data Stores
-2. Data Feeds
-3. Data Sets
+Three sub-tabs:
 
 ### Data Stores tab
-
-The data stores are accessed using the Asset Maker API. They inherit from DataStore (metadataElementTypeName="DataStore").
-They should be organized by type. It should be possible to filter by the deployedImplementationType attribute.
-
-When a data store is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the data store and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related data sets (getSupportedDataSets) from the data sets tab would be good.
+- **API:** `AssetMaker.find_data_assets(search_string, metadata_element_type="DataStore", content_status_list=[], graph_query_depth=0)`
+- **Type:** `DataStore` and all subtypes (Database, CSVFile, DataFile, RelationalDatabase, FileFolder, etc.)
+- **Filter:** `deployedImplementationType` (client-side)
+- **Cross-nav:** `DataSetContent` relationships (key: `supportedDataSets`) navigate to the Data Sets tab
 
 ### Data Feeds tab
-
-The data feeds are accessed using the Asset Maker API. They inherit from DataFeed (metadataElementTypeName="DataFeed").
-They should be organized by type. It should be possible to filter by the deployedImplementationType attribute.
-
-When a data feed is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the data feed and its mermaid graphs, along with any classifications and relationships (like egeria explorer).
+- **API:** `AssetMaker.find_data_assets(search_string, metadata_element_type="DataFeed", content_status_list=[], graph_query_depth=0)`
+- **Type:** `DataFeed` and all subtypes (Topic, KafkaTopic, etc.)
+- **Note:** Coco data feeds are primarily Kafka topics
 
 ### Data Sets tab
-
-The data sets are accessed using the Asset Maker API. They inherit from DataSet (metadataElementTypeName="DataSet").
-They should be organized by type. It should be possible to filter by the deployedImplementationType attribute.
-
-When a data set is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the data set and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related data stores (getDataContent) from the data stores tab would be good.
+- **API:** `AssetMaker.find_data_assets(search_string, metadata_element_type="DataSet", content_status_list=[], graph_query_depth=0)`
+- **Type:** `DataSet` and all subtypes (SecretsCollection, VirtualRelationalTable, etc.)
+- **Cross-nav:** `DataSetContent` relationships navigate to the Data Stores tab
 
 ---
 
-## Under the APIs tile
+## APIs tile
 
-The APIs are accessed using the Asset Maker API. They inherit from DeployedAPI (metadataElementTypeName="DeployedAPI").
-They should be organized by type. It should be possible to filter by the deployedImplementationType attribute.
+Single list (no sub-tabs):
 
-When an API is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the API and its mermaid graphs, along with any classifications and relationships (like egeria explorer). If possible, linking to the related endpoints (getEndpoints) from the endpoints tab would be good.
+- **API:** `AssetMaker.find_assets(search_string, metadata_element_type="DeployedAPI", graph_query_depth=0)`
+- **Type:** `DeployedAPI` (inherits from DeployedSoftwareComponent → Process → Asset)
+- **Filter:** `deployedImplementationType` (client-side)
+- **Cross-nav:** `APIEndpoint` relationships navigate to the Endpoints tab
 
 ---
 
-## Under the Processes tile
+## Processes tile
 
-In the left-hand tree-view, there are 2 tabs:
-
-1. Software Components
-2. Actions
+Two sub-tabs:
 
 ### Software Components tab
-
-The software components are accessed using the Asset Maker API. They inherit from DeployedSoftwareComponent (metadataElementTypeName="DeployedSoftwareComponent").
-They should be organized by type. It should be possible to filter by the deployedImplementationType and activityStatus attributes.
-
-When a software component is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the software component and its mermaid graphs, along with any classifications and relationships (like egeria explorer).
+- **API:** `AssetMaker.find_processes(search_string, metadata_element_type="DeployedSoftwareComponent", activity_status_list=[], graph_query_depth=0)`
+- **Type:** `DeployedSoftwareComponent` and subtypes
+- **Note:** `activity_status_list` defaults to `["IN_PROGRESS"]` — must pass `[]` to see all connectors in Coco
 
 ### Actions tab
-
-The actions are accessed using the Asset Maker API. They inherit from Action (metadataElementTypeName="Action").
-They should be organized by type. It should be possible to filter by the deployedImplementationType and activityStatus attributes.
-
-When an action is selected, the detail panel is displayed.
-In this initial implementation it is sufficient to display the properties of the action and its mermaid graphs, along with any classifications and relationships (like egeria explorer).
+- **API:** `AssetMaker.find_processes(search_string, metadata_element_type="Action", activity_status_list=[], graph_query_depth=0)`
+- **Type:** `Action` and subtypes
 
 ---
 
-## Design Notes and Implementation Plan
+## Backend API surface (`tech_catalog_handler.py`)
 
-*Added 2026-06-06.*
+```
+GET /api/tech-catalog/infrastructure          find_infrastructure (ITInfrastructure)
+GET /api/tech-catalog/software-capabilities   find_software_capabilities
+GET /api/tech-catalog/endpoints               ConnectionMaker.find_endpoints
+GET /api/tech-catalog/data-stores             find_data_assets (DataStore)
+GET /api/tech-catalog/data-feeds              find_data_assets (DataFeed)
+GET /api/tech-catalog/data-sets               find_data_assets (DataSet)
+GET /api/tech-catalog/apis                    find_assets (DeployedAPI)
+GET /api/tech-catalog/software-components     find_processes (DeployedSoftwareComponent)
+GET /api/tech-catalog/actions                 find_processes (Action)
+GET /api/tech-catalog/assets/{guid}           detail for any element by GUID + section hint
+```
+
+All list endpoints accept: `q` (search string), `start_from`, `page_size`, `url`, `server`, `user_id`, `user_pwd`.
+
+Glossary endpoints are served by `glossary_handler.py` (shared with Egeria Explorer).
+
+---
+
+## Design Notes
+
+*Initial design: 2026-06-06. Updated to reflect implementation: 2026-06-08.*
 
 ### Key design decisions
 
 **1. Standalone SPA, not an extension of Egeria Explorer.**
+`type-explorer.html` is already ~7,600 lines. A separate `tech-catalog.html` keeps concerns clean. The two tools share the same visual language (dark theme, CSS variables, sidebar+detail layout) but are independently deployable.
 
-`type-explorer.html` is already ~7,600 lines. Adding 9 more asset-type panels there would make it unmaintainable and slow to load. A separate `the-catalog.html` (~2,500–3,000 lines estimated) keeps concerns clean and makes modularization tractable later. The two tools share the same visual language (dark theme, CSS variables, sidebar+detail layout) but are independently deployable.
+**2. Glossary is shared with Egeria Explorer.**
+`glossary_handler.py` is used by both SPAs without modification. The `GlossaryView` component was ported from `type-explorer.html` with inline styles replacing CSS class dependencies and `creds` prop replacing `CredContext`. When MOD-1 extracts shared components, GlossaryView is the top candidate.
 
-**2. Same URL-routing model as Explorer.**
+**3. Hash-based section routing.**
+`window.location.hash` enables deep-linking from portal cards and bookmarks (e.g., `/tech-catalog#glossary`). Valid section IDs: `glossary`, `infrastructure`, `data-assets`, `apis`, `processes`.
 
-The tool lives at `/the-catalog` (served by the existing Apache proxy → FastAPI). Deep-linking via `window.location.hash` is supported from launch, so portal cards and bookmarks can land directly on a section (e.g., `/tech-catalog#data-stores`). This follows the hash-navigation pattern already in place for Explorer.
+**4. `deployedImplementationType` filtering is client-side.**
+pyegeria `find_*` calls don't expose `deployedImplementationType` as a server-side filter. The sidebar shows a type-grouping dropdown that filters the already-loaded list.
 
-**3. Single backend handler file: `the_catalog_handler.py`.**
+**5. Status filters must always be overridden to `[]`.**
+Every find method defaults to a status that filters out most Coco demo data. The rule: always pass `<status_param>=[]` unless the user explicitly requests filtering. See `cat_calls.md` for the per-method defaults.
 
-All nine asset-type endpoints live in one file. The handler uses `AssetMaker` (from pyegeria) for infrastructure, data assets, APIs, software components, and actions; and `ConnectionMaker` for endpoints. All calls pass `sequencing_order="PROPERTY_ASCENDING"` and `sequencing_property="displayName"` — the established pattern across all existing handlers.
+**6. Detail panel uses `graph_query_depth=3`.**
+List calls use `graph_query_depth=0` for performance. Detail calls use `graph_query_depth=3` to expose nested schema links, lineage anchors, multi-hop relationships, and embedded mermaid diagram fields.
 
-**4. `deployedImplementationType` filtering is client-side in Phase 1.**
+**7. Relationship data is nested in `relatedElement`.**
+pyegeria wraps related elements in `RelatedMetadataElementSummary`. The actual `elementHeader` and `properties` are inside a `relatedElement` sub-dict, not at the item top level. `_extract_relationships()` unwraps this and also extracts `superTypeNames` for subtype-aware navigation.
 
-The pyegeria `find_*` calls do not expose `deployedImplementationType` as a direct server-side filter parameter — it is a property on the returned element. In Phase 1 the sidebar will show a type-grouping dropdown that filters the already-loaded list client-side. Phase 2 can add a `property_names` body parameter if Egeria adds support.
-
-**5. Status filters use the pyegeria-native params.**
-
-- `find_infrastructure` → `deployment_status_list` (default `["ACTIVE"]`)
-- `find_data_assets` → `content_status_list` (default `["ACTIVE"]`)
-- `find_processes` → `activity_status_list`
-- `find_software_capabilities` → no status filter; client-side grouping by type
-
-**6. Detail panel reuses the same component patterns as Explorer.**
-
-`AvailableMermaidDiagrams`, `MermaidSection`, `EgeriaFeedbackWidget`, `EgeriaCommentsSection`, and the property-table layout are copy-initialised from Explorer. When the Modularization workstream (MOD-1→3) runs, these will be extracted to a shared static include so changes propagate automatically. Building the catalog first gives us concrete evidence of which components are truly shared.
-
-**7. Port allocation.**
-
-The Technical Catalog is served by the existing `quickstart-pyegeria-web` FastAPI container via a new Apache `<Location /tech-catalog>` proxy block — same pattern as `/egeria-explorer`. No new container or host port is required.
+**8. Cross-navigation uses a `navTarget` state threaded from App to leaf components.**
+`App` holds `{ navTarget, handleNavigate }`. `SectionView` switches sub-tabs via `useEffect` on `navTarget`. `AssetTabView` detects a new nav target via `useRef` deduplication and calls `handleSelect` directly. This avoids a global store while keeping the component tree clean.
 
 ---
 
-### pyegeria API mapping
+## Implementation status (as of 2026-06-08)
 
-| Section / Tab | pyegeria class | Method | `metadata_element_type` |
-|---|---|---|---|
-| Infrastructure Assets | `AssetMaker` | `find_infrastructure` | `"ITInfrastructure"` |
-| Software Capabilities | `AssetMaker` | `find_software_capabilities` | *(all, filter client-side)* |
-| Endpoints | `ConnectionMaker` | `find_endpoints` | *(body-based search)* |
-| Data Stores | `AssetMaker` | `find_data_assets` | `"DataStore"` |
-| Data Feeds | `AssetMaker` | `find_data_assets` | `"DataFeed"` |
-| Data Sets | `AssetMaker` | `find_data_assets` | `"DataSet"` |
-| APIs | `AssetMaker` | `find_assets` | `"DeployedAPI"` |
-| Software Components | `AssetMaker` | `find_processes` | `"DeployedSoftwareComponent"` |
-| Actions | `AssetMaker` | `find_processes` | `"Action"` |
+| Phase | Items | Status |
+|---|---|---|
+| TC-0 | Scaffolding (SPA shell, handler stub, Apache proxy, portal tile) | ✅ Complete |
+| TC-1 | All list + detail backend endpoints | ✅ Complete |
+| TC-2 | SPA shell + auth seam + splash screen | ✅ Complete |
+| TC-3 | Infrastructure section (3 sub-tabs) | ✅ Complete |
+| TC-4 | Data Assets section (3 sub-tabs) | ✅ Complete |
+| TC-5 | APIs section | ✅ Complete |
+| TC-6 | Processes section (2 sub-tabs) | ✅ Complete |
+| TC-7 | Glossary tile (3-column browser, full term detail) | ✅ Complete |
+| TC-8 | Cross-navigation links via "View →" in relationship cards | ✅ Complete |
+| MOD-1→3 | Extract shared components to `egeria-shared-ui.js` | 🔲 Post-MVP |
 
-Detail panel (any type): `AssetMaker.get_asset_by_guid()` or `find_assets` with GUID filter. Mermaid: existing `/api/mermaid/{guid}` endpoint already works for any Egeria element.
+### Outstanding work
 
----
+See `CATALOG_ISSUES.md` for detailed tracking. Remaining open issues:
+- **O-1/O-2:** Confirm list response key format and whether result-set mermaid graphs are returned
+- **O-3:** Pre-populate "Load Context Diagram" from embedded `mermaidGraph` to avoid redundant fetch
+- **O-8:** Replace O(n) scan for SoftwareCapability detail with `get_software_capability_by_guid`
+- **O-9:** Forward user credentials to mermaid diagram fetch URLs
+- **O-10:** Confirm whether `DeployedAPI` elements in Coco have mermaid graph data
 
-### Backend API endpoints (`tech_catalog_handler.py`)
+### Modularization strategy
 
-```
-GET /api/tech-catalog/infrastructure          find_infrastructure(type=ITInfrastructure)
-GET /api/tech-catalog/software-capabilities   find_software_capabilities()
-GET /api/tech-catalog/endpoints               find_endpoints() via ConnectionMaker
-GET /api/tech-catalog/data-stores             find_data_assets(type=DataStore)
-GET /api/tech-catalog/data-feeds              find_data_assets(type=DataFeed)
-GET /api/tech-catalog/data-sets               find_data_assets(type=DataSet)
-GET /api/tech-catalog/apis                    find_assets(type=DeployedAPI)
-GET /api/tech-catalog/software-components     find_processes(type=DeployedSoftwareComponent)
-GET /api/tech-catalog/actions                 find_processes(type=Action)
-GET /api/tech-catalog/assets/{guid}           get detail for any element by GUID
-```
-
-All list endpoints accept `q` (search string), `start_from`, `page_size`, and credential query params (`url`, `server`, `user_id`, `user_pwd`) — same FastAPI query-param pattern as all other handlers.
-
----
-
-### Phased implementation plan
-
-#### Phase 0 — Scaffolding (TC-0) — *start here*
-
-- Create `tech-catalog.html` skeleton (HTML boilerplate, React/CDN imports, empty `App` component)
-- Create `tech_catalog_handler.py` with one stub endpoint (`/api/tech-catalog/ping`)
-- Register handler in `pyegeria_handler.py` (both quickstart + freshstart)
-- Add Apache `<Location /tech-catalog>` proxy block to `fastapi-proxy.conf` (both envs)
-- Add portal tile "Technical Catalog" to `demo-portal.html` (both portals)
-- Confirm the tile renders and the page loads
-
-#### Phase 1 — Full backend (TC-1)
-
-- Implement all 9 list endpoints + the `/{guid}` detail endpoint
-- Wire in `sequencing_order` / `sequencing_property` on every call
-- Return consistent JSON shape: `{ items: [...], total: N }` with serialized element objects (guid, displayName, qualifiedName, typeName, deployedImplementationType, description, classifications, properties)
-- Manual smoke-test each endpoint against live Egeria
-
-#### Phase 2 — SPA shell + Infrastructure section (TC-2, TC-3)
-
-- App shell: auth seam (reads `/api/auth/me`, gates connection form on `srvManaged`), hash-based section routing, top-level 4-tile splash screen
-- Infrastructure section: 3 sub-tabs (Assets / Capabilities / Endpoints), sidebar with search + type-group filter, detail panel with property table + mermaid buttons + feedback widgets
-
-#### Phase 3 — Data Assets section (TC-4)
-
-- 3 sub-tabs: Data Stores / Data Feeds / Data Sets
-- Same sidebar + detail pattern as Phase 2; add `deployedImplementationType` filter dropdown
-
-#### Phase 4 — APIs and Processes sections (TC-5, TC-6)
-
-- APIs: single list + detail (no sub-tabs needed)
-- Processes: 2 sub-tabs (Software Components / Actions)
-
-#### Phase 5 — Cross-navigation links (TC-8)
-
-- Infrastructure Asset detail → "View Software Capabilities" link that switches sub-tab and pre-selects
-- Software Capability detail → linked Infrastructure Asset
-- Endpoint detail → linked server/asset
-- Data Store detail → linked Data Sets
-
-#### Phase 6 (post-MVP) — Modularization (MOD-1→3)
-
-After both Explorer and Tech Catalog are stable, extract the genuinely shared components:
-- `MermaidDiagram`, `DiagramPanel`, `MermaidSection`, `AvailableMermaidDiagrams`
-- `EgeriaFeedbackWidget`, `EgeriaCommentsSection`
-- Property table renderer
-- Auth seam helpers
-
-Target: a `egeria-shared-ui.js` static file served by FastAPI, imported by both SPAs via `<script>` tag. Both files become ~30% shorter and changes to shared components propagate automatically.
-
----
-
-### Modularization strategy (item #1)
-
-The immediate risk of copy-paste duplication is real — the Mermaid + feedback components are ~350 lines of the Explorer, and the auth seam is ~80 lines. If we change them in one tool and forget the other, they drift.
-
-**Short-term mitigation (now):** When building Tech Catalog, copy the components verbatim from Explorer. Add a `// SHARED — keep in sync with type-explorer.html` comment on each block so drift is visible in code review.
-
-**Medium-term fix (MOD phase):** Once both tools exist and usage patterns are clear, extract to a shared module. The extraction boundary will be obvious from the `// SHARED` markers.
-
-**What NOT to share:** Auth portal HTML, connection forms, persona picker, section routing — these differ enough between tools that sharing would create coupling without benefit.
-
-The Glossary panel is the first candidate for reuse across tools (Explorer → future Data Catalog). Its backend is already a standalone handler (`glossary_handler.py`). The frontend `GlossaryView` component in Explorer (~400 lines) can be extracted to `egeria-shared-ui.js` and embedded in other tools with minimal adaptation — the only coupling is the `onNavigate*` callback props, which the host tool provides.
+Both Explorer and The Catalog share: `MermaidDiagram`, `DiagramPanel`, `MermaidSection`, `AvailableMermaidDiagrams`, `EgeriaFeedbackWidget`, `EgeriaCommentsSection`, the auth seam, and `GlossaryView`. The target for MOD-1 is an `egeria-shared-ui.js` static file served by FastAPI and imported by both SPAs. The Glossary backend (`glossary_handler.py`) is already shared at the API level.


### PR DESCRIPTION
…rent state

- technical_data_catalog_spec.md: reflect 5-tile layout (Glossary first), mark all TC-0 through TC-8 phases complete, document cross-navigation design, relationship data nesting lesson, ConnectionMaker token quirk, and modularization roadmap
- cat_calls.md: restructure as authoritative reference; add Glossary endpoints, cross-nav TYPE_TO_NAV table with known Coco relationships, fix endpoint detail note (token reuse causes 401), close O-4 through O-7 as confirmed working
- CATALOG_ISSUES.md: convert bugs to numbered lessons (L-1 through L-6), add L-3 (ConnectionMaker token), L-4 (relatedElement nesting), L-5 (mermaid bugs), L-6 (cross-nav state threading); retire closed issues O-4 through O-7