### PR TITLE
Move calls to PSQL inside the containter so that it is not needed on local machine

### DIFF
--- a/compose-configs/egeria-quickstart/bin/apply-postgres-init.sh
+++ b/compose-configs/egeria-quickstart/bin/apply-postgres-init.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 QUICKSTART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source engine detection to get $CONTAINER_ENGINE
+source "${QUICKSTART_DIR}/../shared-infra/detect-engine.sh"
+
 SQL_DIR="${QUICKSTART_DIR}/docker-entrypoint-initdb.d"
 INIT_SQL="${SQL_DIR}/init_egeria.sql"
 
@@ -14,9 +18,18 @@ PGUSER="${PGUSER:-egeria_admin}"
 PGPASSWORD="${PGPASSWORD:-admin4egeria}"
 PGDATABASE="${PGDATABASE:-postgres}"
 
-export PGPASSWORD
-
 MIGRATION_ID="egeria-quickstart-init-egeria-v1"
+CONTAINER_NAME="egeria-shared-postgres"
+
+# Wrapper to run psql. Use local psql if available, otherwise use docker/podman exec
+psql_cmd() {
+  if command -v psql &> /dev/null; then
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" "$@"
+  else
+    # Use -h localhost -p 5442 inside the container because that is how it is configured
+    $CONTAINER_ENGINE exec -i -e PGPASSWORD="$PGPASSWORD" "$CONTAINER_NAME" psql -h localhost -p 5442 -U "$PGUSER" -d "$PGDATABASE" "$@"
+  fi
+}
 
 log() {
   echo "[quickstart-postgres-init] $*"
@@ -26,9 +39,15 @@ log() {
 log "Waiting for PostgreSQL at ${PGHOST}:${PGPORT}..."
 MAX_ATTEMPTS=40
 ATTEMPT=1
-until psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null 2>&1; do
+
+until psql_cmd -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null 2>&1; do
   if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
     log "ERROR: PostgreSQL not ready after $MAX_ATTEMPTS attempts."
+    # Dump some diagnostic info
+    if command -v nc &> /dev/null; then
+      log "Diagnostic: nc -zv $PGHOST $PGPORT"
+      nc -zv "$PGHOST" "$PGPORT" 2>&1 || log "  Port $PGPORT is NOT reachable on $PGHOST"
+    fi
     exit 1
   fi
   log "  attempt $ATTEMPT/$MAX_ATTEMPTS (waiting 3s...)"
@@ -37,7 +56,7 @@ until psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_S
 done
 
 # Ensure marker table exists
-psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 <<EOF >/dev/null
+psql_cmd -v ON_ERROR_STOP=1 <<EOF >/dev/null
 CREATE SCHEMA IF NOT EXISTS quickstart_migrations;
 CREATE TABLE IF NOT EXISTS quickstart_migrations.applied_migrations (
   migration_id text PRIMARY KEY,
@@ -46,7 +65,7 @@ CREATE TABLE IF NOT EXISTS quickstart_migrations.applied_migrations (
 EOF
 
 # Check if migration already applied
-ALREADY_APPLIED=$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -t -c "SELECT 1 FROM quickstart_migrations.applied_migrations WHERE migration_id = '$MIGRATION_ID';" | xargs)
+ALREADY_APPLIED=$(psql_cmd -v ON_ERROR_STOP=1 -t -c "SELECT 1 FROM quickstart_migrations.applied_migrations WHERE migration_id = '$MIGRATION_ID';" 2>/dev/null | xargs)
 
 if [ "$ALREADY_APPLIED" = "1" ]; then
   log "Migration $MIGRATION_ID already applied; skipping."
@@ -55,11 +74,25 @@ fi
 
 # Apply migration
 log "Applying migration $MIGRATION_ID ..."
-cd "$SQL_DIR"
-psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -f "$INIT_SQL"
+if command -v psql &> /dev/null; then
+  cd "$SQL_DIR"
+  psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -f "$INIT_SQL"
+else
+  # If psql is not on host, we must run it in the container.
+  # We use 'docker cp' to copy the SQL files to the container so that '\ir' works correctly.
+  # We copy them to /tmp/quickstart-init/
+  TMP_DIR="/tmp/quickstart-init"
+  $CONTAINER_ENGINE exec "$CONTAINER_NAME" mkdir -p "$TMP_DIR"
+  $CONTAINER_ENGINE cp "$SQL_DIR/." "$CONTAINER_NAME:$TMP_DIR/"
+  
+  $CONTAINER_ENGINE exec -i -e PGPASSWORD="$PGPASSWORD" "$CONTAINER_NAME" /bin/bash -c "cd $TMP_DIR && psql -h localhost -p 5442 -U $PGUSER -d $PGDATABASE -v ON_ERROR_STOP=1 -f init_egeria.sql"
+  
+  # Cleanup
+  $CONTAINER_ENGINE exec "$CONTAINER_NAME" rm -rf "$TMP_DIR"
+fi
 
 # Record success
-psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 <<EOF >/dev/null
+psql_cmd -v ON_ERROR_STOP=1 <<EOF >/dev/null
 INSERT INTO quickstart_migrations.applied_migrations (migration_id)
 VALUES ('$MIGRATION_ID')
 ON CONFLICT (migration_id) DO NOTHING;

--- a/compose-configs/egeria-quickstart/docker-entrypoint-initdb.d/add_coco_schemas.sh
+++ b/compose-configs/egeria-quickstart/docker-entrypoint-initdb.d/add_coco_schemas.sh
@@ -14,21 +14,64 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DATA_DIR="$SCRIPT_DIR/data"
 
+# Source engine detection to get $CONTAINER_ENGINE
+source "${SCRIPT_DIR}/../../shared-infra/detect-engine.sh"
+
 PGHOST="${PGHOST:-localhost}"
 PGPORT="${PGPORT:-5442}"
 PGUSER="${PGUSER:-egeria_admin}"
 PGPASSWORD="${PGPASSWORD:-admin4egeria}"
+# Use coco_pharma as default database for this script
+PGDATABASE="${PGDATABASE:-coco_pharma}"
 
-export PGPASSWORD
+CONTAINER_NAME="egeria-shared-postgres"
 
-PSQL="psql -h $PGHOST -p $PGPORT -U $PGUSER -d coco_pharma -v ON_ERROR_STOP=1"
+# Wrapper to run psql. Use local psql if available, otherwise use docker/podman exec
+psql_cmd() {
+  if command -v psql &> /dev/null; then
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 "$@"
+  else
+    # Use -h localhost -p 5442 inside the container because that is how it is configured
+    $CONTAINER_ENGINE exec -e PGPASSWORD="$PGPASSWORD" "$CONTAINER_NAME" psql -h localhost -p 5442 -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 "$@"
+  fi
+}
 
-echo "Creating coco_sus schema and loading data..."
-$PSQL -c "CREATE SCHEMA IF NOT EXISTS coco_sus; GRANT ALL ON SCHEMA coco_sus TO egeria_admin, egeria_user, airflow_user;"
-$PSQL -f <(cat <(printf 'SET search_path TO coco_sus;\n') "$DATA_DIR/coco_sus.sql")
+log() {
+  echo "[add-coco-schemas] $*"
+}
 
-echo "Creating coco_ods schema and loading data..."
-$PSQL -c "CREATE SCHEMA IF NOT EXISTS coco_ods; GRANT ALL ON SCHEMA coco_ods TO egeria_admin, egeria_user, airflow_user;"
-$PSQL -f <(cat <(printf 'SET search_path TO coco_ods;\n') "$DATA_DIR/coco_ods.sql")
+log "Starting coco schema addition..."
 
-echo "Done. coco_sus and coco_ods schemas are ready in coco_pharma."
+# 1. Create coco_sus
+log "Creating coco_sus schema..."
+psql_cmd -c "CREATE SCHEMA IF NOT EXISTS coco_sus; GRANT ALL ON SCHEMA coco_sus TO egeria_admin, egeria_user, airflow_user;"
+
+log "Loading coco_sus data..."
+if command -v psql &> /dev/null; then
+    psql_cmd -f <(cat <(printf 'SET search_path TO coco_sus;\n') "$DATA_DIR/coco_sus.sql")
+else
+    # Copy data to container and run psql -f
+    $CONTAINER_ENGINE exec "$CONTAINER_NAME" mkdir -p /tmp/coco-data
+    $CONTAINER_ENGINE cp "$DATA_DIR/coco_sus.sql" "$CONTAINER_NAME:/tmp/coco-data/coco_sus.sql"
+    $CONTAINER_ENGINE exec -i -e PGPASSWORD="$PGPASSWORD" "$CONTAINER_NAME" psql -h localhost -p 5442 -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -c "SET search_path TO coco_sus;" -f /tmp/coco-data/coco_sus.sql
+fi
+
+# 2. Create coco_ods
+log "Creating coco_ods schema..."
+psql_cmd -c "CREATE SCHEMA IF NOT EXISTS coco_ods; GRANT ALL ON SCHEMA coco_ods TO egeria_admin, egeria_user, airflow_user;"
+
+log "Loading coco_ods data..."
+if command -v psql &> /dev/null; then
+    psql_cmd -f <(cat <(printf 'SET search_path TO coco_ods;\n') "$DATA_DIR/coco_ods.sql")
+else
+    # Copy data to container and run psql -f
+    $CONTAINER_ENGINE exec "$CONTAINER_NAME" mkdir -p /tmp/coco-data
+    $CONTAINER_ENGINE cp "$DATA_DIR/coco_ods.sql" "$CONTAINER_NAME:/tmp/coco-data/coco_ods.sql"
+    $CONTAINER_ENGINE exec -i -e PGPASSWORD="$PGPASSWORD" "$CONTAINER_NAME" psql -h localhost -p 5442 -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 -c "SET search_path TO coco_ods;" -f /tmp/coco-data/coco_ods.sql
+fi
+
+log "Done. coco_sus and coco_ods schemas are ready in coco_pharma."
+# Cleanup
+if ! command -v psql &> /dev/null; then
+  $CONTAINER_ENGINE exec "$CONTAINER_NAME" rm -rf /tmp/coco-data
+fi

--- a/compose-configs/shared-infra/ensure-shared-infra.sh
+++ b/compose-configs/shared-infra/ensure-shared-infra.sh
@@ -64,6 +64,21 @@ wait_for_container_state egeria-shared-kafka
 wait_for_container_state egeria-shared-postgres
 wait_for_container_state egeria-shared-openlineage-proxy-backend
 
+# Extra safety: Wait for Postgres port to be reachable on localhost
+# Container 'healthy' (pg_isready) doesn't always mean the host-mapped port is fully bound/reachable yet.
+# Skip if nc is not found.
+if command -v nc &> /dev/null; then
+  echo "[shared-infra] Waiting for Postgres port 5442 to be reachable on localhost..."
+  for i in {1..20}; do
+    if nc -zv localhost 5442 >/dev/null 2>&1; then
+      echo "[shared-infra] Postgres port 5442 is reachable."
+      break
+    fi
+    [[ $i -eq 20 ]] && echo "[shared-infra] WARNING: Postgres port 5442 still not reachable on localhost."
+    sleep 1
+  done
+fi
+
 echo "[shared-infra] Shared Kafka, Postgres, and proxy are ready."
 popd >/dev/null
 


### PR DESCRIPTION

Summary (from Junie)
•
Fixed a failure in database initialization scripts when the psql client is missing on the host machine.
•
Resolved an issue where relative SQL includes (\ir) failed during containerized execution.
•
Added safety checks for the nc (netcat) utility to avoid script errors on systems where it's not installed.
Changes
•
Updated apply-postgres-init.sh and add_coco_schemas.sh to use docker cp (or podman cp) to transfer SQL scripts into the PostgreSQL container before execution. This ensures that psql -f can correctly resolve relative paths for included SQL files.
•
Modified the fallback psql_cmd to properly handle containerized execution with necessary environment variables and connection parameters.
•
Wrapped nc calls in availability checks to prevent "command not found" errors while still providing diagnostic information when available.
•
Standardized the database initialization workflow to be independent of the host's installed toolset.
Verification
•
Manually executed apply-postgres-init.sh and confirmed it successfully applies migrations, including those with \ir directives, using the container's psql.
•
Manually executed add_coco_schemas.sh and verified it successfully loads the Coco Pharmaceuticals sample data into the database.
•
Confirmed that the scripts correctly handle existing roles and schemas without failing (idempotency).